### PR TITLE
Explicit outbound interface

### DIFF
--- a/app/lib/use_cases/generate_kea_config.rb
+++ b/app/lib/use_cases/generate_kea_config.rb
@@ -31,7 +31,8 @@ module UseCases
         Dhcp4: {
           "interfaces-config": {
             "interfaces": ["*"],
-            "dhcp-socket-type": "udp"
+            "dhcp-socket-type": "udp",
+            "outbound-interface": "use-routing"
           },
           "lease-database": {
             type: "mysql",


### PR DESCRIPTION
# What

Add this configuration according to this documentation:

https://kea.readthedocs.io/en/latest/arm/dhcp4-srv.html

# Why

Since upgrading KEA to run on Alpine, the outbound interface isn't
specified.

This led to an error message:
"failed to send DHCPv4 packet: Interface lo/1 does not have any suitable IPv4 sockets open."