### PR TITLE
Fix autoreloading of files in development docker conatiner

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -58,7 +58,7 @@ Rails.application.configure do
 
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
-  config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+  config.file_watcher = ActiveSupport::FileUpdateChecker
 
   config.check_yarn_integrity = false
   config.s3_aws_config = {


### PR DESCRIPTION
Autoreloading using the EventedFileUpdateChecker does not work in a
containerized docker environment. Instead use the FileUpdateChecker.
