### PR TITLE
Update fits_id label to all caps in error messages

### DIFF
--- a/app/views/sites/_form.html.erb
+++ b/app/views/sites/_form.html.erb
@@ -1,6 +1,6 @@
 <%= form_with model: site, local: true do |f| %>
   <div class="govuk-form-group <%= field_error(f.object, :fits_id )%>">
-    <%= f.label :fits_id, "FITS Id", class: "govuk-label" %>
+    <%= f.label :fits_id, class: "govuk-label" %>
     <%= f.text_field :fits_id, class: "govuk-input" %>
   </div>
 

--- a/app/views/sites/index.html.erb
+++ b/app/views/sites/index.html.erb
@@ -9,7 +9,7 @@
     <caption class="govuk-table__caption">List of Sites</caption>
     <thead class="govuk-table__head">
       <tr class="govuk-table__row">
-        <th scope="col" class="govuk-table__header">FITS Id</th>
+        <th scope="col" class="govuk-table__header">FITS ID</th>
         <th scope="col" class="govuk-table__header">Name</th>
         <th scope="col" class="govuk-table__header">
           <span class="govuk-visually-hidden">Actions</span>

--- a/app/views/sites/show.html.erb
+++ b/app/views/sites/show.html.erb
@@ -2,7 +2,7 @@
 
 <dl class="govuk-summary-list">
   <div class="govuk-summary-list__row">
-    <dt class="govuk-summary-list__key">FITS Id</dt>
+    <dt class="govuk-summary-list__key">FITS ID</dt>
     <dd class="govuk-summary-list__value"><%= @site.fits_id %></dd>
   </div>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -34,3 +34,5 @@ en:
     attributes:
       subnet:
         cidr_block: "CIDR block"
+      site: 
+        fits_id: "FITS ID"

--- a/spec/acceptance/create_sites_spec.rb
+++ b/spec/acceptance/create_sites_spec.rb
@@ -37,7 +37,7 @@ describe "create sites", type: :feature do
 
       expect(current_path).to eql("/sites/new")
 
-      fill_in "FITS Id", with: "MYFITS101"
+      fill_in "FITS ID", with: "MYFITS101"
       fill_in "Name", with: "My London Site"
 
       click_on "Create"

--- a/spec/acceptance/update_sites_spec.rb
+++ b/spec/acceptance/update_sites_spec.rb
@@ -37,10 +37,10 @@ describe "update sites", type: :feature do
 
       click_on "Edit"
 
-      expect(page).to have_field("FITS Id", with: site.fits_id)
+      expect(page).to have_field("FITS ID", with: site.fits_id)
       expect(page).to have_field("Name", with: site.name)
 
-      fill_in "FITS Id", with: "MYFITS202"
+      fill_in "FITS ID", with: "MYFITS202"
       fill_in "Name", with: "My Manchester Site"
 
       click_on "Update"


### PR DESCRIPTION
# What
Update fits_id label to all caps in error messages

# Screenshots
![image](https://user-images.githubusercontent.com/64264510/95750536-32fc7b80-0c95-11eb-8bfb-827db54c8888.png)

