### PR TITLE
Persist the database as a data volume

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ shell:
 	$(DOCKER_COMPOSE) run --rm app sh
 
 stop:
-	$(DOCKER_COMPOSE) down -v
+	$(DOCKER_COMPOSE) down
 
 migrate:
 	./scripts/migrate.sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,8 @@ services:
       MYSQL_DATABASE: root
     expose:
       - "3306"
+    volumes:
+      - datavolume:/var/lib/mysql
 
   app:
     build:
@@ -28,3 +30,4 @@ services:
 
 volumes:
   node_modules:
+  datavolume:


### PR DESCRIPTION
# What
Persists the database as a volume

# Why
So that the database isn't dropped every time we run `make stop` or `make serve`

# Screenshots

# Notes
