### PR TITLE
Add sentry for error reporting

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,7 @@ gem "aws-sdk-s3", "~> 1.73"
 gem "ipaddress_2"
 gem "aws-sdk-ecs", "~> 1.8"
 gem "cancancan", "~> 3.1"
+gem "sentry-raven"
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -260,6 +260,8 @@ GEM
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
+    sentry-raven (3.1.1)
+      faraday (>= 1.0)
     shoulda-matchers (4.3.0)
       activesupport (>= 4.2.0)
     simplecov (0.19.0)
@@ -343,6 +345,7 @@ DEPENDENCIES
   rspec-rails (~> 4.0.1)
   sassc-rails
   selenium-webdriver
+  sentry-raven
   shoulda-matchers (~> 4.0)
   simplecov
   simplecov-console


### PR DESCRIPTION
# What
Add sentry for error reporting. 

# Why
In order to keep track of 500 errors we need a reporting tool to see what went wrong. Sentry.io provides this.

# Notes
If `SENTRY_DSN` is not senv in the env vars, sentry will not report errors. To test, set up `SENTRY_DSN` either in your .env file or in the env vars for your environment.
