### PR TITLE
Publish kea config when a subnet is updated

### DIFF
--- a/app/controllers/subnets_controller.rb
+++ b/app/controllers/subnets_controller.rb
@@ -24,6 +24,7 @@ class SubnetsController < ApplicationController
 
   def update
     if @subnet.update(subnet_params)
+      publish_kea_config
       redirect_to subnets_path, notice: "Successfully updated subnet"
     else
       render :edit


### PR DESCRIPTION
# What
Publishes an updated KEA config when a Subnet is updated

# Why
So that the KEA config in S3 reflects the Subnets in the Admin database

# Screenshots

# Notes
