### PR TITLE
Append subnets to kea config

### DIFF
--- a/app/lib/use_cases/generate_kea_config.rb
+++ b/app/lib/use_cases/generate_kea_config.rb
@@ -1,6 +1,32 @@
 module UseCases
   class GenerateKeaConfig
+    def initialize(subnets: [])
+      @subnets = subnets
+    end
+
     def execute
+      config = default_config
+
+      config[:Dhcp4][:subnet4] += @subnets.map { |subnet| subnet_config(subnet) }
+
+      config
+    end
+
+    private
+
+    def subnet_config(subnet)
+      {
+        pools: [
+          {
+            pool: "#{subnet.start_address} - #{subnet.end_address}"
+          }
+        ],
+        subnet: subnet.cidr_block,
+        id: subnet.id
+      }
+    end
+
+    def default_config
       {
         Dhcp4: {
           "interfaces-config": {

--- a/spec/use_cases/generate_kea_config_spec.rb
+++ b/spec/use_cases/generate_kea_config_spec.rb
@@ -54,5 +54,14 @@ describe UseCases::GenerateKeaConfig do
         }
       ])
     end
+
+    it "returns a kea config with the correct keys" do
+      config = UseCases::GenerateKeaConfig.new.execute
+      expect(config).to have_key :Dhcp4
+      expect(config[:Dhcp4].keys).to match_array([
+        :"host-reservation-identifiers", :"hosts-database", :"interfaces-config",
+        :"lease-database", :"valid-lifetime", :loggers, :subnet4
+      ])
+    end
   end
 end

--- a/spec/use_cases/generate_kea_config_spec.rb
+++ b/spec/use_cases/generate_kea_config_spec.rb
@@ -2,22 +2,57 @@ require "rails_helper"
 
 describe UseCases::GenerateKeaConfig do
   describe "#execute" do
-    context "default config" do
-      it "returns a default subnet used for smoke testing" do
-        config = UseCases::GenerateKeaConfig.new.execute
+    it "returns a default subnet used for smoke testing" do
+      config = UseCases::GenerateKeaConfig.new.execute
 
-        expect(config[:Dhcp4]).to include(subnet4: [
-          {
-            pools: [
-              {
-                pool: "172.0.0.1 - 172.0.2.0"
-              }
-            ],
-            subnet: "127.0.0.1/0",
-            id: 1
-          }
-        ])
-      end
+      expect(config.dig(:Dhcp4, :subnet4)).to match_array([
+        {
+          pools: [
+            {
+              pool: "172.0.0.1 - 172.0.2.0"
+            }
+          ],
+          subnet: "127.0.0.1/0",
+          id: 1
+        }
+      ])
+    end
+
+    it "appends subnets to the subnet4 list" do
+      subnet1 = build_stubbed(:subnet, cidr_block: "10.0.1.0/24", start_address: "10.0.1.1", end_address: "10.0.1.255")
+      subnet2 = build_stubbed(:subnet, cidr_block: "10.0.2.0/24", start_address: "10.0.2.1", end_address: "10.0.2.255")
+
+      config = UseCases::GenerateKeaConfig.new(subnets: [subnet1, subnet2]).execute
+
+      expect(config.dig(:Dhcp4, :subnet4)).to match_array([
+        {
+          pools: [
+            {
+              pool: "172.0.0.1 - 172.0.2.0"
+            }
+          ],
+          subnet: "127.0.0.1/0",
+          id: 1
+        },
+        {
+          pools: [
+            {
+              pool: "10.0.1.1 - 10.0.1.255"
+            }
+          ],
+          subnet: "10.0.1.0/24",
+          id: subnet1.id
+        },
+        {
+          pools: [
+            {
+              pool: "10.0.2.1 - 10.0.2.255"
+            }
+          ],
+          subnet: "10.0.2.0/24",
+          id: subnet2.id
+        }
+      ])
     end
   end
 end


### PR DESCRIPTION
# What
Updates the GenerateKeaConfig usecase to take an array of subnets and return a config reflecting the new subnets

# Why
So that we can generate kea configs using the Subnets stored in the database

# Screenshots

# Notes