### PR TITLE
Specify explicit ECS AWS SDK configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ ENV LANG='C.UTF-8' \
   DB_PASS=${DB_PASS} \
   SECRET_KEY_BASE=${SECRET_KEY_BASE} \
   KEA_CONFIG_BUCKET='testbucket' \
+  AWS_DEFAULT_REGION='eu-west-2' \
   DB_NAME=${DB_NAME}
 
 WORKDIR /usr/src/app

--- a/app/controllers/subnets_controller.rb
+++ b/app/controllers/subnets_controller.rb
@@ -81,7 +81,7 @@ class SubnetsController < ApplicationController
       ecs_gateway: Gateways::Ecs.new(
         cluster_name: ENV.fetch("DHCP_CLUSTER_NAME"),
         service_name: ENV.fetch("DHCP_SERVICE_NAME"),
-        aws_config: Rails.application.config.s3_aws_config
+        aws_config: Rails.application.config.ecs_aws_config
       )
     ).execute
   end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -62,7 +62,10 @@ Rails.application.configure do
 
   config.check_yarn_integrity = false
   config.s3_aws_config = {
-    region: "eu-west-2",
+    stub_responses: true
+  }
+
+  config.ecs_aws_config = {
     stub_responses: true
   }
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -81,7 +81,7 @@ Rails.application.configure do
   # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new 'app-name')
 
   if ENV["RAILS_LOG_TO_STDOUT"].present?
-    logger = ActiveSupport::Logger.new(STDOUT)
+    logger = ActiveSupport::Logger.new($stdout)
     logger.formatter = config.log_formatter
     config.logger = ActiveSupport::TaggedLogging.new(logger)
   end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -88,7 +88,8 @@ Rails.application.configure do
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
-  config.s3_aws_config = {region: "eu-west-2"}
+  config.s3_aws_config = {}
+  config.ecs_aws_config = {}
 
   # Inserts middleware to perform automatic connection switching.
   # The `database_selector` hash is used to pass options to the DatabaseSelector

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -43,7 +43,8 @@ Rails.application.configure do
 
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr
-  config.s3_aws_config = {stub_responses: true, region: "eu-west-2"}
+  config.s3_aws_config = {stub_responses: true}
+  config.ecs_aws_config = {stub_responses: true}
 
   # Raises error for missing translations.
   # config.action_view.raise_on_missing_translations = true

--- a/spec/gateways/s3_spec.rb
+++ b/spec/gateways/s3_spec.rb
@@ -6,7 +6,6 @@ describe Gateways::S3 do
   let(:data) { {blah: "foobar"}.to_json }
   let(:aws_config) do
     {
-      region: "eu-west-2",
       stub_responses: {
         get_object: ->(context) {
           if context.params.fetch(:bucket) == bucket && context.params.fetch(:key) == key


### PR DESCRIPTION
# What

Development and test environments stub out AWS to not make actual network calls.
Currently only an S3 configuration exists, create one for ECS as well.

Also remove duplication of the region configuration for the SDK by moving it to the Dockerfile

# Why

ECS depends on a different configuration to stub out api calls specific to the service.
