### PR TITLE
Validate uniqueness of Subnet#cidr_block

### DIFF
--- a/app/models/subnet.rb
+++ b/app/models/subnet.rb
@@ -47,7 +47,9 @@ class Subnet < ApplicationRecord
     return unless IPAddress.valid_ipv4_subnet?(cidr_block)
 
     subnet_address = IPAddress::IPv4.new(cidr_block).address
-    if Subnet.where.not(id: id).where("cidr_block LIKE ?", "#{subnet_address}/%").exists?
+    if Subnet.where.not(id: id)
+        .where.not(cidr_block: cidr_block)
+        .where("cidr_block LIKE ?", "#{subnet_address}/%").exists?
       errors.add(:cidr_block, "matches a subnet with the same address")
     end
   end

--- a/app/models/subnet.rb
+++ b/app/models/subnet.rb
@@ -1,12 +1,12 @@
 class Subnet < ApplicationRecord
   KEA_SUBNET_ID_OFFSET = 1000
 
-  validates :cidr_block, presence: true
+  validates :cidr_block, presence: true, uniqueness: {case_sensitive: false}
   validates :start_address, presence: true
   validates :end_address, presence: true
 
   validate :cidr_block_is_a_valid_ipv4_subnet, :start_address_is_a_valid_ipv4_address,
-    :end_address_is_a_valid_ipv4_address
+    :end_address_is_a_valid_ipv4_address, :cidr_block_address_is_unique
 
   def ip_addr
     IPAddr.new(cidr_block)
@@ -39,6 +39,16 @@ class Subnet < ApplicationRecord
 
     unless IPAddress.valid_ipv4?(end_address)
       errors.add(:end_address, "is not a valid IPv4 address")
+    end
+  end
+
+  def cidr_block_address_is_unique
+    return if cidr_block.blank?
+    return unless IPAddress.valid_ipv4_subnet?(cidr_block)
+
+    subnet_address = IPAddress::IPv4.new(cidr_block).address
+    if Subnet.where.not(id: id).where("cidr_block LIKE ?", "#{subnet_address}/%").exists?
+      errors.add(:cidr_block, "matches a subnet with the same address")
     end
   end
 end

--- a/spec/models/subnet_spec.rb
+++ b/spec/models/subnet_spec.rb
@@ -1,7 +1,10 @@
 require "rails_helper"
 
 RSpec.describe Subnet, type: :model do
+  subject { build :subnet }
+
   it { is_expected.to validate_presence_of :cidr_block }
+  it { is_expected.to validate_uniqueness_of(:cidr_block).case_insensitive }
   it { is_expected.to validate_presence_of :start_address }
   it { is_expected.to validate_presence_of :end_address }
 
@@ -36,5 +39,13 @@ RSpec.describe Subnet, type: :model do
     subnet = build :subnet, end_address: "10.0.4"
     expect(subnet).not_to be_valid
     expect(subnet.errors[:end_address]).to eq(["is not a valid IPv4 address"])
+  end
+
+  it "validates cidr_block is unique by the address" do
+    create :subnet, cidr_block: "10.0.4.0/24"
+    subnet = build :subnet, cidr_block: "10.0.4.0/20"
+
+    expect(subnet).not_to be_valid
+    expect(subnet.errors[:cidr_block]).to eq(["matches a subnet with the same address"])
   end
 end

--- a/spec/models/subnet_spec.rb
+++ b/spec/models/subnet_spec.rb
@@ -48,4 +48,12 @@ RSpec.describe Subnet, type: :model do
     expect(subnet).not_to be_valid
     expect(subnet.errors[:cidr_block]).to eq(["matches a subnet with the same address"])
   end
+
+  it "does not append the subnet address validation when the cidr_block matches exactly" do
+    create :subnet, cidr_block: "10.0.4.0/24"
+    subnet = build :subnet, cidr_block: "10.0.4.0/24"
+
+    expect(subnet).not_to be_valid
+    expect(subnet.errors[:cidr_block]).to_not include "matches a subnet with the same address"
+  end
 end


### PR DESCRIPTION
# What
Adds a simple uniqueness validator as well as a validation on the address of cidr_block (i.e. 10.0.4.0/24 and 10.0.4.0/23 are considered equivalent)

# Why
To prevent the user from entering duplicate subnets and causing issues with the KEA configuration

# Screenshots

# Notes
This change doesn't include a unique constraint migration as we currently have duplicates in our database that need to be cleared out first to prevent the migration from failing.
