### PR TITLE
Add a omniauth developer mode login for local development

### DIFF
--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -1,6 +1,13 @@
 class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
+  skip_before_action :verify_authenticity_token, only: :developer
+
   def cognito
     @user = User.from_omniauth(request.env["omniauth.auth"])
+    sign_in_and_redirect @user
+  end
+
+  def developer
+    @user = User.where(provider: "developer").first_or_create
     sign_in_and_redirect @user
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,7 +1,5 @@
 class User < ApplicationRecord
-  # Include default devise modules. Others available are:
-  # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
-  devise :omniauthable, omniauth_providers: %i[cognito]
+  devise :omniauthable, omniauth_providers: Rails.env.development? ? %i[cognito developer] : %i[cognito]
 
   def self.from_omniauth(auth)
     where(provider: auth.provider, uid: auth.uid).first_or_create

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,3 +1,7 @@
 <h1 class="govuk-heading-xl">Log in</h1>
 
 <%= button_to "Sign in with Azure", user_cognito_omniauth_authorize_path, { class: 'govuk-button', "data-module" => "govuk-button" } %>
+
+<% if Rails.env.development? %>
+  <%= button_to "Sign in as a developer", user_developer_omniauth_authorize_path, { class: 'govuk-button', "data-module" => "govuk-button" } %>
+<% end %>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -276,6 +276,7 @@ Devise.setup do |config|
   config.omniauth :cognito, ENV["COGNITO_CLIENT_ID"], ENV["COGNITO_CLIENT_SECRET"], client_options: {site: ENV["COGNITO_USER_POOL_SITE"]}, scope: "email openid aws.cognito.signin.user.admin profile",
                                                                                     user_pool_id: ENV["COGNITO_USER_POOL_ID"],
                                                                                     aws_region: "eu-west-2", strategy_class: OmniAuth::Strategies::Cognito
+  config.omniauth :developer
 
   # ==> Warden configuration
   # If you want to use other strategies, that are not supported by Devise, or


### PR DESCRIPTION
# What
Add a omniauth developer strategy to help login in development

# Why
So that developers can login without using Azure / Cognito

# Screenshots

# Notes
