### PR TITLE
Navbar sign out using a delete method

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,14 +6,11 @@
     <%= csp_meta_tag %>
 
     <%= stylesheet_link_tag 'application', media: 'all' %>
-    <%= javascript_include_tag 'application' %>
   </head>
 
   <body class="govuk-template__body app-body-class">
 
-    <script>
-        document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
-    </script>
+    <script>document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');</script>
     <a href="#main-content" class="govuk-skip-link">Skip to main content</a>
 
     <header class="govuk-header" role="banner" data-module="govuk-header">
@@ -85,6 +82,6 @@
       </div>
     </div>
   </footer>
-    <%= javascript_include_tag "application.js" %>
+  <%= javascript_include_tag "application.js" %>
   </body>
 </html>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -42,6 +42,18 @@
             </span>
             <%- end %>
         </div>
+        <div class="govuk-header__content">
+          <button type="button" class="govuk-header__menu-button govuk-js-header-toggle" aria-controls="navigation" aria-label="Show or hide Top Level Navigation">Menu</button>
+          <nav>
+            <ul id="navigation" class="govuk-header__navigation " aria-label="Top Level Navigation" dir="RTL">
+              <% if user_signed_in? %>
+                <li class="govuk-header__navigation-item">
+                  <%= link_to "Sign out", destroy_user_session_path, method: :delete, class: "govuk-header__link" %>
+                </li>
+              <% end %>
+            </ul>
+          </nav>
+        </div>
       </div>
     </header>
     <div class="govuk-width-container">

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -268,7 +268,7 @@ Devise.setup do |config|
   # config.navigational_formats = ['*/*', :html]
 
   # The default HTTP method used to sign out a resource. Default is :delete.
-  config.sign_out_via = :get
+  config.sign_out_via = [:get, :delete]
 
   # ==> OmniAuth
   # Add a new OmniAuth provider. Check the wiki for more information on setting

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   devise_for :users, controllers: {omniauth_callbacks: "users/omniauth_callbacks"}
   devise_scope :user do
     get "sign_in", to: "devise/sessions#new", as: :new_user_session
-    get "sign_out", to: "devise/sessions#destroy", as: :destroy_user_session
+    match "sign_out", to: "devise/sessions#destroy", as: :destroy_user_session, via: [:get, :delete]
   end
 
   resources :subnets, only: [:index, :new, :create, :edit, :update]


### PR DESCRIPTION
# What
Adds a sign out link using delete method to the navbar

# Why
Since the sign out action is destroying the session, it makes more sense for
it to be a DELETE rather then a GET. 

Because 'link buttons' are [not supported](https://github.com/ministryofjustice/staff-device-dns-dhcp-admin/pull/30) in the govuk frontend framework, we are using a link_to with `method: :delete` which falls back to a GET request if javascript is disabled.

# Screenshots
<img width="1123" alt="ScreenShot 2020-08-27 at 18 24 44@2x" src="https://user-images.githubusercontent.com/7527178/91538087-299a9800-e90f-11ea-9369-643cecb4b39c.png">

# Notes