### PR TITLE
CI deploys the Admin Portal

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,10 @@ stop:
 migrate:
 	./scripts/migrate.sh
 
-deploy: build
+deploy:
+	./scripts/deploy
+
+publish:
 	echo ${REGISTRY_URL}
 	aws ecr get-login-password | docker login --username AWS --password-stdin ${REGISTRY_URL}
 	docker tag docker_admin:latest ${REGISTRY_URL}/${ENV}-admin:latest
@@ -45,4 +48,4 @@ deploy: build
 lint:
 	$(DOCKER_COMPOSE) run --rm app bundle exec standardrb --fix
 
-.PHONY: build serve stop test deploy migrate build-dev
+.PHONY: build serve stop test deploy migrate build-dev publish

--- a/README.md
+++ b/README.md
@@ -57,6 +57,53 @@ COGNITO_USER_POOL_SITE
 COGNITO_USER_POOL_ID
 ```
 
+## Scripts
+
+We have two utility scripts in the `./scripts` directory to:
+
+1. Migrate the database schema
+2. Deploy new tasks into the service
+
+### Deployment
+
+The `deploy` command is wrapped in a Makefile, it calls `./scripts/deploy` which schedules a zero downtime phased [deployment](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/update-service.html) in ECS.
+
+It doubles the currently running tasks and briefly serves traffic from the new and existing tasks in the service.
+The older tasks are eventually decommissioned, and production traffic is gradually shifted over to only the new running tasks.
+
+On CI this command is executed from the [buildspec.yml](./buildspec.yml) file after migrations and publishing the new image to ECR has been completed.
+
+#### Targetting the ECS cluster and service to deploy
+
+The ECS infrastructure is managed by Terraform. The name of the cluster and service are outputs from the apply and set as environment variables on CI ($DHCP_DNS_TERRAFORM_OUTPUTS). The deploy script references these dynamic names to target the ECS Admin service and cluster. This is to avoid depending on the names of the services and clusters, which may change in the future.
+
+The build pipeline assumes a role to access the target AWS account.
+
+#### Deploying from local machine
+
+1. Export the following configurations as an environment variable.
+
+```bash
+  export DHCP_DNS_TERRAFORM_OUTPUTS='{
+    "admin": {
+      "ecs": {
+        "cluster_name": "[TARGET_CLUSTER_NAME]",
+        "service_name": "[TARGET_SERVICE_NAME]"
+      }
+    }
+  }'
+```
+
+This mimics what happens on CI where this environment variable is already set.
+
+When run locally, you need to target the AWS account directly with AWS Vault.
+
+2. Schedule the deployment
+
+```bash
+  aws-vault exec [target_aws_account_profile] -- make deploy
+```
+
 ## Maintenance
 
 ### AWS RDS SSL certificate

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -23,9 +23,10 @@ phases:
 
   build:
     commands:
-      - make deploy
+      - make publish
       - TEMP_ROLE=`aws sts assume-role --role-arn $ROLE_ARN --role-session-name test-$BUILD_ID`
       - export AWS_ACCESS_KEY_ID=$(echo "${TEMP_ROLE}" | jq -r '.Credentials.AccessKeyId')
       - export AWS_SECRET_ACCESS_KEY=$(echo "${TEMP_ROLE}" | jq -r '.Credentials.SecretAccessKey')
       - export AWS_SESSION_TOKEN=$(echo "${TEMP_ROLE}" | jq -r '.Credentials.SessionToken')
       - make migrate
+      - make deploy

--- a/scripts/aws-helpers.sh
+++ b/scripts/aws-helpers.sh
@@ -65,13 +65,3 @@ function override_command_structure() {
   }
 EOF
 }
-
-function ecs_deploy() {
-  local cluster_name="${1}"
-  local service_name="${2}"
-
-  aws ecs update-service \
-        --cluster "${cluster_name}" \
-        --service "${service_name}" \
-        --force-new-deployment
-}

--- a/scripts/deploy
+++ b/scripts/deploy
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -e
+
+cluster_name=$( jq -r '.admin.ecs.cluster_name' <<< "${DHCP_DNS_TERRAFORM_OUTPUTS}" )
+service_name=$( jq -r '.admin.ecs.service_name' <<< "${DHCP_DNS_TERRAFORM_OUTPUTS}" )
+
+aws ecs update-service \
+  --cluster $cluster_name \
+  --service $service_name \
+  --force-new-deployment


### PR DESCRIPTION
# What

This will automatically deploy the admin portal through CI.
Remove duplicated deployment logic and document in README.

# Why

We want changes pushed through the pipeline to be immediately deployed without having to manually restart the tasks in ECS.

