### PR TITLE
Publish an updated KEA config when we create a new Subnet

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -61,5 +61,13 @@ Rails.application.configure do
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
 
   config.check_yarn_integrity = false
-  config.s3_aws_config = {region: "eu-west-2"}
+  config.s3_aws_config = {
+    region: "eu-west-2",
+    stub_responses: {
+      put_object: {},
+      get_object: {
+        body: '^[a-zA-Z0-9\.-]+@([a-zA-Z0-9-]+\.)*(gov\.uk)$'
+      }
+    }
+  }
 end


### PR DESCRIPTION
# What
When we create a new Subnet, this will publish an updated config using all of the Subnets in the database.

# Why
So that the config in S3 is kept up to date with the Subnets in the Admin database

# Screenshots

# Notes
