### PR TITLE
Update GenerateKeyConfig use case to return a hash

### DIFF
--- a/app/lib/use_cases/generate_kea_config.rb
+++ b/app/lib/use_cases/generate_kea_config.rb
@@ -1,63 +1,61 @@
-# stub response until we can generate real configurations
-
 module UseCases
   class GenerateKeaConfig
     def execute
-      '{
-        "Dhcp4":{
-          "interfaces-config":{
-            "interfaces":[
+      {
+        Dhcp4: {
+          "interfaces-config": {
+            "interfaces": [
               "*",
               "dhcp-socket-type": "udp"
             ]
           },
-          "lease-database":{
-            "type":"mysql",
-            "name":"<DB_NAME>",
-            "user":"<DB_USER>",
-            "password":"<DB_PASS>",
-            "host":"<DB_HOST>",
-            "port":3306
+          "lease-database": {
+            type: "mysql",
+            name: "<DB_NAME>",
+            user: "<DB_USER>",
+            password: "<DB_PASS>",
+            host: "<DB_HOST>",
+            port: 3306
           },
-          "valid-lifetime":4000,
-          "host-reservation-identifiers":[
+          "valid-lifetime": 4000,
+          "host-reservation-identifiers": [
             "circuit-id",
             "hw-address",
             "duid",
             "client-id"
           ],
-          "hosts-database":{
-            "type":"mysql",
-            "name":"<DB_NAME>",
-            "user":"<DB_USER>",
-            "password":"<DB_PASS>",
-            "host":"<DB_HOST>",
-            "port":3306
+          "hosts-database": {
+            type: "mysql",
+            name: "<DB_NAME>",
+            user: "<DB_USER>",
+            password: "<DB_PASS>",
+            host: "<DB_HOST>",
+            port: 3306
           },
-          "subnet4":[
+          subnet4: [
             {
-              "pools":[
+              pools: [
                 {
-                  "pool":"172.0.0.1 - 172.0.2.0"
+                  pool: "172.0.0.1 - 172.0.2.0"
                 }
               ],
-              "subnet":"127.0.0.1/0",
-              "id":1 # This is the subnet used for smoke testing
+              subnet: "127.0.0.1/0",
+              id: 1 # This is the subnet used for smoke testing
             }
           ],
-          "loggers":[
+          loggers: [
             {
-              "name":"kea-dhcp4",
-              "output_options":[
+              name: "kea-dhcp4",
+              "output_options": [
                 {
-                  "output":"stdout"
+                  output: "stdout"
                 }
               ],
-              "severity":"DEBUG"
+              severity: "DEBUG"
             }
           ]
         }
-      }'
+      }
     end
   end
 end

--- a/app/lib/use_cases/publish_kea_config.rb
+++ b/app/lib/use_cases/publish_kea_config.rb
@@ -6,7 +6,7 @@ class UseCases::PublishKeaConfig
 
   def execute
     payload = generate_config.execute
-    destination_gateway.write(data: payload)
+    destination_gateway.write(data: payload.to_json)
   end
 
   private

--- a/spec/use_cases/generate_kea_config_spec.rb
+++ b/spec/use_cases/generate_kea_config_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+describe UseCases::GenerateKeaConfig do
+  describe "#execute" do
+    context "default config" do
+      it "returns a default subnet used for smoke testing" do
+        config = UseCases::GenerateKeaConfig.new.execute
+
+        expect(config[:Dhcp4]).to include(subnet4: [
+          {
+            pools: [
+              {
+                pool: "172.0.0.1 - 172.0.2.0"
+              }
+            ],
+            subnet: "127.0.0.1/0",
+            id: 1
+          }
+        ])
+      end
+    end
+  end
+end

--- a/spec/use_cases/publish_kea_config_spec.rb
+++ b/spec/use_cases/publish_kea_config_spec.rb
@@ -13,7 +13,7 @@ describe UseCases::PublishKeaConfig do
   end
   let(:s3_gateway) { instance_spy(Gateways::S3) }
   let(:config) do
-    '{ some: "json" }'
+    { some: "json" }
   end
 
   before do
@@ -22,6 +22,6 @@ describe UseCases::PublishKeaConfig do
 
   it "publishes the Kea config" do
     expect(s3_gateway).to have_received(:write)
-      .with(data: config)
+      .with(data: config.to_json)
   end
 end

--- a/spec/use_cases/publish_kea_config_spec.rb
+++ b/spec/use_cases/publish_kea_config_spec.rb
@@ -13,7 +13,7 @@ describe UseCases::PublishKeaConfig do
   end
   let(:s3_gateway) { instance_spy(Gateways::S3) }
   let(:config) do
-    { some: "json" }
+    {some: "json"}
   end
 
   before do


### PR DESCRIPTION
Returning a hash makes this use case easier to test. We can then call to_json
on that hash when we need to send the payload to s3

Co-authored-by: Efua Akumanyi <efua.akumanyi@gmail.com>
