### PR TITLE
Enforce SSL DB connection in production

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ WORKDIR /usr/src/app
 ADD https://s3.amazonaws.com/rds-downloads/rds-combined-ca-bundle.pem /usr/src/cert/
 
 RUN apk add --no-cache --virtual .build-deps build-base && \
-  apk add --no-cache nodejs yarn mysql-dev bash make
+  apk add --no-cache nodejs yarn mysql-dev mysql-client bash make
 
 COPY Gemfile Gemfile.lock .ruby-version ./
 RUN bundle config set no-cache 'true' && \
@@ -42,6 +42,10 @@ COPY . .
 ARG RUN_PRECOMPILATION=true
 RUN if [ ${RUN_PRECOMPILATION} = 'true' ]; then \
   ASSET_PRECOMPILATION_ONLY=true RAILS_ENV=production bundle exec rails assets:precompile; \
+  fi
+
+RUN if [ ${RACK_ENV} = 'production' ]; then \
+  ./scripts/bootstrap.sh; \
   fi
 
 EXPOSE 3000

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -v -e -u -o pipefail
+
+mysql -u ${DB_USER} -p${DB_PASS} -n ${DB_NAME} -h ${DB_HOST} -e "ALTER USER '${DB_USER}'@'%' REQUIRE SSL;"


### PR DESCRIPTION
# What
Enforces an SSL connection to the database

# Why
To ensure that we are always encrypted database traffic in transit.

# Screenshots

# Notes
Our security groups prevent the shared-services account from accessing the database which prevents us from using terraform to set "REQUIRE SSL;"
