### PR TITLE
Include global options in the kea config

### DIFF
--- a/app/lib/use_cases/generate_kea_config.rb
+++ b/app/lib/use_cases/generate_kea_config.rb
@@ -1,7 +1,8 @@
 module UseCases
   class GenerateKeaConfig
-    def initialize(subnets: [])
+    def initialize(subnets: [], global_option: nil)
       @subnets = subnets
+      @global_option = global_option
     end
 
     def execute
@@ -61,6 +62,25 @@ module UseCases
       result
     end
 
+    def global_options_config
+      return {} if @global_option.blank?
+
+      {
+        "option-data": [
+          {
+            "name": "domain-name-servers",
+            "data": @global_option.domain_name_servers.join(", ")
+          }, {
+            "name": "routers",
+            "data": @global_option.routers.join(", ")
+          }, {
+            "name": "domain-name",
+            "data": @global_option.domain_name
+          }
+        ]
+      }
+    end
+
     def default_config
       {
         Dhcp4: {
@@ -114,7 +134,7 @@ module UseCases
               severity: "DEBUG"
             }
           ]
-        }
+        }.merge(global_options_config)
       }
     end
   end

--- a/spec/use_cases/generate_kea_config_spec.rb
+++ b/spec/use_cases/generate_kea_config_spec.rb
@@ -104,5 +104,31 @@ describe UseCases::GenerateKeaConfig do
         ]
       }))
     end
+
+    it "includes global options in the config" do
+      global_option = build_stubbed(:global_option)
+
+      config = UseCases::GenerateKeaConfig.new(subnets: [], global_option: global_option).execute
+
+      expect(config.dig(:Dhcp4, :"option-data")).to match_array([
+        {
+          "name": "domain-name-servers",
+          "data": global_option.domain_name_servers.join(", ")
+        },
+        {
+          "name": "domain-name",
+          "data": global_option.domain_name
+        },
+        {
+          "name": "routers",
+          "data": global_option.routers.join(", ")
+        }
+      ])
+    end
+
+    it "does not set the global options if none are passed in" do
+      config = UseCases::GenerateKeaConfig.new(subnets: [], global_option: nil).execute
+      expect(config[:Dhcp4].keys).to_not include :"option-data"
+    end
   end
 end


### PR DESCRIPTION
# What
Appends the global option config to the kea config

# Why
So that changes to the global config are represented in the kea config

# Screenshots

# Notes
https://kea.readthedocs.io/en/kea-1.8.0/arm/dhcp4-srv.html#standard-dhcpv4-options