### PR TITLE
Validate that only one GlobalOption can exist in the database

### DIFF
--- a/app/models/global_option.rb
+++ b/app/models/global_option.rb
@@ -7,6 +7,8 @@ class GlobalOption < ApplicationRecord
     ipv4_list: {message: "contains an invalid IPv4 address or is not separated using commas"}
   validates :domain_name, presence: true
 
+  validate :only_one_record
+
   def routers
     return [] unless self[:routers]
     self[:routers].split(",")
@@ -30,6 +32,14 @@ class GlobalOption < ApplicationRecord
       val.join(",")
     else
       val
+    end
+  end
+
+  private
+
+  def only_one_record
+    if GlobalOption.where.not(id: id).exists?
+      errors.add(:base, "A global option already exists")
     end
   end
 end

--- a/spec/models/global_option_spec.rb
+++ b/spec/models/global_option_spec.rb
@@ -118,4 +118,12 @@ RSpec.describe GlobalOption, type: :model do
       end
     end
   end
+
+  it "can only have 1 record in the database" do
+    create(:global_option)
+
+    new_global_option = build(:global_option)
+    expect(new_global_option).to_not be_valid
+    expect(new_global_option.errors[:base]).to include "A global option already exists"
+  end
 end


### PR DESCRIPTION
# What
Validate that only one GlobalOption can exist in the database

# Why
To ensure we maintain the expectation of there only ever being one global option in the system

# Screenshots

# Notes
