### PR TITLE
Flash messages

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -2,3 +2,5 @@ $govuk-image-url-function: "image-url";
 $govuk-font-url-function: "font-url";
 
 @import "../../../node_modules/govuk-frontend/govuk/all";
+@import "./utilities/*";
+@import "./components/*";

--- a/app/assets/stylesheets/components/flash_messages.scss
+++ b/app/assets/stylesheets/components/flash_messages.scss
@@ -1,0 +1,12 @@
+.flash-holder {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+  }
+
+  .flash-message-notice {
+    width: 100%;
+    padding: 1em;
+    color: $colour-white;
+    background: $colour-turquoise;
+  }

--- a/app/assets/stylesheets/utilities/colours.scss
+++ b/app/assets/stylesheets/utilities/colours.scss
@@ -1,0 +1,7 @@
+$colour-black: govuk-colour('black');
+$colour-blue: govuk-colour('blue');
+$colour-light-blue: govuk-colour('light-blue');
+$colour-dark-grey: govuk-colour('dark-grey');
+$colour-turquoise: govuk-colour('turquoise');
+$colour-white: govuk-colour('white');
+$colour-green: govuk-colour('green');

--- a/app/controllers/subnets_controller.rb
+++ b/app/controllers/subnets_controller.rb
@@ -10,7 +10,7 @@ class SubnetsController < ApplicationController
   def create
     @subnet = Subnet.new(subnet_params)
     if @subnet.save
-      redirect_to subnets_path
+      redirect_to subnets_path, notice: "Successfully created subnet"
     else
       render :new
     end

--- a/app/views/layouts/_flash_notices.html.erb
+++ b/app/views/layouts/_flash_notices.html.erb
@@ -1,0 +1,20 @@
+<% flash.each do |name, msg| -%>
+    <% next if name == "timedout" %>
+    <% next if msg.empty? %>
+
+    <% if name == 'notice' %>
+      <div class='flash-holder'>
+        <%= content_tag :p, msg, class: "govuk-heading-m flash-message-notice" %>
+      </div>
+    <% end %>
+    <% if name == 'alert' %>
+      <div class="govuk-error-summary">
+        <h2 class= "govuk-error-summary__title">
+          There is a problem
+        </h2>
+        <div class="govuk-error-summary__body">
+          <p><%= msg %></p>
+        </div>
+      </div>
+    <% end %>
+  <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -53,12 +53,14 @@
         <div class="govuk-grid-row">
           <div class="govuk-grid-column-three-quarters">
             <main class="govuk-main-wrapper govuk-!-padding-top-4" id="main-content" role="main">
+              <%= render "layouts/flash_notices" %>
               <%= yield %>
             </main>
           </div>
         </div>
       <% else %>
         <main class="govuk-main-wrapper" id="main-content" role="main">
+          <%= render "layouts/flash_notices" %>
           <%= yield %>
         </main>
       <% end %>


### PR DESCRIPTION
# What
Added support for flash messages. A flash message is shown on a successful creation of a subnet
# Why
So that you get confirmation that a subnet is added to the table successfully
# Screenshots
![image](https://user-images.githubusercontent.com/54268863/91065963-ffa05780-e628-11ea-8bce-62c2e3eb4f19.png)

# Notes
