### PR TITLE
Hardcode the subnet for testing

### DIFF
--- a/app/lib/use_cases/generate_kea_config.rb
+++ b/app/lib/use_cases/generate_kea_config.rb
@@ -38,11 +38,11 @@ module UseCases
             {
               "pools":[
                 {
-                  "pool":"0.0.0.0 - 255.255.255.255"
+                  "pool":"172.0.0.1 - 172.0.2.0"
                 }
               ],
-              "subnet":"0.0.0.0/0",
-              "id":1
+              "subnet":"127.0.0.1/0",
+              "id":1 # This is the subnet used for smoke testing
             }
           ],
           "loggers":[


### PR DESCRIPTION
# What
Create a test subnet for acceptance testing 

# Why
PerfDHCP will use this to do acceptance testing on boot of a container.
This pool and subnet range need to always be present for the tests to
function.

# Screenshots

# Notes
