### PR TITLE
Connect to database using SSL in production

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,8 @@ ENV LANG='C.UTF-8' \
 
 WORKDIR /usr/src/app
 
+ADD https://s3.amazonaws.com/rds-downloads/rds-combined-ca-bundle.pem /usr/src/cert/
+
 RUN apk add --no-cache --virtual .build-deps build-base && \
   apk add --no-cache nodejs yarn mysql-dev bash make
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,6 @@ COGNITO_USER_POOL_ID
 
 ### AWS RDS SSL certificate
 
-The AWS RDS SSL certificate is due to expire August 22, 2024. See [the documentation](https://docs.aws.amazon.com/documentdb/latest/developerguide/ca_cert_rotation.html) for information on update the certificate closer to the date.
+The AWS RDS SSL certificate is due to expire August 22, 2024. See [the documentation](https://docs.aws.amazon.com/documentdb/latest/developerguide/ca_cert_rotation.html) for information on updating the certificate closer to the date.
 
 To update the certificate, update the Dockerfile to use the new intermediate (region specific) certificate (found [here](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.SSL.html)), and update the `config/database.yml` to point to the new certificate file path.

--- a/README.md
+++ b/README.md
@@ -56,3 +56,11 @@ COGNITO_CLIENT_SECRET
 COGNITO_USER_POOL_SITE
 COGNITO_USER_POOL_ID
 ```
+
+## Maintenance
+
+### AWS RDS SSL certificate
+
+The AWS RDS SSL certificate is due to expire August 22, 2024. See [the documentation](https://docs.aws.amazon.com/documentdb/latest/developerguide/ca_cert_rotation.html) for information on update the certificate closer to the date.
+
+To update the certificate, update the Dockerfile to use the new intermediate (region specific) certificate (found [here](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.SSL.html)), and update the `config/database.yml` to point to the new certificate file path.

--- a/config/database.yml
+++ b/config/database.yml
@@ -15,3 +15,5 @@ test:
 
 production:
   <<: *default
+  ssl_mode: :verify_identity
+  sslca: <%= Rails.root.join("../cert/rds-combined-ca-bundle.pem") %>


### PR DESCRIPTION
# What
Connects to the production database using SSL

# Why
To ensure traffic is encrypted in transit between the app and the database

# Screenshots

# Notes
The cert is added to a different directory to the WORKDIR. This prevents the
cert from being deleted when the WORKDIR gets mounted by docker-compose

Cert docs : https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.SSL.html

Mysql specific docs : https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_MySQL.html#MySQL.Concepts.SSLSupport