### PR TITLE
Use custom cognito omniauth strategy

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,8 @@ gem 'jbuilder', '~> 2.7'
 gem 'bootsnap', '>= 1.4.2', require: false
 gem 'tzinfo-data'
 gem 'devise'
-gem 'omniauth-cognito-idp', '~> 0.1.1'
+gem 'jwt'
+gem 'omniauth-oauth2'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -130,9 +130,6 @@ GEM
     omniauth (1.9.1)
       hashie (>= 3.4.6)
       rack (>= 1.6.2, < 3)
-    omniauth-cognito-idp (0.1.1)
-      jwt
-      omniauth-oauth2
     omniauth-oauth2 (1.6.0)
       oauth2 (~> 1.1)
       omniauth (~> 1.9)
@@ -263,9 +260,10 @@ DEPENDENCIES
   devise
   dotenv-rails
   jbuilder (~> 2.7)
+  jwt
   listen (~> 3.2)
   mysql2 (~> 0.5.3)
-  omniauth-cognito-idp (~> 0.1.1)
+  omniauth-oauth2
   puma (~> 4.1)
   rails (~> 6.0.3, >= 6.0.3.2)
   rspec-rails (~> 4.0.1)

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -1,5 +1,5 @@
 class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
-  def cognito_idp
+  def cognito
     @user = User.from_omniauth(request.env["omniauth.auth"])
     sign_in_and_redirect @user
   end

--- a/app/lib/omni_auth/strategies/cognito.rb
+++ b/app/lib/omni_auth/strategies/cognito.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+# Copyright 2018 The Sage Group Plc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+#
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'omniauth-oauth2'
+require 'jwt'
+
+module OmniAuth
+  module Strategies
+    # OmniAuth strategy that authenticates against an Amazon Cognito User Pool
+    class Cognito < OmniAuth::Strategies::OAuth2
+      option :name, 'cognito'
+      option :client_options,
+        {
+          authorize_url: '/oauth2/authorize',
+          token_url: '/oauth2/token',
+          auth_scheme: :basic_auth
+        }
+      option :jwt_leeway, 60
+      option :user_pool_id, nil
+      option :aws_region, nil
+
+      uid do
+        parsed_id_token['sub'] if parsed_id_token
+      end
+
+      info do
+        if parsed_id_token
+          {
+            name: parsed_id_token['name'],
+            email: parsed_id_token['email'],
+            phone: parsed_id_token['phone_number']
+          }
+        end
+      end
+
+      credentials do
+        { token: access_token.token }.tap do |hash|
+          hash[:refresh_token] = access_token.refresh_token if access_token.expires? && access_token.refresh_token
+          hash[:expires_at] = access_token.expires_at if access_token.expires?
+          hash[:expires] = access_token.expires?
+          hash[:id_token] = id_token if id_token
+        end
+      end
+
+      extra do
+        { raw_info: parsed_id_token.reject { |key| %w[iss aud exp iat token_use nbf].include?(key) } }
+      end
+
+      private
+
+      # Override this method to remove the query string from the callback_url because Cognito
+      # requires an exact match
+      def build_access_token
+        client.auth_code.get_token(
+          request.params['code'],
+          { redirect_uri: callback_url.split('?').first }.merge(token_params.to_hash(symbolize_keys: true)),
+          deep_symbolize(options.auth_token_params)
+        )
+      end
+
+      def id_token
+        access_token['id_token']
+      end
+
+      def parsed_id_token
+        return nil unless id_token
+
+        @parsed_id_token ||= ::JWT.decode(
+          id_token,
+          nil,
+          false,
+          verify_iss: options[:aws_region] && options[:user_pool_id],
+          iss: "https://cognito.#{options[:aws_region]}.amazonaws.com/#{options[:user_pool_id]}",
+          verify_aud: true,
+          aud: options[:client_id],
+          verify_sub: true,
+          verify_expiration: true,
+          verify_not_before: true,
+          verify_iat: true,
+          verify_jti: false,
+          leeway: options[:jwt_leeway]).first
+      end
+    end
+  end
+end

--- a/app/lib/omni_auth/strategies/cognito.rb
+++ b/app/lib/omni_auth/strategies/cognito.rb
@@ -15,18 +15,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require 'omniauth-oauth2'
-require 'jwt'
+require "omniauth-oauth2"
+require "jwt"
 
 module OmniAuth
   module Strategies
     # OmniAuth strategy that authenticates against an Amazon Cognito User Pool
     class Cognito < OmniAuth::Strategies::OAuth2
-      option :name, 'cognito'
+      option :name, "cognito"
       option :client_options,
         {
-          authorize_url: '/oauth2/authorize',
-          token_url: '/oauth2/token',
+          authorize_url: "/oauth2/authorize",
+          token_url: "/oauth2/token",
           auth_scheme: :basic_auth
         }
       option :jwt_leeway, 60
@@ -34,21 +34,21 @@ module OmniAuth
       option :aws_region, nil
 
       uid do
-        parsed_id_token['sub'] if parsed_id_token
+        parsed_id_token["sub"] if parsed_id_token
       end
 
       info do
         if parsed_id_token
           {
-            name: parsed_id_token['name'],
-            email: parsed_id_token['email'],
-            phone: parsed_id_token['phone_number']
+            name: parsed_id_token["name"],
+            email: parsed_id_token["email"],
+            phone: parsed_id_token["phone_number"]
           }
         end
       end
 
       credentials do
-        { token: access_token.token }.tap do |hash|
+        {token: access_token.token}.tap do |hash|
           hash[:refresh_token] = access_token.refresh_token if access_token.expires? && access_token.refresh_token
           hash[:expires_at] = access_token.expires_at if access_token.expires?
           hash[:expires] = access_token.expires?
@@ -57,7 +57,7 @@ module OmniAuth
       end
 
       extra do
-        { raw_info: parsed_id_token.reject { |key| %w[iss aud exp iat token_use nbf].include?(key) } }
+        {raw_info: parsed_id_token.reject { |key| %w[iss aud exp iat token_use nbf].include?(key) }}
       end
 
       private
@@ -66,14 +66,14 @@ module OmniAuth
       # requires an exact match
       def build_access_token
         client.auth_code.get_token(
-          request.params['code'],
-          { redirect_uri: callback_url.split('?').first }.merge(token_params.to_hash(symbolize_keys: true)),
+          request.params["code"],
+          {redirect_uri: callback_url.split("?").first}.merge(token_params.to_hash(symbolize_keys: true)),
           deep_symbolize(options.auth_token_params)
         )
       end
 
       def id_token
-        access_token['id_token']
+        access_token["id_token"]
       end
 
       def parsed_id_token
@@ -92,7 +92,8 @@ module OmniAuth
           verify_not_before: true,
           verify_iat: true,
           verify_jti: false,
-          leeway: options[:jwt_leeway]).first
+          leeway: options[:jwt_leeway]
+        ).first
       end
     end
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,9 +1,9 @@
 class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
-  devise :omniauthable, omniauth_providers: %i[cognito-idp]
+  devise :omniauthable, omniauth_providers: %i[cognito]
 
-  def from_omniauth(auth)
+  def self.from_omniauth(auth)
     where(provider: auth.provider, uid: auth.uid).first_or_create
   end
 end

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,3 +1,3 @@
 <h2>Log in</h2>
 
-<%= link_to "Sign in with Cognito", user_cognito_idp_omniauth_authorize_path %>
+<%= link_to "Sign in with Cognito", user_cognito_omniauth_authorize_path %>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -272,8 +272,8 @@ Devise.setup do |config|
   # Add a new OmniAuth provider. Check the wiki for more information on setting
   # up on your models and hooks.
   config.omniauth :cognito, ENV["COGNITO_CLIENT_ID"], ENV["COGNITO_CLIENT_SECRET"], client_options: {site: ENV["COGNITO_USER_POOL_SITE"]}, scope: "email openid aws.cognito.signin.user.admin profile",
-                                                                                         user_pool_id: ENV["COGNITO_USER_POOL_ID"],
-                                                                                         aws_region: "eu-west-2", strategy_class: OmniAuth::Strategies::Cognito
+                                                                                    user_pool_id: ENV["COGNITO_USER_POOL_ID"],
+                                                                                    aws_region: "eu-west-2", strategy_class: OmniAuth::Strategies::Cognito
 
   # ==> Warden configuration
   # If you want to use other strategies, that are not supported by Devise, or

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'omni_auth/strategies/cognito'
+require "omni_auth/strategies/cognito"
 
 # Assuming you have not yet modified this file, each configuration option below
 # is set to its default value. Note that some are commented out while others

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'omni_auth/strategies/cognito'
+
 # Assuming you have not yet modified this file, each configuration option below
 # is set to its default value. Note that some are commented out while others
 # are not: uncommented lines are intended to protect your configuration from

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -271,9 +271,9 @@ Devise.setup do |config|
   # ==> OmniAuth
   # Add a new OmniAuth provider. Check the wiki for more information on setting
   # up on your models and hooks.
-  config.omniauth "cognito-idp", ENV["COGNITO_CLIENT_ID"], ENV["COGNITO_CLIENT_SECRET"], client_options: {site: ENV["COGNITO_USER_POOL_SITE"]}, scope: "email openid aws.cognito.signin.user.admin profile",
+  config.omniauth :cognito, ENV["COGNITO_CLIENT_ID"], ENV["COGNITO_CLIENT_SECRET"], client_options: {site: ENV["COGNITO_USER_POOL_SITE"]}, scope: "email openid aws.cognito.signin.user.admin profile",
                                                                                          user_pool_id: ENV["COGNITO_USER_POOL_ID"],
-                                                                                         aws_region: "eu-west-2"
+                                                                                         aws_region: "eu-west-2", strategy_class: OmniAuth::Strategies::Cognito
 
   # ==> Warden configuration
   # If you want to use other strategies, that are not supported by Devise, or

--- a/spec/acceptance/hello_world_spec.rb
+++ b/spec/acceptance/hello_world_spec.rb
@@ -7,11 +7,12 @@ RSpec.describe "GET /", type: :feature do
 
       Rails.application.env_config["devise.mapping"] = Devise.mappings[:user]
       Rails.application.env_config["omniauth.auth"] = OmniAuth.config.mock_auth[:cognito]
+
+      visit "/sign_in"
+      click_link("Sign in with Cognito")
     end
 
     it "displays hello" do
-      visit "/sign_in"
-      click_link("Sign in with Cognito")
       visit "/"
       expect(page).to have_content "Hello from Staff Device"
     end

--- a/spec/acceptance/hello_world_spec.rb
+++ b/spec/acceptance/hello_world_spec.rb
@@ -1,14 +1,22 @@
 require "rails_helper"
 
 RSpec.describe "GET /", type: :feature do
-  it "displays hello when signed in" do
-    pending "Log in functionality not yet implemented"
+  context 'user signed in' do
+    before do
+      OmniAuth.config.add_mock(:cognito, { provider: 'cognito', uid: '12345' })
 
-    visit "/sign_in"
-    click_link("Sign in with Cognito")
-    visit "/"
-    expect(page).to have_content "Hello from Staff Device"
+      Rails.application.env_config["devise.mapping"] = Devise.mappings[:user]
+      Rails.application.env_config["omniauth.auth"] = OmniAuth.config.mock_auth[:cognito]
+    end
+
+    it "displays hello" do
+      visit "/sign_in"
+      click_link("Sign in with Cognito")
+      visit "/"
+      expect(page).to have_content "Hello from Staff Device"
+    end
   end
+
 
   it "displays log in when not signed in" do
     visit "/"

--- a/spec/acceptance/hello_world_spec.rb
+++ b/spec/acceptance/hello_world_spec.rb
@@ -1,9 +1,9 @@
 require "rails_helper"
 
 RSpec.describe "GET /", type: :feature do
-  context 'user signed in' do
+  context "user signed in" do
     before do
-      OmniAuth.config.add_mock(:cognito, { provider: 'cognito', uid: '12345' })
+      OmniAuth.config.add_mock(:cognito, {provider: "cognito", uid: "12345"})
 
       Rails.application.env_config["devise.mapping"] = Devise.mappings[:user]
       Rails.application.env_config["omniauth.auth"] = OmniAuth.config.mock_auth[:cognito]
@@ -16,7 +16,6 @@ RSpec.describe "GET /", type: :feature do
       expect(page).to have_content "Hello from Staff Device"
     end
   end
-
 
   it "displays log in when not signed in" do
     visit "/"

--- a/spec/lib/omni_auth/strategies/cognito_spec.rb
+++ b/spec/lib/omni_auth/strategies/cognito_spec.rb
@@ -1,17 +1,17 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
-require 'support/shared_oauth2_examples'
+require "spec_helper"
+require "support/shared_oauth2_examples"
 
 RSpec.describe OmniAuth::Strategies::Cognito do
   subject { strategy }
 
   let(:strategy) { described_class.new(app, client_id, client_secret, options) }
 
-  let(:app) { ->(_env) { [200, '', {}] } }
+  let(:app) { ->(_env) { [200, "", {}] } }
   let(:options) { {} }
-  let(:client_id) { 'ABCDE' }
-  let(:client_secret) { '987654321' }
+  let(:client_id) { "ABCDE" }
+  let(:client_secret) { "987654321" }
 
   around do |example|
     OmniAuth.config.test_mode = true
@@ -21,9 +21,9 @@ RSpec.describe OmniAuth::Strategies::Cognito do
     OmniAuth.config.test_mode = false
   end
 
-  it_behaves_like 'an oauth2 strategy'
+  it_behaves_like "an oauth2 strategy"
 
-  describe '#build_access_token' do
+  describe "#build_access_token" do
     subject do
       described_class.new(client_id, client_secret, options).tap do |strategy|
         allow(strategy).to receive(:client).and_return(oauth_client)
@@ -32,54 +32,55 @@ RSpec.describe OmniAuth::Strategies::Cognito do
       end
     end
 
-    let(:oauth_client) { double('OAuth2::Client', auth_code: auth_code) }
-    let(:auth_code) { double('OAuth2::AuthCode', get_token: access_token_object) }
-    let(:access_token_object) { double('OAuth2::AccessToken') }
-    let(:callback_url) { 'http://localhost/auth/cognito/callback?code=1234' }
+    let(:oauth_client) { double("OAuth2::Client", auth_code: auth_code) }
+    let(:auth_code) { double("OAuth2::AuthCode", get_token: access_token_object) }
+    let(:access_token_object) { double("OAuth2::AccessToken") }
+    let(:callback_url) { "http://localhost/auth/cognito/callback?code=1234" }
 
-    let(:request) { double('Rack::Request', params: params) }
-    let(:params) { { 'code' => '12345' } }
+    let(:request) { double("Rack::Request", params: params) }
+    let(:params) { {"code" => "12345"} }
 
-    it 'does not send the query part of the request URL as callback URL' do
+    it "does not send the query part of the request URL as callback URL" do
       expect(auth_code).to receive(:get_token).with(
-        params['code'],
-        { redirect_uri: callback_url.split('?').first }.merge(subject.token_params.to_hash(symbolize_keys: true)),
-        subject.__send__(:deep_symbolize, subject.options.auth_token_params)).and_return(access_token_object)
+        params["code"],
+        {redirect_uri: callback_url.split("?").first}.merge(subject.token_params.to_hash(symbolize_keys: true)),
+        subject.__send__(:deep_symbolize, subject.options.auth_token_params)
+      ).and_return(access_token_object)
 
       expect(subject.__send__(:build_access_token)).to eql access_token_object
     end
   end
 
-  describe 'auth hash' do
-    let(:options) { { aws_region: 'eu-west-1', user_pool_id: 'user_pool_id' } }
+  describe "auth hash" do
+    let(:options) { {aws_region: "eu-west-1", user_pool_id: "user_pool_id"} }
 
-    let(:auth_hash) { env['omniauth.auth'] }
+    let(:auth_hash) { env["omniauth.auth"] }
 
     let(:env) { {} }
-    let(:request) { double('Rack::Request', params: {'state' => strategy.session['omniauth.state']}) }
-    let(:session) { { 'omniauth.state' => 'some_state' } }
-    let(:oauth_client) { double('OAuth2::Client', auth_code: auth_code) }
-    let(:auth_code) { double('OAuth2::AuthCode') }
+    let(:request) { double("Rack::Request", params: {"state" => strategy.session["omniauth.state"]}) }
+    let(:session) { {"omniauth.state" => "some_state"} }
+    let(:oauth_client) { double("OAuth2::Client", auth_code: auth_code) }
+    let(:auth_code) { double("OAuth2::AuthCode") }
     let(:access_token_object) { OAuth2::AccessToken.from_hash(oauth_client, token_hash) }
 
     let(:token_hash) do
       {
-        'expires_at' => token_expires.to_i,
-        'access_token' => access_token_string,
-        'refresh_token' => refresh_token_string,
-        'id_token' => id_token_string
+        "expires_at" => token_expires.to_i,
+        "access_token" => access_token_string,
+        "refresh_token" => refresh_token_string,
+        "id_token" => id_token_string
       }
     end
 
     let(:now) { Time.now }
     let(:token_expires) { now + 3600 }
-    let(:access_token_string) { 'access_token' }
-    let(:refresh_token_string) { 'refresh_token' }
+    let(:access_token_string) { "access_token" }
+    let(:refresh_token_string) { "refresh_token" }
 
-    let(:id_sub) { '1234-5678-9012' }
-    let(:id_phone) { 'some phone number' }
-    let(:id_email) { 'some email address' }
-    let(:id_name) { 'Some Name' }
+    let(:id_sub) { "1234-5678-9012" }
+    let(:id_phone) { "some phone number" }
+    let(:id_email) { "some email address" }
+    let(:id_name) { "Some Name" }
 
     let(:id_token_string) do
       JWT.encode(
@@ -94,11 +95,11 @@ RSpec.describe OmniAuth::Strategies::Cognito do
           email: id_email,
           name: id_name
         },
-        '12345'
+        "12345"
       )
     end
 
-    let(:callback_url) { 'http://localhost/auth/cognito/callback?code=1234' }
+    let(:callback_url) { "http://localhost/auth/cognito/callback?code=1234" }
 
     before do
       allow(strategy).to receive(:env).and_return(env)
@@ -112,34 +113,34 @@ RSpec.describe OmniAuth::Strategies::Cognito do
       strategy.callback_phase
     end
 
-    describe ':uid' do
-      it 'includes the `sub` claim from the ID token' do
+    describe ":uid" do
+      it "includes the `sub` claim from the ID token" do
         expect(auth_hash[:uid]).to eql id_sub
       end
     end
 
-    describe ':info' do
-      it 'includes name, email and phone' do
-        expect(auth_hash[:info]).to eql('name' => id_name, 'email' => id_email, 'phone' => id_phone)
+    describe ":info" do
+      it "includes name, email and phone" do
+        expect(auth_hash[:info]).to eql("name" => id_name, "email" => id_email, "phone" => id_phone)
       end
     end
 
-    describe ':credentials' do
-      it 'contains all tokens' do
+    describe ":credentials" do
+      it "contains all tokens" do
         expect(auth_hash[:credentials]).to eql(
-          'expires' => true,
-          'expires_at' => token_expires.to_i,
-          'id_token' => id_token_string,
-          'refresh_token' => refresh_token_string,
-          'token' => access_token_string
+          "expires" => true,
+          "expires_at" => token_expires.to_i,
+          "id_token" => id_token_string,
+          "refresh_token" => refresh_token_string,
+          "token" => access_token_string
         )
       end
     end
 
-    describe ':extra' do
-      it 'contains the parsed data from the id token' do
+    describe ":extra" do
+      it "contains the parsed data from the id token" do
         expect(auth_hash[:extra])
-          .to eql('raw_info' => {'sub' => id_sub, 'phone_number' => id_phone, 'email' => id_email, 'name' => id_name})
+          .to eql("raw_info" => {"sub" => id_sub, "phone_number" => id_phone, "email" => id_email, "name" => id_name})
       end
     end
   end

--- a/spec/lib/omni_auth/strategies/cognito_spec.rb
+++ b/spec/lib/omni_auth/strategies/cognito_spec.rb
@@ -1,0 +1,146 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'support/shared_oauth2_examples'
+
+RSpec.describe OmniAuth::Strategies::Cognito do
+  subject { strategy }
+
+  let(:strategy) { described_class.new(app, client_id, client_secret, options) }
+
+  let(:app) { ->(_env) { [200, '', {}] } }
+  let(:options) { {} }
+  let(:client_id) { 'ABCDE' }
+  let(:client_secret) { '987654321' }
+
+  around do |example|
+    OmniAuth.config.test_mode = true
+
+    example.run
+
+    OmniAuth.config.test_mode = false
+  end
+
+  it_behaves_like 'an oauth2 strategy'
+
+  describe '#build_access_token' do
+    subject do
+      described_class.new(client_id, client_secret, options).tap do |strategy|
+        allow(strategy).to receive(:client).and_return(oauth_client)
+        allow(strategy).to receive(:request).and_return(request)
+        allow(strategy).to receive(:callback_url).and_return(callback_url)
+      end
+    end
+
+    let(:oauth_client) { double('OAuth2::Client', auth_code: auth_code) }
+    let(:auth_code) { double('OAuth2::AuthCode', get_token: access_token_object) }
+    let(:access_token_object) { double('OAuth2::AccessToken') }
+    let(:callback_url) { 'http://localhost/auth/cognito/callback?code=1234' }
+
+    let(:request) { double('Rack::Request', params: params) }
+    let(:params) { { 'code' => '12345' } }
+
+    it 'does not send the query part of the request URL as callback URL' do
+      expect(auth_code).to receive(:get_token).with(
+        params['code'],
+        { redirect_uri: callback_url.split('?').first }.merge(subject.token_params.to_hash(symbolize_keys: true)),
+        subject.__send__(:deep_symbolize, subject.options.auth_token_params)).and_return(access_token_object)
+
+      expect(subject.__send__(:build_access_token)).to eql access_token_object
+    end
+  end
+
+  describe 'auth hash' do
+    let(:options) { { aws_region: 'eu-west-1', user_pool_id: 'user_pool_id' } }
+
+    let(:auth_hash) { env['omniauth.auth'] }
+
+    let(:env) { {} }
+    let(:request) { double('Rack::Request', params: {'state' => strategy.session['omniauth.state']}) }
+    let(:session) { { 'omniauth.state' => 'some_state' } }
+    let(:oauth_client) { double('OAuth2::Client', auth_code: auth_code) }
+    let(:auth_code) { double('OAuth2::AuthCode') }
+    let(:access_token_object) { OAuth2::AccessToken.from_hash(oauth_client, token_hash) }
+
+    let(:token_hash) do
+      {
+        'expires_at' => token_expires.to_i,
+        'access_token' => access_token_string,
+        'refresh_token' => refresh_token_string,
+        'id_token' => id_token_string
+      }
+    end
+
+    let(:now) { Time.now }
+    let(:token_expires) { now + 3600 }
+    let(:access_token_string) { 'access_token' }
+    let(:refresh_token_string) { 'refresh_token' }
+
+    let(:id_sub) { '1234-5678-9012' }
+    let(:id_phone) { 'some phone number' }
+    let(:id_email) { 'some email address' }
+    let(:id_name) { 'Some Name' }
+
+    let(:id_token_string) do
+      JWT.encode(
+        {
+          sub: id_sub,
+          iat: now.to_i,
+          iss: "https://cognito.eu-west-1.amazonaws.com/user_pool_id",
+          nbf: now.to_i,
+          exp: token_expires.to_i,
+          aud: strategy.options[:client_id],
+          phone_number: id_phone,
+          email: id_email,
+          name: id_name
+        },
+        '12345'
+      )
+    end
+
+    let(:callback_url) { 'http://localhost/auth/cognito/callback?code=1234' }
+
+    before do
+      allow(strategy).to receive(:env).and_return(env)
+      allow(strategy).to receive(:session).and_return(session)
+      allow(strategy).to receive(:request).and_return(request)
+      allow(strategy).to receive(:callback_url).and_return(callback_url)
+      allow(strategy).to receive(:client).and_return(oauth_client)
+
+      allow(auth_code).to receive(:get_token).and_return(access_token_object)
+
+      strategy.callback_phase
+    end
+
+    describe ':uid' do
+      it 'includes the `sub` claim from the ID token' do
+        expect(auth_hash[:uid]).to eql id_sub
+      end
+    end
+
+    describe ':info' do
+      it 'includes name, email and phone' do
+        expect(auth_hash[:info]).to eql('name' => id_name, 'email' => id_email, 'phone' => id_phone)
+      end
+    end
+
+    describe ':credentials' do
+      it 'contains all tokens' do
+        expect(auth_hash[:credentials]).to eql(
+          'expires' => true,
+          'expires_at' => token_expires.to_i,
+          'id_token' => id_token_string,
+          'refresh_token' => refresh_token_string,
+          'token' => access_token_string
+        )
+      end
+    end
+
+    describe ':extra' do
+      it 'contains the parsed data from the id token' do
+        expect(auth_hash[:extra])
+          .to eql('raw_info' => {'sub' => id_sub, 'phone_number' => id_phone, 'email' => id_email, 'name' => id_name})
+      end
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -7,6 +7,8 @@ abort("The Rails environment is running in production mode!") if Rails.env.produ
 require "rspec/rails"
 # Add additional requires below this line. Rails is not loaded until this point!
 
+OmniAuth.config.test_mode = true
+
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are
 # run as spec files by default. This means that files in spec/support that end
@@ -31,6 +33,10 @@ rescue ActiveRecord::PendingMigrationError => e
   exit 1
 end
 RSpec.configure do |config|
+  config.before(:each) do
+    OmniAuth.config.mock_auth[:cognito] = nil
+  end
+
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
 

--- a/spec/support/shared_oauth2_examples.rb
+++ b/spec/support/shared_oauth2_examples.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+shared_examples 'an oauth2 strategy' do
+  # Courtesy omniauth-37signals:
+  # https://github.com/tallgreentree/omniauth-37signals/blob/master/spec/support/shared_examples.rb
+
+  describe '#client' do
+    it 'should be initialized with symbolized client_options' do
+      options.merge!(client_options: { 'authorize_url' => 'https://example.com' })
+
+      expect(subject.client.options[:authorize_url]).to eq('https://example.com')
+    end
+  end
+
+  describe '#authorize_params' do
+    it 'should include any authorize params passed in the :authorize_params option' do
+      options.merge!(authorize_params: { foo: 'bar', baz: 'zip' })
+
+      expect(subject.authorize_params['foo']).to eq('bar')
+      expect(subject.authorize_params['baz']).to eq('zip')
+    end
+
+    it 'should include top-level options that are marked as :authorize_options' do
+      options.merge!(authorize_options: [:scope, :foo], scope: 'bar', foo: 'baz')
+
+      expect(subject.authorize_params['scope']).to eq('bar')
+      expect(subject.authorize_params['foo']).to eq('baz')
+    end
+  end
+
+  describe '#token_params' do
+    it 'should include any token params passed in the :token_params option' do
+      options.merge!(token_params: { foo: 'bar', baz: 'zip' })
+
+      expect(subject.token_params['foo']).to eq('bar')
+      expect(subject.token_params['baz']).to eq('zip')
+    end
+
+    it 'should include top-level options that are marked as :token_options' do
+      options.merge!(token_options: [:scope, :foo], scope: 'bar', foo: 'baz')
+
+      expect(subject.token_params['scope']).to eq('bar')
+      expect(subject.token_params['foo']).to eq('baz')
+    end
+  end
+end

--- a/spec/support/shared_oauth2_examples.rb
+++ b/spec/support/shared_oauth2_examples.rb
@@ -1,46 +1,46 @@
 # frozen_string_literal: true
 
-shared_examples 'an oauth2 strategy' do
+shared_examples "an oauth2 strategy" do
   # Courtesy omniauth-37signals:
   # https://github.com/tallgreentree/omniauth-37signals/blob/master/spec/support/shared_examples.rb
 
-  describe '#client' do
-    it 'should be initialized with symbolized client_options' do
-      options.merge!(client_options: { 'authorize_url' => 'https://example.com' })
+  describe "#client" do
+    it "should be initialized with symbolized client_options" do
+      options[:client_options] = {"authorize_url" => "https://example.com"}
 
-      expect(subject.client.options[:authorize_url]).to eq('https://example.com')
+      expect(subject.client.options[:authorize_url]).to eq("https://example.com")
     end
   end
 
-  describe '#authorize_params' do
-    it 'should include any authorize params passed in the :authorize_params option' do
-      options.merge!(authorize_params: { foo: 'bar', baz: 'zip' })
+  describe "#authorize_params" do
+    it "should include any authorize params passed in the :authorize_params option" do
+      options[:authorize_params] = {foo: "bar", baz: "zip"}
 
-      expect(subject.authorize_params['foo']).to eq('bar')
-      expect(subject.authorize_params['baz']).to eq('zip')
+      expect(subject.authorize_params["foo"]).to eq("bar")
+      expect(subject.authorize_params["baz"]).to eq("zip")
     end
 
-    it 'should include top-level options that are marked as :authorize_options' do
-      options.merge!(authorize_options: [:scope, :foo], scope: 'bar', foo: 'baz')
+    it "should include top-level options that are marked as :authorize_options" do
+      options.merge!(authorize_options: [:scope, :foo], scope: "bar", foo: "baz")
 
-      expect(subject.authorize_params['scope']).to eq('bar')
-      expect(subject.authorize_params['foo']).to eq('baz')
+      expect(subject.authorize_params["scope"]).to eq("bar")
+      expect(subject.authorize_params["foo"]).to eq("baz")
     end
   end
 
-  describe '#token_params' do
-    it 'should include any token params passed in the :token_params option' do
-      options.merge!(token_params: { foo: 'bar', baz: 'zip' })
+  describe "#token_params" do
+    it "should include any token params passed in the :token_params option" do
+      options[:token_params] = {foo: "bar", baz: "zip"}
 
-      expect(subject.token_params['foo']).to eq('bar')
-      expect(subject.token_params['baz']).to eq('zip')
+      expect(subject.token_params["foo"]).to eq("bar")
+      expect(subject.token_params["baz"]).to eq("zip")
     end
 
-    it 'should include top-level options that are marked as :token_options' do
-      options.merge!(token_options: [:scope, :foo], scope: 'bar', foo: 'baz')
+    it "should include top-level options that are marked as :token_options" do
+      options.merge!(token_options: [:scope, :foo], scope: "bar", foo: "baz")
 
-      expect(subject.token_params['scope']).to eq('bar')
-      expect(subject.token_params['foo']).to eq('baz')
+      expect(subject.token_params["scope"]).to eq("bar")
+      expect(subject.token_params["foo"]).to eq("baz")
     end
   end
 end


### PR DESCRIPTION
Clones the strategy used in the omniauth-cognito-idp gem, replacing the 'cognito-idp' name with 'cognito' to resolve path issues in devise and rails