### PR TITLE
Allow nulls for subnet options

### DIFF
--- a/app/lib/use_cases/generate_kea_config.rb
+++ b/app/lib/use_cases/generate_kea_config.rb
@@ -37,20 +37,26 @@ module UseCases
         "option-data": []
       }
 
-      result[:"option-data"] << {
-        "name": "domain-name-servers",
-        "data": option.domain_name_servers.join(", ")
-      } if option.domain_name_servers.any?
+      if option.domain_name_servers.any?
+        result[:"option-data"] << {
+          "name": "domain-name-servers",
+          "data": option.domain_name_servers.join(", ")
+        }
+      end
 
-      result[:"option-data"] << {
-        "name": "routers",
-        "data": option.routers.join(", ")
-      } if option.routers.any?
+      if option.routers.any?
+        result[:"option-data"] << {
+          "name": "routers",
+          "data": option.routers.join(", ")
+        }
+      end
 
-      result[:"option-data"] << {
-        "name": "domain-name",
-        "data": option.domain_name
-      } if option.domain_name.present?
+      if option.domain_name.present?
+        result[:"option-data"] << {
+          "name": "domain-name",
+          "data": option.domain_name
+        }
+      end
 
       result
     end

--- a/app/lib/use_cases/generate_kea_config.rb
+++ b/app/lib/use_cases/generate_kea_config.rb
@@ -27,27 +27,32 @@ module UseCases
           "site-id": subnet.site.fits_id,
           "site-name": subnet.site.name
         }
-      }.merge(options_config(subnet))
+      }.merge(options_config(subnet.option))
     end
 
-    def options_config(subnet)
-      return {} unless subnet.option.present?
-      {
-        "option-data": [
-          {
-            "name": "domain-name-servers",
-            "data": subnet.option.domain_name_servers.join(", ")
-          },
-          {
-            "name": "routers",
-            "data": subnet.option.routers.join(", ")
-          },
-          {
-            "name": "domain-name",
-            "data": subnet.option.domain_name
-          }
-        ]
+    def options_config(option)
+      return {} unless option.present?
+
+      result = {
+        "option-data": []
       }
+
+      result[:"option-data"] << {
+        "name": "domain-name-servers",
+        "data": option.domain_name_servers.join(", ")
+      } if option.domain_name_servers.any?
+
+      result[:"option-data"] << {
+        "name": "routers",
+        "data": option.routers.join(", ")
+      } if option.routers.any?
+
+      result[:"option-data"] << {
+        "name": "domain-name",
+        "data": option.domain_name
+      } if option.domain_name.present?
+
+      result
     end
 
     def default_config

--- a/app/models/option.rb
+++ b/app/models/option.rb
@@ -1,13 +1,11 @@
 class Option < ApplicationRecord
   belongs_to :subnet
 
-  validates :routers,
-    presence: {message: "must contain at least one IPv4 address separated using commas"},
-    ipv4_list: {message: "contains an invalid IPv4 address or is not separated using commas"}
-  validates :domain_name_servers,
-    presence: {message: "must contain at least one IPv4 address separated using commas"},
-    ipv4_list: {message: "contains an invalid IPv4 address or is not separated using commas"}
-  validates :domain_name, presence: true
+  INVALID_IPV4_LIST_MESSAGE = "contains an invalid IPv4 address or is not separated using commas"
+  validates :routers, ipv4_list: {message: INVALID_IPV4_LIST_MESSAGE}
+  validates :domain_name_servers, ipv4_list: {message: INVALID_IPV4_LIST_MESSAGE}
+
+  validate :at_least_one_option
 
   def routers
     return [] unless self[:routers]
@@ -33,5 +31,12 @@ class Option < ApplicationRecord
     else
       val
     end
+  end
+
+  private
+
+  def at_least_one_option
+    return if routers.any? || domain_name_servers.any? || domain_name.present?
+    errors.add(:base, "At least one option must be filled out")
   end
 end

--- a/db/migrate/20201008085614_make_option_fields_nullable.rb
+++ b/db/migrate/20201008085614_make_option_fields_nullable.rb
@@ -1,0 +1,7 @@
+class MakeOptionFieldsNullable < ActiveRecord::Migration[6.0]
+  def change
+    change_column_null :options, :routers, true
+    change_column_null :options, :domain_name_servers, true
+    change_column_null :options, :domain_name, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,8 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_07_143425) do
+ActiveRecord::Schema.define(version: 2020_10_08_085614) do
+
   create_table "global_options", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "routers", null: false
     t.string "domain_name_servers", null: false
@@ -20,9 +21,9 @@ ActiveRecord::Schema.define(version: 2020_10_07_143425) do
   end
 
   create_table "options", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
-    t.string "routers", null: false
-    t.string "domain_name_servers", null: false
-    t.string "domain_name", null: false
+    t.string "routers"
+    t.string "domain_name_servers"
+    t.string "domain_name"
     t.boolean "global", default: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,6 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema.define(version: 2020_10_08_085614) do
-
   create_table "global_options", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "routers", null: false
     t.string "domain_name_servers", null: false

--- a/spec/acceptance/update_options_spec.rb
+++ b/spec/acceptance/update_options_spec.rb
@@ -62,6 +62,8 @@ describe "update options", type: :feature do
       visit "/subnets/#{subnet.to_param}/options/edit"
 
       fill_in "Routers", with: ""
+      fill_in "Domain Name Servers", with: ""
+      fill_in "Domain Name", with: ""
 
       click_on "Update"
 

--- a/spec/models/option_spec.rb
+++ b/spec/models/option_spec.rb
@@ -7,19 +7,14 @@ RSpec.describe Option, type: :model do
     expect(subject).to be_valid
   end
 
-  it "is invalid with no routers" do
-    subject.routers = []
-    expect(subject).not_to be_valid
-    expect(subject.errors[:routers]).to include("must contain at least one IPv4 address separated using commas")
-  end
+  it "is invalid if none of the options are completed" do
+    subject.routers = nil
+    subject.domain_name_servers = nil
+    subject.domain_name = nil
 
-  it "is invalid with no domain_name_servers" do
-    subject.domain_name_servers = []
     expect(subject).not_to be_valid
-    expect(subject.errors[:domain_name_servers]).to include("must contain at least one IPv4 address separated using commas")
+    expect(subject.errors[:base]).to include("At least one option must be filled out")
   end
-
-  it { is_expected.to validate_presence_of :domain_name }
 
   it "rejects an incorrect routers" do
     option = build :option, routers: ["abcd", "efg"]

--- a/spec/use_cases/generate_kea_config_spec.rb
+++ b/spec/use_cases/generate_kea_config_spec.rb
@@ -87,7 +87,7 @@ describe UseCases::GenerateKeaConfig do
     end
 
     it "appends options to the subnet" do
-      option = build_stubbed(:option)
+      option = build_stubbed(:option, routers: nil)
 
       config = UseCases::GenerateKeaConfig.new(subnets: [option.subnet]).execute
 
@@ -96,10 +96,6 @@ describe UseCases::GenerateKeaConfig do
           {
             "name": "domain-name-servers",
             "data": option.domain_name_servers.join(", ")
-          },
-          {
-            "name": "routers",
-            "data": option.routers.join(", ")
           },
           {
             "name": "domain-name",


### PR DESCRIPTION
# What 
Make all attributes optional for subnet options, but ensure at least one option is set.

# Why 
In order to overwrite a single global option, we should not need to set everything.