### PR TITLE
Revert database encoding back to latin1

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -1,7 +1,6 @@
 default: &default
   adapter: mysql2
-  encoding: utf8mb4
-  collation: utf8mb4_unicode_ci
+  encoding: latin1
   host: <%= ENV.fetch('DB_HOST') %>
   port: 3306
   username: <%= ENV.fetch('DB_USER') %>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema.define(version: 2020_10_08_093043) do
-  create_table "global_options", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "global_options", options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
     t.string "routers", null: false
     t.string "domain_name_servers", null: false
     t.string "domain_name", null: false
@@ -19,7 +19,7 @@ ActiveRecord::Schema.define(version: 2020_10_08_093043) do
     t.datetime "updated_at", precision: 6, null: false
   end
 
-  create_table "options", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "options", options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
     t.string "routers"
     t.string "domain_name_servers"
     t.string "domain_name"
@@ -29,14 +29,14 @@ ActiveRecord::Schema.define(version: 2020_10_08_093043) do
     t.index ["subnet_id"], name: "index_options_on_subnet_id"
   end
 
-  create_table "sites", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "sites", options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
     t.string "name", null: false
     t.string "fits_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end
 
-  create_table "subnets", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "subnets", options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
     t.string "cidr_block", null: false
     t.string "start_address", null: false
     t.string "end_address", null: false
@@ -46,7 +46,7 @@ ActiveRecord::Schema.define(version: 2020_10_08_093043) do
     t.index ["site_id"], name: "index_subnets_on_site_id"
   end
 
-  create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "provider"
@@ -54,7 +54,7 @@ ActiveRecord::Schema.define(version: 2020_10_08_093043) do
     t.boolean "editor", default: false
   end
 
-  create_table "zones", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "zones", options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
     t.string "name", null: false
     t.string "forwarders", null: false
     t.string "purpose"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,6 @@ version: "3.4"
 services:
   db:
     image: "mysql:5.7"
-    command: ['mysqld', '--character-set-server=utf8mb4', '--collation-server=utf8mb4_unicode_ci']
     env_file: .env.${ENV}
     expose:
       - "3306"


### PR DESCRIPTION
# What
Changes the database encoding back to latin1

# Why
We decided to stick with latin1 encoding for now and investigate a migration to utf8 in the future.

We want to consider migrating our admin database to use UTF8. We had a discussion as to whether we required it and decided it wasn't worth it. Kea only supports latin1 so kea should not require it and our validations
should protect us from invalid configuration of Kea.

Potential places we may want it in the future include users and usernames. Right now it isn't a requirement.

# Screenshots

# Notes
