### PR TITLE
Publish config file to S3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ ENV LANG='C.UTF-8' \
   DB_USER=${DB_USER} \
   DB_PASS=${DB_PASS} \
   SECRET_KEY_BASE=${SECRET_KEY_BASE} \
+  KEA_CONFIG_BUCKET='testbucket' \
   DB_NAME=${DB_NAME}
 
 WORKDIR /usr/src/app

--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ gem "tzinfo-data"
 gem "devise"
 gem "jwt"
 gem "omniauth-oauth2"
+gem "aws-sdk-s3", "~> 1.73"
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -59,6 +59,22 @@ GEM
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
     ast (2.4.1)
+    aws-eventstream (1.1.0)
+    aws-partitions (1.357.0)
+    aws-sdk-core (3.104.3)
+      aws-eventstream (~> 1, >= 1.0.2)
+      aws-partitions (~> 1, >= 1.239.0)
+      aws-sigv4 (~> 1.1)
+      jmespath (~> 1.0)
+    aws-sdk-kms (1.36.0)
+      aws-sdk-core (~> 3, >= 3.99.0)
+      aws-sigv4 (~> 1.1)
+    aws-sdk-s3 (1.78.0)
+      aws-sdk-core (~> 3, >= 3.104.3)
+      aws-sdk-kms (~> 1)
+      aws-sigv4 (~> 1.1)
+    aws-sigv4 (1.2.2)
+      aws-eventstream (~> 1, >= 1.0.2)
     bcrypt (3.1.15)
     bindex (0.8.1)
     bootsnap (1.4.7)
@@ -98,6 +114,7 @@ GEM
       concurrent-ruby (~> 1.0)
     jbuilder (2.10.0)
       activesupport (>= 5.0.0)
+    jmespath (1.4.0)
     jwt (2.2.1)
     listen (3.2.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
@@ -280,6 +297,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  aws-sdk-s3 (~> 1.73)
   bootsnap (>= 1.4.2)
   byebug
   capybara (>= 2.15)

--- a/README.md
+++ b/README.md
@@ -7,11 +7,18 @@ This is the web frontend for managing Staff Device DNS / DHCP servers
 ## Development
 
 1. Clone the repository
-1. If this is the first time you have setup the project, setup the database.
+1. If this is the first time you have setup the project
+    1. Setup the database.
 
-```sh
-make db-setup
-```
+        ```sh
+        make db-setup
+        ```
+
+    2. Build the base containers.
+
+        ```sh
+        make build-dev
+        ```
 
 1. Start the application
 

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,12 +1,12 @@
 class HomeController < ApplicationController
   def show
-    #temporary location for testing until we have a way to publish configurations
+    # temporary location for testing until we have a way to publish configurations
     UseCases::PublishKeaConfig.new(
       destination_gateway: Gateways::S3.new(
-        bucket: ENV.fetch('KEA_CONFIG_BUCKET'),
-        key: 'config.json'
+        bucket: ENV.fetch("KEA_CONFIG_BUCKET"),
+        key: "config.json"
       ),
-      generate_config: UseCases::GenerateKeaConfig.new,
+      generate_config: UseCases::GenerateKeaConfig.new
     ).execute
   end
 end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,4 +1,12 @@
 class HomeController < ApplicationController
   def show
+    #temporary location for testing until we have a way to publish configurations
+    UseCases::PublishKeaConfig.new(
+      destination_gateway: Gateways::S3.new(
+        bucket: ENV.fetch('KEA_CONFIG_BUCKET'),
+        key: 'config.json'
+      ),
+      generate_config: UseCases::GenerateKeaConfig.new,
+    ).execute
   end
 end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -3,8 +3,9 @@ class HomeController < ApplicationController
     # temporary location for testing until we have a way to publish configurations
     UseCases::PublishKeaConfig.new(
       destination_gateway: Gateways::S3.new(
-        bucket: ENV.fetch("KEA_CONFIG_BUCKET"),
-        key: "config.json"
+        bucket: ENV.fetch('KEA_CONFIG_BUCKET'),
+        key: 'config.json',
+        aws_config: Rails.application.config.s3_aws_config
       ),
       generate_config: UseCases::GenerateKeaConfig.new
     ).execute

--- a/app/lib/gateways/s3.rb
+++ b/app/lib/gateways/s3.rb
@@ -1,0 +1,33 @@
+module Gateways
+  class S3
+    def initialize(bucket:, key:)
+      @bucket = bucket
+      @key = key
+      @client = Aws::S3::Client.new(config)
+    end
+
+    def write(data:)
+      client.put_object(
+        body: data,
+        bucket: bucket,
+        key: key,
+      )
+
+      {}
+    end
+
+    def read
+      client.get_object(bucket: bucket, key: key).body.read
+    end
+
+  private
+
+    DEFAULT_REGION = "eu-west-2".freeze
+
+    attr_reader :bucket, :key, :client
+
+    def config
+      { region: DEFAULT_REGION }.merge(Rails.application.config.s3_aws_config)
+    end
+  end
+end

--- a/app/lib/gateways/s3.rb
+++ b/app/lib/gateways/s3.rb
@@ -10,7 +10,7 @@ module Gateways
       client.put_object(
         body: data,
         bucket: bucket,
-        key: key,
+        key: key
       )
 
       {}
@@ -20,14 +20,14 @@ module Gateways
       client.get_object(bucket: bucket, key: key).body.read
     end
 
-  private
+    private
 
     DEFAULT_REGION = "eu-west-2".freeze
 
     attr_reader :bucket, :key, :client
 
     def config
-      { region: DEFAULT_REGION }.merge(Rails.application.config.s3_aws_config)
+      {region: DEFAULT_REGION}.merge(Rails.application.config.s3_aws_config)
     end
   end
 end

--- a/app/lib/gateways/s3.rb
+++ b/app/lib/gateways/s3.rb
@@ -1,9 +1,9 @@
 module Gateways
   class S3
-    def initialize(bucket:, key:)
+    def initialize(bucket:, key:, aws_config:)
       @bucket = bucket
       @key = key
-      @client = Aws::S3::Client.new(config)
+      @client = Aws::S3::Client.new(aws_config)
     end
 
     def write(data:)
@@ -22,12 +22,6 @@ module Gateways
 
     private
 
-    DEFAULT_REGION = "eu-west-2".freeze
-
     attr_reader :bucket, :key, :client
-
-    def config
-      {region: DEFAULT_REGION}.merge(Rails.application.config.s3_aws_config)
-    end
   end
 end

--- a/app/lib/use_cases/generate_kea_config.rb
+++ b/app/lib/use_cases/generate_kea_config.rb
@@ -1,4 +1,4 @@
-#stub response until we can generate real configurations
+# stub response until we can generate real configurations
 
 module UseCases
   class GenerateKeaConfig

--- a/app/lib/use_cases/generate_kea_config.rb
+++ b/app/lib/use_cases/generate_kea_config.rb
@@ -1,0 +1,63 @@
+#stub response until we can generate real configurations
+
+module UseCases
+  class GenerateKeaConfig
+    def execute
+      '{
+        "Dhcp4":{
+          "interfaces-config":{
+            "interfaces":[
+              "<INTERFACE>"
+            ]
+          },
+          "lease-database":{
+            "type":"mysql",
+            "name":"<DB_NAME>",
+            "user":"<DB_USER>",
+            "password":"<DB_PASS>",
+            "host":"<DB_HOST>",
+            "port":3306
+          },
+          "valid-lifetime":4000,
+          "host-reservation-identifiers":[
+            "circuit-id",
+            "hw-address",
+            "duid",
+            "client-id"
+          ],
+          "hosts-database":{
+            "type":"mysql",
+            "name":"<DB_NAME>",
+            "user":"<DB_USER>",
+            "password":"<DB_PASS>",
+            "host":"<DB_HOST>",
+            "port":3306
+          },
+          "subnet4":[
+            {
+              "pools":[
+                {
+                  "pool":"192.0.2.10 - 192.0.2.200"
+                }
+              ],
+              "subnet":"192.0.2.0/24",
+              "interface":"<INTERFACE>",
+              "id":1
+            }
+          ],
+          "loggers":[
+            {
+              "name":"kea-dhcp4",
+              "output_options":[
+                {
+                  "output":"stdout"
+                }
+              ],
+              "severity":"INFO"
+            }
+          ]
+        }
+      }'
+    end
+  end
+end

--- a/app/lib/use_cases/publish_kea_config.rb
+++ b/app/lib/use_cases/publish_kea_config.rb
@@ -1,0 +1,15 @@
+class UseCases::PublishKeaConfig
+  def initialize(destination_gateway:, generate_config:)
+    @destination_gateway = destination_gateway
+    @generate_config = generate_config
+  end
+
+  def execute
+    payload = generate_config.execute
+    destination_gateway.write(data: payload)
+  end
+
+private
+
+  attr_reader :generate_config, :destination_gateway
+end

--- a/app/lib/use_cases/publish_kea_config.rb
+++ b/app/lib/use_cases/publish_kea_config.rb
@@ -9,7 +9,7 @@ class UseCases::PublishKeaConfig
     destination_gateway.write(data: payload)
   end
 
-private
+  private
 
   attr_reader :generate_config, :destination_gateway
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -61,4 +61,5 @@ Rails.application.configure do
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
 
   config.check_yarn_integrity = false
+  config.s3_aws_config = {}
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -61,5 +61,5 @@ Rails.application.configure do
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
 
   config.check_yarn_integrity = false
-  config.s3_aws_config = {}
+  config.s3_aws_config = { region: "eu-west-2" }
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -88,7 +88,7 @@ Rails.application.configure do
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
-  config.s3_aws_config = {}
+  config.s3_aws_config = { region: "eu-west-2" }
 
   # Inserts middleware to perform automatic connection switching.
   # The `database_selector` hash is used to pass options to the DatabaseSelector

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -88,6 +88,7 @@ Rails.application.configure do
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
+  config.s3_aws_config = {}
 
   # Inserts middleware to perform automatic connection switching.
   # The `database_selector` hash is used to pass options to the DatabaseSelector

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -43,7 +43,7 @@ Rails.application.configure do
 
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr
-  config.s3_aws_config = { stub_responses: true }
+  config.s3_aws_config = {stub_responses: true}
 
   # Raises error for missing translations.
   # config.action_view.raise_on_missing_translations = true

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -43,6 +43,7 @@ Rails.application.configure do
 
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr
+  config.s3_aws_config = { stub_responses: true }
 
   # Raises error for missing translations.
   # config.action_view.raise_on_missing_translations = true

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -43,7 +43,7 @@ Rails.application.configure do
 
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr
-  config.s3_aws_config = {stub_responses: true}
+  config.s3_aws_config = { stub_responses: true, region: "eu-west-2"  }
 
   # Raises error for missing translations.
   # config.action_view.raise_on_missing_translations = true

--- a/spec/gateways/s3_spec.rb
+++ b/spec/gateways/s3_spec.rb
@@ -3,8 +3,7 @@ describe Gateways::S3 do
 
   let(:bucket) { "StubBucket" }
   let(:key) { "StubKey" }
-  let(:data) { { blah: "foobar" }.to_json }
-
+  let(:data) { {blah: "foobar"}.to_json }
 
   it "writes the data to the S3 bucket" do
     expect(gateway.write(data: data)).to eq({})
@@ -16,10 +15,10 @@ describe Gateways::S3 do
         stub_responses: {
           get_object: ->(context) {
             if context.params.fetch(:bucket) == bucket && context.params.fetch(:key) == key
-              { body: "some data" }
+              {body: "some data"}
             end
-          },
-        },
+          }
+        }
       }
     end
 

--- a/spec/gateways/s3_spec.rb
+++ b/spec/gateways/s3_spec.rb
@@ -1,27 +1,27 @@
 describe Gateways::S3 do
-  subject(:gateway) { described_class.new(bucket: bucket, key: key) }
+  subject(:gateway) { described_class.new(bucket: bucket, key: key, aws_config: aws_config) }
 
   let(:bucket) { "StubBucket" }
   let(:key) { "StubKey" }
   let(:data) { {blah: "foobar"}.to_json }
+  let(:aws_config) do
+      {
+        region: "eu-west-2",
+        stub_responses: {
+          get_object: ->(context) {
+            if context.params.fetch(:bucket) == bucket && context.params.fetch(:key) == key
+              { body: "some data" }
+            end
+          },
+        }
+      }
+    end
 
   it "writes the data to the S3 bucket" do
     expect(gateway.write(data: data)).to eq({})
   end
 
   context "when reading a file from the S3 bucket" do
-    before do
-      Rails.application.config.s3_aws_config = {
-        stub_responses: {
-          get_object: ->(context) {
-            if context.params.fetch(:bucket) == bucket && context.params.fetch(:key) == key
-              {body: "some data"}
-            end
-          }
-        }
-      }
-    end
-
     it "returns the contents of the file" do
       expect(gateway.read).to eq("some data")
     end

--- a/spec/gateways/s3_spec.rb
+++ b/spec/gateways/s3_spec.rb
@@ -1,0 +1,30 @@
+describe Gateways::S3 do
+  subject(:gateway) { described_class.new(bucket: bucket, key: key) }
+
+  let(:bucket) { "StubBucket" }
+  let(:key) { "StubKey" }
+  let(:data) { { blah: "foobar" }.to_json }
+
+
+  it "writes the data to the S3 bucket" do
+    expect(gateway.write(data: data)).to eq({})
+  end
+
+  context "when reading a file from the S3 bucket" do
+    before do
+      Rails.application.config.s3_aws_config = {
+        stub_responses: {
+          get_object: ->(context) {
+            if context.params.fetch(:bucket) == bucket && context.params.fetch(:key) == key
+              { body: "some data" }
+            end
+          },
+        },
+      }
+    end
+
+    it "returns the contents of the file" do
+      expect(gateway.read).to eq("some data")
+    end
+  end
+end

--- a/spec/use_cases/publish_kea_config_spec.rb
+++ b/spec/use_cases/publish_kea_config_spec.rb
@@ -1,0 +1,27 @@
+describe UseCases::PublishKeaConfig do
+  subject(:use_case) do
+    described_class.new(
+      destination_gateway: s3_gateway,
+      generate_config: generate_config
+    )
+  end
+
+  let(:generate_config) do
+    double(
+      execute: config
+    )
+  end
+  let(:s3_gateway) { instance_spy(Gateways::S3) }
+  let(:config) do
+    '{ some: "json" }'
+  end
+
+  before do
+    use_case.execute
+  end
+
+  it "publishes the Kea config" do
+    expect(s3_gateway).to have_received(:write)
+      .with(data: config)
+  end
+end


### PR DESCRIPTION
This adds the functionality to publish a config file to S3. Currently using a dummy
file until implemented. Envoked from the home controller after sign in
for testing, will be moved once a better location exists.