### PR TITLE
Offset the kea subnet ID to avoid collisions with the default smoke test subnet

### DIFF
--- a/app/lib/use_cases/generate_kea_config.rb
+++ b/app/lib/use_cases/generate_kea_config.rb
@@ -22,7 +22,7 @@ module UseCases
           }
         ],
         subnet: subnet.cidr_block,
-        id: subnet.id
+        id: subnet.kea_id
       }
     end
 

--- a/app/models/subnet.rb
+++ b/app/models/subnet.rb
@@ -1,4 +1,6 @@
 class Subnet < ApplicationRecord
+  KEA_SUBNET_ID_OFFSET = 1000
+
   validates :cidr_block, presence: true
   validates :start_address, presence: true
   validates :end_address, presence: true
@@ -8,6 +10,10 @@ class Subnet < ApplicationRecord
 
   def ip_addr
     IPAddr.new(cidr_block)
+  end
+
+  def kea_id
+    id + KEA_SUBNET_ID_OFFSET
   end
 
   private

--- a/spec/use_cases/generate_kea_config_spec.rb
+++ b/spec/use_cases/generate_kea_config_spec.rb
@@ -64,7 +64,7 @@ describe UseCases::GenerateKeaConfig do
       ])
     end
 
-    it "offsets the id for subnets to avoid collision with the default subnet" do
+    it "offsets the id to avoid collision with the reserved smoke testing subnet" do
       subnet1 = build_stubbed(:subnet, id: 1, cidr_block: "10.0.1.0/24")
       subnet2 = build_stubbed(:subnet, id: 2, cidr_block: "10.0.2.0/24")
 

--- a/spec/use_cases/generate_kea_config_spec.rb
+++ b/spec/use_cases/generate_kea_config_spec.rb
@@ -41,7 +41,7 @@ describe UseCases::GenerateKeaConfig do
             }
           ],
           subnet: "10.0.1.0/24",
-          id: subnet1.id
+          id: subnet1.kea_id
         },
         {
           pools: [
@@ -50,7 +50,7 @@ describe UseCases::GenerateKeaConfig do
             }
           ],
           subnet: "10.0.2.0/24",
-          id: subnet2.id
+          id: subnet2.kea_id
         }
       ])
     end
@@ -61,6 +61,19 @@ describe UseCases::GenerateKeaConfig do
       expect(config[:Dhcp4].keys).to match_array([
         :"host-reservation-identifiers", :"hosts-database", :"interfaces-config",
         :"lease-database", :"valid-lifetime", :loggers, :subnet4
+      ])
+    end
+
+    it "offsets the id for subnets to avoid collision with the default subnet" do
+      subnet1 = build_stubbed(:subnet, id: 1, cidr_block: "10.0.1.0/24")
+      subnet2 = build_stubbed(:subnet, id: 2, cidr_block: "10.0.2.0/24")
+
+      config = UseCases::GenerateKeaConfig.new(subnets: [subnet1, subnet2]).execute
+
+      expect(config.dig(:Dhcp4, :subnet4)).to match_array([
+        hash_including(subnet: "127.0.0.1/0", id: 1),
+        hash_including(subnet: "10.0.1.0/24", id: 1001),
+        hash_including(subnet: "10.0.2.0/24", id: 1002)
       ])
     end
   end


### PR DESCRIPTION
# What
Offsets the kea subnet identifier by 1000 to avoid any collisions and also give us a buffer in case we want to add any more fixed subnets in the future

# Why
Previously we were using the database id as the kea subnet4 identifier. This caused a collision with the hardcoded smoke test subnet (id: 1).

# Screenshots
N/A

# Notes
Note: The offset must never be changed. Changing the identifier after it has been set will result in leases stored in the leases database to point to a different subnet

See kea subnet identifier docs for more info
https://kea.readthedocs.io/en/kea-1.6.2/arm/dhcp4-srv.html#ipv4-subnet-identifier