### PR TITLE
Validate Zone forwarders

### DIFF
--- a/app/models/zone.rb
+++ b/app/models/zone.rb
@@ -1,4 +1,18 @@
 class Zone < ApplicationRecord
-  validates :name, presence: true, uniqueness: { case_sensitive: false }
+  validates :name, presence: true, uniqueness: {case_sensitive: false}
   validates :forwarders, presence: true
+
+  validate :forwarders_is_a_valid_bind_dns_forwarder
+
+  def forwarders_is_a_valid_bind_dns_forwarder
+    return if forwarders.blank?
+
+    unless forwarders.end_with?(";")
+      errors.add(:forwarders, "must end with a semi-colon")
+    end
+
+    if forwarders.split(";").any? { |ip_address| !IPAddress.valid_ipv4?(ip_address) }
+      errors.add(:forwarders, "contains an invalid IPv4 address")
+    end
+  end
 end

--- a/spec/models/zone_spec.rb
+++ b/spec/models/zone_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe Zone, type: :model do
   subject { build :zone }
@@ -6,4 +6,23 @@ RSpec.describe Zone, type: :model do
   it { is_expected.to validate_uniqueness_of(:name).case_insensitive }
   it { is_expected.to validate_presence_of :name }
   it { is_expected.to validate_presence_of :forwarders }
+
+  context "forwarders validation" do
+    it "must be a valid IPv4 address" do
+      zone = build :zone, forwarders: "poorly_entered_data;"
+      expect(zone).to_not be_valid
+      expect(zone.errors[:forwarders]).to eq(["contains an invalid IPv4 address"])
+    end
+
+    it "must end with a semi-colon" do
+      zone = build :zone, forwarders: "127.0.0.1"
+      expect(zone).to_not be_valid
+      expect(zone.errors[:forwarders]).to eq(["must end with a semi-colon"])
+    end
+
+    it "must be a valid BIND DNS forwarder string" do
+      zone = build :zone, forwarders: "127.0.0.1;127.0.0.2;"
+      expect(zone).to be_valid
+    end
+  end
 end


### PR DESCRIPTION
# What
Validates that the forwarders column on the Zone model is a valid BIND DNS forwarder string

# Why
So that we use it to generate a BIND DNS named.conf file in the future

# Screenshots

# Notes
Example conf with forwarders set: https://help.ubuntu.com/community/BIND9ServerHowto#Caching_Server_configuration