### PR TITLE
Remove global options from options table

### DIFF
--- a/app/models/option.rb
+++ b/app/models/option.rb
@@ -1,6 +1,7 @@
 class Option < ApplicationRecord
   belongs_to :subnet
 
+  validates :subnet, presence: true
   INVALID_IPV4_LIST_MESSAGE = "contains an invalid IPv4 address or is not separated using commas"
   validates :routers, ipv4_list: {message: INVALID_IPV4_LIST_MESSAGE}
   validates :domain_name_servers, ipv4_list: {message: INVALID_IPV4_LIST_MESSAGE}

--- a/db/migrate/20201008084752_remove_global_from_options.rb
+++ b/db/migrate/20201008084752_remove_global_from_options.rb
@@ -1,0 +1,17 @@
+class RemoveGlobalFromOptions < ActiveRecord::Migration[6.0]
+  def up
+    Option.where(global: true).destroy_all
+
+    remove_column :options, :global
+  end
+
+  def down
+    add_column :options, :global, :boolean, default: false
+
+    Option.find_or_create_by(global: true) do |option|
+      option.routers = ["192.1.1.10", "192.1.1.12"]
+      option.domain_name_servers = ["192.1.2.10", "192.1.2.12"]
+      option.domain_name = "seeds.example.com"
+    end
+  end
+end

--- a/db/migrate/20201008093043_make_options_subnet_id_not_nullable.rb
+++ b/db/migrate/20201008093043_make_options_subnet_id_not_nullable.rb
@@ -1,0 +1,5 @@
+class MakeOptionsSubnetIdNotNullable < ActiveRecord::Migration[6.0]
+  def change
+    change_column_null :options, :subnet_id, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,8 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_08_085614) do
+ActiveRecord::Schema.define(version: 2020_10_08_093043) do
+
   create_table "global_options", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "routers", null: false
     t.string "domain_name_servers", null: false
@@ -25,7 +26,7 @@ ActiveRecord::Schema.define(version: 2020_10_08_085614) do
     t.string "domain_name"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.bigint "subnet_id"
+    t.bigint "subnet_id", null: false
     t.index ["subnet_id"], name: "index_options_on_subnet_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,6 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema.define(version: 2020_10_08_093043) do
-
   create_table "global_options", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "routers", null: false
     t.string "domain_name_servers", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -23,7 +23,6 @@ ActiveRecord::Schema.define(version: 2020_10_08_085614) do
     t.string "routers"
     t.string "domain_name_servers"
     t.string "domain_name"
-    t.boolean "global", default: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.bigint "subnet_id"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,5 +1,0 @@
-Option.find_or_create_by(global: true) do |option|
-  option.routers = ["192.1.1.10", "192.1.1.12"]
-  option.domain_name_servers = ["192.1.2.10", "192.1.2.12"]
-  option.domain_name = "seeds.example.com"
-end

--- a/spec/models/option_spec.rb
+++ b/spec/models/option_spec.rb
@@ -7,6 +7,8 @@ RSpec.describe Option, type: :model do
     expect(subject).to be_valid
   end
 
+  it { is_expected.to validate_presence_of :subnet }
+
   it "is invalid if none of the options are completed" do
     subject.routers = nil
     subject.domain_name_servers = nil


### PR DESCRIPTION
# What
Remove `global?` flag from the `Option` model and enforce an association with a subnet.

# Why
We prefer a separate table for `GlobalOption`s. This allows our database schema to be stricter about associations and separates global option logic.

# Notes
We delete global options for the options table and reinstate the seeded global options on the down. This is simpler currently than migrating but something we potentially care about in the future. Right now we dont have any real production data we need to maintain. If we do want to maintain the data, we should migrate the global options between the tables.
