### PR TITLE
Change all existing tables to utf8 and ensure new ones are created with utf8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ stop:
 migrate:
 	./scripts/migrate.sh
 
-migrate-dev:
+migrate-dev: start-db
 	$(DOCKER_COMPOSE) run --rm app bundle exec rake db:migrate
 
 deploy:

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,6 +1,7 @@
 default: &default
   adapter: mysql2
-  encoding: utf8
+  encoding: utf8mb4
+  collation: utf8mb4_unicode_ci
   host: <%= ENV.fetch('DB_HOST') %>
   port: 3306
   username: <%= ENV.fetch('DB_USER') %>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,14 +11,14 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema.define(version: 2020_10_01_110011) do
-  create_table "sites", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "sites", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "fits_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end
 
-  create_table "subnets", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "subnets", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "cidr_block", null: false
     t.string "start_address", null: false
     t.string "end_address", null: false
@@ -28,7 +28,7 @@ ActiveRecord::Schema.define(version: 2020_10_01_110011) do
     t.index ["site_id"], name: "index_subnets_on_site_id"
   end
 
-  create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
+  create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "provider"
@@ -36,7 +36,7 @@ ActiveRecord::Schema.define(version: 2020_10_01_110011) do
     t.boolean "editor", default: false
   end
 
-  create_table "zones", options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
+  create_table "zones", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "forwarders", null: false
     t.string "purpose"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@ version: "3.4"
 services:
   db:
     image: "mysql:5.7"
+    command: ['mysqld', '--character-set-server=utf8mb4', '--collation-server=utf8mb4_unicode_ci']
     env_file: .env.${ENV}
     expose:
       - "3306"

--- a/scripts/migrate.sh
+++ b/scripts/migrate.sh
@@ -5,7 +5,7 @@ set -v -e -u -o pipefail
 source ./scripts/aws-helpers.sh
 
 function migrate() {
-  local migration_command="./bin/rails db:migrate"
+  local migration_command="./bin/rails db:migrate:reset"
   local docker_service_name="admin"
   local cluster_name service_name task_definition docker_service_name
 


### PR DESCRIPTION
# What
Updates the tables in the schema to use the correct encoding. Also sets the correct character set in local dev so that new tables are created with utf8mb4

# Why
So that tables are not created with the mysql default (latin1)

# Screenshots

# Notes
