### PR TITLE
Set the User as an editor if they have the editor app role

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,9 +1,11 @@
 class User < ApplicationRecord
+  EDITOR_ROLE = "editor"
+
   devise :omniauthable, omniauth_providers: Rails.env.development? ? %i[cognito developer] : %i[cognito]
 
   def self.from_omniauth(auth)
     user = find_or_initialize_by(provider: auth.provider, uid: auth.uid)
-    user.editor = true # Temporarily set all to editor until we pull roles from cognito
+    user.editor = auth.extra.raw_info["custom:app_role"] == EDITOR_ROLE
     user.save
     user
   end

--- a/spec/acceptance/sign_in_spec.rb
+++ b/spec/acceptance/sign_in_spec.rb
@@ -9,7 +9,9 @@ RSpec.describe "GET /sign_in", type: :feature do
   context "user signed in" do
     before do
       # Simulate logging in via Cognito Omniauth provider
-      OmniAuth.config.add_mock(:cognito, {provider: "cognito", uid: "12345"})
+      OmniAuth.config.add_mock(:cognito, {
+        provider: "cognito", uid: "12345", extra: {raw_info: {"custom:app_role": "editor"}}
+      })
 
       Rails.application.env_config["devise.mapping"] = Devise.mappings[:user]
       Rails.application.env_config["omniauth.auth"] = OmniAuth.config.mock_auth[:cognito]
@@ -18,7 +20,7 @@ RSpec.describe "GET /sign_in", type: :feature do
       click_button("Sign in with Azure")
     end
 
-    it "displays redirects to the root path if the user signs in" do
+    it "redirects to the root path" do
       expect(current_path).to eq "/"
       expect(page).to have_content "DHCP / DNS Admin portal"
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,28 @@
+require "rails_helper"
+
+describe User, type: :model do
+  describe ".from_omniauth" do
+    subject(:user) { User.from_omniauth(auth_hash) }
+    let(:auth_hash) do
+      # Mocking OmniAuth::AuthHash
+      double(provider: "cognito", uid: "1",
+             extra: double(raw_info: {"custom:app_role" => role}))
+    end
+
+    context "editor app role" do
+      let(:role) { "editor" }
+
+      it "sets editor to true" do
+        expect(user.editor?).to eq true
+      end
+    end
+
+    context "viewer app role" do
+      let(:role) { "viewer" }
+
+      it "sets editor to false" do
+        expect(user.editor?).to eq false
+      end
+    end
+  end
+end


### PR DESCRIPTION
# What

Sets the editor flag on User based on the app_role returned by cognito. The app role is stored in the raw_info hash of the omniauth auth hash. The schema can be found here: https://github.com/omniauth/omniauth/wiki/Auth-Hash-Schema

The app_role is set in the infrastructure repo
https://github.com/ministryofjustice/staff-device-dns-dhcp-infrastructure/blob/da39db9c36f41fa78529f88239ad5dc5ef6d5286/modules/authentication/main.tf#L47-L50

# Why

So that Users have the correct, up to date permissions.

# Screenshots

# Notes
