### PR TITLE
Reword creation and deletion of subnet options

### DIFF
--- a/app/views/options/_form.html.erb
+++ b/app/views/options/_form.html.erb
@@ -26,7 +26,7 @@
     <%= f.text_field :domain_name, class: "govuk-input" %>
   </div>
 
-  <%= f.submit f.object.new_record? ? "Create" : "Update", {
+  <%= f.submit f.object.new_record? ? "Override" : "Update", {
     class: "govuk-button",
     "data-module" => "govuk-button"
   } %>

--- a/app/views/options/destroy.html.erb
+++ b/app/views/options/destroy.html.erb
@@ -1,8 +1,8 @@
-<h2 class="govuk-heading-l">Are you sure you want to delete these options?</h2>
+<h2 class="govuk-heading-l">Are you sure you want reset these options back to the global?</h2>
 
-<p class="govuk-body">Deleting options cannot be undone</p>
+<p class="govuk-body">Resetting options cannot be undone</p>
 
-<%= button_to "Delete options", subnet_options_path(@option.subnet),
+<%= button_to "Reset options", subnet_options_path(@option.subnet),
   method: :delete,
   class: "govuk-button govuk-button--warning govuk-!-margin-right-1",
   data: {

--- a/app/views/options/new.html.erb
+++ b/app/views/options/new.html.erb
@@ -1,5 +1,5 @@
 <%= render "layouts/form_errors", resource: @option %>
 
-<h2 class="govuk-heading-l">Creating a options</h2>
+<h2 class="govuk-heading-l">Overriding global options</h2>
 
 <%= render "form", option: @option %>

--- a/app/views/subnets/show.html.erb
+++ b/app/views/subnets/show.html.erb
@@ -4,10 +4,10 @@
   <% end %>
 
   <% if can?(:destroy, @subnet.option) %>
-    <%= link_to "Delete options", subnet_options_path(@subnet), class:"govuk-link", method: :delete %>
+    <%= link_to "Reset to global options", subnet_options_path(@subnet), class:"govuk-link", method: :delete %>
   <% end %>
 
   <%= render "options/details", option: @subnet.option %>
 <% else %>
-  <%= link_to "Create options", new_subnet_options_path(@subnet) if can?(:create, Option) %>
+  <%= link_to "Override global options", new_subnet_options_path(@subnet) if can?(:create, Option) %>
 <% end %>


### PR DESCRIPTION
# What
Instead of using create and delete, use "override global" and "reset to global"
so its clear to the user what is happening.

# Why
Our language about creating and deleting options for a subnet seem odd from a UX perspective

# Notes
I realize this language has the potential to be controversial so i pulled it into its own PR. I think its worth a discussion as to wether we think this wording is better.
