### PR TITLE
Don't install development and test gems in production

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ ARG DB_USER=root
 ARG DB_PASS=root
 ARG SECRET_KEY_BASE="fakekeybase"
 ARG DB_NAME=root
+ARG BUNDLE_WITHOUT=""
 
 # required for certain linting tools that read files, such as erb-lint
 ENV LANG='C.UTF-8' \
@@ -23,9 +24,8 @@ RUN apk add --no-cache --virtual .build-deps build-base && \
   apk add --no-cache nodejs yarn mysql-dev bash make
 
 COPY Gemfile Gemfile.lock .ruby-version ./
-ARG BUNDLE_INSTALL_FLAGS
 RUN bundle config set no-cache 'true' && \
-  bundle install ${BUNDLE_INSTALL_FLAGS}
+  bundle install
 
 COPY package.json yarn.lock ./
 RUN yarn && yarn cache clean

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ endif
 DOCKER_BUILD_CMD = BUNDLE_INSTALL_FLAGS="$(BUNDLE_FLAGS)" $(DOCKER_COMPOSE) build
 
 build:
-	docker build -t docker_admin . --build-arg RACK_ENV --build-arg DB_HOST --build-arg DB_USER --build-arg DB_PASS --build-arg SECRET_KEY_BASE --build-arg DB_NAME
+	docker build -t docker_admin . --build-arg RACK_ENV --build-arg DB_HOST --build-arg DB_USER --build-arg DB_PASS --build-arg SECRET_KEY_BASE --build-arg DB_NAME --build-arg BUNDLE_WITHOUT
 
 build-dev:
 	$(DOCKER_COMPOSE) build

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -5,6 +5,7 @@ env:
     DB_PORT: 3306
     RACK_ENV: "production"
     ENV: ${ENV}
+    BUNDLE_WITHOUT: "test development"
   parameter-store:
     DB_USER: "/codebuild/dhcp/$ENV/admin/db/username"
     DB_PASS: "/codebuild/dhcp/$ENV/admin/db/password"


### PR DESCRIPTION
Bundler has deprecated the "--without flag":
https://github.com/rubygems/bundler/issues/7531

By setting BUNDLE_WITHOUT env variable you can achieve the same thing.

Docker images should be smaller with less dependencies.