### PR TITLE
Use a different database name for the test environment

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -12,6 +12,7 @@ development:
 
 test:
   <<: *default
+  database: <%= "#{ENV.fetch('DB_NAME')}_test" %>
 
 production:
   <<: *default


### PR DESCRIPTION
# What
Appends "_test" to the database name in the test environment

# Why
To ensure that we don't accidentally populate the test database with data from local testing or vice versa.

# Notes
Run `make db-setup` to create the new test database
