### PR TITLE
Use .env files to configure local / CI environments

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,0 +1,3 @@
+MYSQL_ROOT_PASSWORD=root
+MYSQL_DATABASE=staff_device_dns_dhcp_admin_development
+DB_NAME=staff_device_dns_dhcp_admin_development

--- a/.env.test
+++ b/.env.test
@@ -1,0 +1,3 @@
+MYSQL_ROOT_PASSWORD=root
+MYSQL_DATABASE=staff_device_dns_dhcp_admin_development
+DB_NAME=staff_device_dns_dhcp_admin_test

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ db-setup: start-db
 serve: stop start-db
 	$(DOCKER_COMPOSE) up app
 
+test: export ENV=test
 test:
 	$(DOCKER_COMPOSE) run --rm app bundle exec rake
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,8 @@
-DOCKER_COMPOSE = docker-compose -f docker-compose.yml
+ifndef ENV
+ENV=development
+endif
+
+DOCKER_COMPOSE = ENV=${ENV} docker-compose -f docker-compose.yml
 BUNDLE_FLAGS=
 
 DOCKER_BUILD_CMD = BUNDLE_INSTALL_FLAGS="$(BUNDLE_FLAGS)" $(DOCKER_COMPOSE) build
@@ -11,7 +15,7 @@ build-dev:
 
 start-db:
 	$(DOCKER_COMPOSE) up -d db
-	./mysql/bin/wait_for_mysql
+	ENV=${ENV} ./mysql/bin/wait_for_mysql
 
 db-setup: start-db
 	$(DOCKER_COMPOSE) run --rm app ./bin/rails db:create db:schema:load db:seed

--- a/README.md
+++ b/README.md
@@ -26,6 +26,26 @@ This is the web frontend for managing Staff Device DNS / DHCP servers
 $ make serve
 ```
 
+### Running tests
+
+1. First setup your test database
+```sh
+ENV=test make db-setup
+```
+1. To run the entire test suite
+```sh
+make test
+```
+1. If you would like to run individual tests
+  1. First shell onto a test container
+  ```sh
+  ENV=test make shell
+  ```
+  1. Run the tests you would like, for example rspec.
+  ```sh
+  bundle exec rspec path/to/spec/file
+  ```
+
 ### Environment Variables
 
 The following environment variables must be added to .env to authenticate against AWS Cognito.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,9 +3,7 @@ version: "3.4"
 services:
   db:
     image: "mysql:5.7"
-    environment:
-      MYSQL_ROOT_PASSWORD: root
-      MYSQL_DATABASE: root
+    env_file: .env.${ENV}
     expose:
       - "3306"
 
@@ -25,6 +23,7 @@ services:
       - "3000"
     ports:
       - "3000:3000"
+    env_file: .env.${ENV}
 
 volumes:
   node_modules:

--- a/mysql/bin/wait_for_mysql
+++ b/mysql/bin/wait_for_mysql
@@ -3,7 +3,7 @@
 # The Jenkins runner doesn't support TTY sessions meaning docker-compose exec commands
 # failed to execute properly and would hang the CI
 # https://github.com/docker/compose/issues/5696
-until docker-compose exec -T db mysql -hdb -uroot -proot -e 'SELECT 1' &> /dev/null
+until docker-compose exec -T db /bin/bash -c 'mysql -h127.0.0.1 -uroot -p$MYSQL_ROOT_PASSWORD -e "SELECT 1"' &> /dev/null
 do
   printf "."
   sleep 1


### PR DESCRIPTION
# What
Use .env files per environment to configure environment specific information, specifically database names.

# Why
Previously databases on local machines would all try to use the same `DB_NAME` which would be the same between test and development. This caused local development databases to be wiped out by test runs.

# Notes
By default `make` commands running `docker-compose` will now run prepended with `ENV=development` apart from the test command which runs prepended with `ENV=test`. `make db-setup` will need to be run under all local environments to re create and migrate the database locally. So for example to recreate the new test database we can now run `ENV=test make db-setup`.
