### PR TITLE
Create GlobalOption model

### DIFF
--- a/app/models/global_option.rb
+++ b/app/models/global_option.rb
@@ -1,3 +1,35 @@
 class GlobalOption < ApplicationRecord
-  validates :routers, :domain_name_servers, :domain_name, presence: true
+  validates :routers,
+    presence: {message: "must contain at least one IPv4 address separated using commas"},
+    ipv4_list: {message: "contains an invalid IPv4 address or is not separated using commas"}
+  validates :domain_name_servers,
+    presence: {message: "must contain at least one IPv4 address separated using commas"},
+    ipv4_list: {message: "contains an invalid IPv4 address or is not separated using commas"}
+  validates :domain_name, presence: true
+
+  def routers
+    return [] unless self[:routers]
+    self[:routers].split(",")
+  end
+
+  def routers=(val)
+    self[:routers] = if val.respond_to?(:join)
+      val.join(",")
+    else
+      val
+    end
+  end
+
+  def domain_name_servers
+    return [] unless self[:domain_name_servers]
+    self[:domain_name_servers].split(",")
+  end
+
+  def domain_name_servers=(val)
+    self[:domain_name_servers] = if val.respond_to?(:join)
+      val.join(",")
+    else
+      val
+    end
+  end
 end

--- a/app/models/global_option.rb
+++ b/app/models/global_option.rb
@@ -1,0 +1,3 @@
+class GlobalOption < ApplicationRecord
+  validates :routers, :domain_name_servers, :domain_name, presence: true
+end

--- a/db/migrate/20201007143425_create_global_options.rb
+++ b/db/migrate/20201007143425_create_global_options.rb
@@ -1,0 +1,11 @@
+class CreateGlobalOptions < ActiveRecord::Migration[6.0]
+  def change
+    create_table :global_options do |t|
+      t.string :routers, null: false
+      t.string :domain_name_servers, null: false
+      t.string :domain_name, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,15 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_05_131618) do
+ActiveRecord::Schema.define(version: 2020_10_07_143425) do
+  create_table "global_options", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
+    t.string "routers", null: false
+    t.string "domain_name_servers", null: false
+    t.string "domain_name", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
   create_table "options", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "routers", null: false
     t.string "domain_name_servers", null: false

--- a/spec/controllers/sites_controller_spec.rb
+++ b/spec/controllers/sites_controller_spec.rb
@@ -27,7 +27,7 @@ describe SitesController, type: :controller do
       subnet2 = create :subnet, cidr_block: "10.0.3.0/24", site: subnet1.site
       subnet3 = create :subnet, cidr_block: "10.0.10.0/24", site: subnet1.site
 
-      get :show, params: { id: subnet1.site_id }
+      get :show, params: {id: subnet1.site_id}
 
       expect(assigns(:subnets)).to eq [subnet2, subnet3, subnet1]
     end

--- a/spec/factories/global_options.rb
+++ b/spec/factories/global_options.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :global_option do
+    routers { ["10.0.4.0", "10.0.4.2"] }
+    domain_name_servers { ["12.0.4.1", "12.0.4.5"] }
+    domain_name { "www.example.com" }
+  end
+end

--- a/spec/models/global_option_spec.rb
+++ b/spec/models/global_option_spec.rb
@@ -1,0 +1,13 @@
+require "rails_helper"
+
+RSpec.describe GlobalOption, type: :model do
+  subject { build :global_option }
+
+  it "has a valid factory" do
+    expect(subject).to be_valid
+  end
+
+  it { is_expected.to validate_presence_of :routers }
+  it { is_expected.to validate_presence_of :domain_name_servers }
+  it { is_expected.to validate_presence_of :domain_name }
+end

--- a/spec/models/global_option_spec.rb
+++ b/spec/models/global_option_spec.rb
@@ -7,7 +7,115 @@ RSpec.describe GlobalOption, type: :model do
     expect(subject).to be_valid
   end
 
-  it { is_expected.to validate_presence_of :routers }
-  it { is_expected.to validate_presence_of :domain_name_servers }
+  it do
+    is_expected.to validate_presence_of(:routers)
+      .with_message("must contain at least one IPv4 address separated using commas")
+  end
+
+  it do
+    is_expected.to validate_presence_of(:domain_name_servers)
+      .with_message("must contain at least one IPv4 address separated using commas")
+  end
+
   it { is_expected.to validate_presence_of :domain_name }
+
+  it "rejects an incorrect routers" do
+    option = build :option, routers: ["abcd", "efg"]
+    expect(option).not_to be_valid
+    expect(option.errors[:routers]).to eq(["contains an invalid IPv4 address or is not separated using commas"])
+  end
+
+  it "rejects an incorrect domain_name_server" do
+    option = build :option, domain_name_servers: ["abcd", "efg"]
+    expect(option).not_to be_valid
+    expect(option.errors[:domain_name_servers]).to eq(["contains an invalid IPv4 address or is not separated using commas"])
+  end
+
+  describe "#routers" do
+    context "when routers is nil" do
+      before do
+        subject.routers = nil
+      end
+
+      it "returns an empty array" do
+        expect(subject.routers).to eq([])
+      end
+    end
+
+    context "when routers is not empty" do
+      before do
+        subject.routers = "192.168.0.2,192.168.0.3"
+      end
+
+      it "returns an empty array" do
+        expect(subject.routers).to eq(["192.168.0.2", "192.168.0.3"])
+      end
+    end
+  end
+
+  describe "#routers=" do
+    context "when the value is a string" do
+      before do
+        subject.routers = "192.168.0.2,192.168.0.3"
+      end
+
+      it "returns an empty array" do
+        expect(subject.routers).to eq(["192.168.0.2", "192.168.0.3"])
+      end
+    end
+
+    context "when the value is an array" do
+      before do
+        subject.routers = ["192.168.0.2", "192.168.0.3"]
+      end
+
+      it "returns an empty array" do
+        expect(subject.routers).to eq(["192.168.0.2", "192.168.0.3"])
+      end
+    end
+  end
+
+  describe "#domain_name_servers" do
+    context "when domain_name_servers is nil" do
+      before do
+        subject.domain_name_servers = nil
+      end
+
+      it "returns an empty array" do
+        expect(subject.domain_name_servers).to eq([])
+      end
+    end
+
+    context "when domain_name_servers is not empty" do
+      before do
+        subject.domain_name_servers = "192.168.0.2,192.168.0.3"
+      end
+
+      it "returns an empty array" do
+        expect(subject.domain_name_servers).to eq(["192.168.0.2", "192.168.0.3"])
+      end
+    end
+  end
+
+  describe "#domain_name_servers=" do
+    context "when the value is a string" do
+      before do
+        subject.domain_name_servers = "192.168.0.2,192.168.0.3"
+      end
+
+      it "returns an empty array" do
+        expect(subject.domain_name_servers).to eq(["192.168.0.2", "192.168.0.3"])
+      end
+    end
+
+    context "when the value is an array" do
+      before do
+        subject.domain_name_servers = ["192.168.0.2", "192.168.0.3"]
+      end
+
+      it "returns an empty array" do
+        expect(subject.domain_name_servers).to eq(["192.168.0.2", "192.168.0.3"])
+      end
+    end
+  end
 end


### PR DESCRIPTION
# What
Creates a global option model which will represent the default options for all subnets

# Why
So that subnets have a default set of options to use (if they don't have a subnet specific options set)

# Screenshots

# Notes
Option docs https://kea.readthedocs.io/en/kea-1.8.0/arm/dhcp4-srv.html#standard-dhcpv4-options