### PR TITLE
Use GET action to sign out

### DIFF
--- a/app/views/home/show.html.erb
+++ b/app/views/home/show.html.erb
@@ -1,3 +1,3 @@
 <p>Hello from Staff Device</p>
 
-<%= link_to "Logout", destroy_user_session_path, method: :delete %>
+<%= link_to "Logout", destroy_user_session_path %>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -268,7 +268,7 @@ Devise.setup do |config|
   # config.navigational_formats = ['*/*', :html]
 
   # The default HTTP method used to sign out a resource. Default is :delete.
-  config.sign_out_via = :delete
+  config.sign_out_via = :get
 
   # ==> OmniAuth
   # Add a new OmniAuth provider. Check the wiki for more information on setting

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   devise_for :users, controllers: {omniauth_callbacks: "users/omniauth_callbacks"}
   devise_scope :user do
     get "sign_in", to: "devise/sessions#new", as: :new_user_session
-    delete "sign_out", to: "devise/sessions#destroy", as: :destroy_user_session
+    get "sign_out", to: "devise/sessions#destroy", as: :destroy_user_session
   end
 
   get "/healthcheck", to: "monitoring#healthcheck"


### PR DESCRIPTION
This removes the javascript requirement to get `method: :delete` to work