### PR TITLE
Store zone forwarders as a comma separated list of IPv4 addresses

### DIFF
--- a/app/lib/use_cases/generate_bind_config.rb
+++ b/app/lib/use_cases/generate_bind_config.rb
@@ -51,9 +51,13 @@ zone "127.in-addr.arpa" IN {
       %(
 zone "#{zone.name}" IN {
   type forward;
-  forwarders {#{zone.kea_forwarders}};
+  forwarders {#{format_zone_forwarders(zone.forwarders)}};
 };
 )
     }.join
+  end
+
+  def format_zone_forwarders(forwarders)
+    forwarders.join(";") + ";"
   end
 end

--- a/app/lib/use_cases/generate_bind_config.rb
+++ b/app/lib/use_cases/generate_bind_config.rb
@@ -51,7 +51,7 @@ zone "127.in-addr.arpa" IN {
       %(
 zone "#{zone.name}" IN {
   type forward;
-  forwarders {#{zone.forwarders}};
+  forwarders {#{zone.kea_forwarders}};
 };
 )
     }.join

--- a/app/models/zone.rb
+++ b/app/models/zone.rb
@@ -8,10 +8,4 @@ class Zone < ApplicationRecord
     return [] unless self[:forwarders]
     self[:forwarders].split(",")
   end
-
-  def kea_forwarders
-    return "" if forwarders.blank?
-
-    forwarders.join(";") + ";"
-  end
 end

--- a/app/views/zones/_form.html.erb
+++ b/app/views/zones/_form.html.erb
@@ -10,9 +10,9 @@
   <div class="govuk-form-group <%= field_error(f.object, :forwarders) %>">
     <%= f.label :forwarders, "Forwarders", class: "govuk-label" %>
     <div id="zone_forwarders-hint" class="govuk-hint">
-      Must be in the form: 127.0.0.1;127.0.0.2;
+      Must be in the form: 127.0.0.1,127.0.0.2
     </div>
-    <%= f.text_field :forwarders, class: "govuk-input" %>
+    <%= f.text_field :forwarders, value: f.object.forwarders.join(","), class: "govuk-input" %>
   </div>
 
   <div class="govuk-form-group <%= field_error(f.object, :purpose) %>">

--- a/app/views/zones/index.html.erb
+++ b/app/views/zones/index.html.erb
@@ -23,7 +23,7 @@
       <% @zones.each do |zone| %>
         <tr class="govuk-table__row">
           <td class="govuk-table__cell"><%= zone.name %></td>
-          <td class="govuk-table__cell"><%= zone.forwarders %></td>
+          <td class="govuk-table__cell"><%= zone.forwarders.join(",") %></td>
           <td class="govuk-table__cell"><%= zone.purpose %></td>
           <% if can? :manage, Subnet %>
             <td class="govuk-table__cell">

--- a/db/migrate/20201012115948_change_zone_forwarders_to_comma_separated.rb
+++ b/db/migrate/20201012115948_change_zone_forwarders_to_comma_separated.rb
@@ -1,0 +1,15 @@
+class ChangeZoneForwardersToCommaSeparated < ActiveRecord::Migration[6.0]
+  def up
+    Zone.find_each do |zone|
+      zone.forwarders = zone[:forwarders].split(";").join(",")
+      zone.save!
+    end
+  end
+
+  def down
+    Zone.find_each do |zone|
+      zone.forwarders = zone[:forwarders].split(",").join(";") + ";"
+      zone.save(validate: false)
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_08_093043) do
+ActiveRecord::Schema.define(version: 2020_10_12_115948) do
   create_table "global_options", options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
     t.string "routers", null: false
     t.string "domain_name_servers", null: false

--- a/spec/acceptance/create_zones_spec.rb
+++ b/spec/acceptance/create_zones_spec.rb
@@ -13,7 +13,7 @@ describe "create zones", type: :feature do
     expect(current_path).to eql("/zones/new")
 
     fill_in "Name", with: "test.example.com"
-    fill_in "Forwarders", with: "10.1.1.25;10.1.1.28;"
+    fill_in "Forwarders", with: "10.1.1.25,10.1.1.28"
     fill_in "Purpose", with: "Frontend Driven Test"
 
     click_button "Create"
@@ -22,7 +22,7 @@ describe "create zones", type: :feature do
 
     zone = Zone.last
     expect(zone.name).to eq "test.example.com"
-    expect(zone.forwarders).to eq "10.1.1.25;10.1.1.28;"
+    expect(zone.forwarders).to eq ["10.1.1.25", "10.1.1.28"]
     expect(zone.purpose).to eq "Frontend Driven Test"
   end
 

--- a/spec/acceptance/update_zones_spec.rb
+++ b/spec/acceptance/update_zones_spec.rb
@@ -13,11 +13,11 @@ describe "update zones", type: :feature do
     click_on "Edit"
 
     expect(page).to have_field("Name", with: zone.name)
-    expect(page).to have_field("Forwarders", with: zone.forwarders)
+    expect(page).to have_field("Forwarders", with: zone.forwarders.join(","))
     expect(page).to have_field("Purpose", with: zone.purpose)
 
     fill_in "Name", with: "test.example.com"
-    fill_in "Forwarders", with: "127.0.0.2;127.0.0.1;"
+    fill_in "Forwarders", with: "127.0.0.2,127.0.0.1"
     fill_in "Purpose", with: "UI Testing for Updating"
 
     click_button "Update"
@@ -25,7 +25,7 @@ describe "update zones", type: :feature do
     expect(current_path).to eq("/zones")
 
     expect(page).to have_content("test.example.com")
-    expect(page).to have_content("127.0.0.2;127.0.0.1;")
+    expect(page).to have_content("127.0.0.2,127.0.0.1")
     expect(page).to have_content("UI Testing for Updating")
   end
 

--- a/spec/acceptance/zones_spec.rb
+++ b/spec/acceptance/zones_spec.rb
@@ -11,7 +11,7 @@ describe "GET /zones", type: :feature do
 
     visit "/zones"
     expect(page).to have_content zone.name
-    expect(page).to have_content zone.forwarders
+    expect(page).to have_content zone.forwarders.join(",")
     expect(page).to have_content zone.purpose
 
     expect(page).to have_content zone2.name

--- a/spec/factories/zones.rb
+++ b/spec/factories/zones.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :zone do
     name { "example.com" }
-    forwarders { "127.0.0.5;127.0.0.8;" }
+    forwarders { "127.0.0.5,127.0.0.8" }
     purpose { "My example app forwarding" }
   end
 end

--- a/spec/models/zone_spec.rb
+++ b/spec/models/zone_spec.rb
@@ -9,30 +9,37 @@ RSpec.describe Zone, type: :model do
 
   it { is_expected.to validate_uniqueness_of(:name).case_insensitive }
   it { is_expected.to validate_presence_of :name }
-  it { is_expected.to validate_presence_of :forwarders }
+  it { is_expected.to validate_presence_of(:forwarders).with_message("must contain at least one IPv4 address separated using commas") }
 
   context "forwarders validation" do
     it "must be a valid IPv4 address" do
-      zone = build :zone, forwarders: ";"
+      zone = build :zone, forwarders: ","
       expect(zone).to_not be_valid
-      expect(zone.errors[:forwarders]).to eq(["contains an invalid IPv4 address"])
+      expect(zone.errors[:forwarders]).to eq(["must contain at least one IPv4 address separated using commas"])
     end
 
     it "must be a valid IPv4 address" do
       zone = build :zone, forwarders: "poorly_entered_data;"
       expect(zone).to_not be_valid
-      expect(zone.errors[:forwarders]).to eq(["contains an invalid IPv4 address"])
+      expect(zone.errors[:forwarders]).to eq(["contains an invalid IPv4 address or is not separated using commas"])
     end
 
-    it "must end with a semi-colon" do
-      zone = build :zone, forwarders: "127.0.0.1"
+    it "must be comma separated" do
+      zone = build :zone, forwarders: "127.0.0.1|127.0.0.1"
       expect(zone).to_not be_valid
-      expect(zone.errors[:forwarders]).to eq(["must end with a semi-colon"])
+      expect(zone.errors[:forwarders]).to eq(["contains an invalid IPv4 address or is not separated using commas"])
     end
 
-    it "must be a valid BIND DNS forwarder string" do
-      zone = build :zone, forwarders: "127.0.0.1;127.0.0.2;"
+    it "must be a valid comma separated list of IPv4 addresses" do
+      zone = build :zone, forwarders: "127.0.0.1,127.0.0.2"
       expect(zone).to be_valid
+    end
+  end
+
+  context "kea_forwarders" do
+    it "returns a semicolon separated list of IPv4s" do
+      zone = build :zone, forwarders: "127.0.0.1,127.0.0.2"
+      expect(zone.kea_forwarders).to eq "127.0.0.1;127.0.0.2;"
     end
   end
 end

--- a/spec/models/zone_spec.rb
+++ b/spec/models/zone_spec.rb
@@ -35,11 +35,4 @@ RSpec.describe Zone, type: :model do
       expect(zone).to be_valid
     end
   end
-
-  context "kea_forwarders" do
-    it "returns a semicolon separated list of IPv4s" do
-      zone = build :zone, forwarders: "127.0.0.1,127.0.0.2"
-      expect(zone.kea_forwarders).to eq "127.0.0.1;127.0.0.2;"
-    end
-  end
 end

--- a/spec/use_cases/generate_bind_config_spec.rb
+++ b/spec/use_cases/generate_bind_config_spec.rb
@@ -49,8 +49,8 @@ zone "127.in-addr.arpa" IN {
 
   describe "Dynamic zones" do
     before do
-      create(:zone, name: "example.test.com", forwarders: "127.0.0.1;127.0.0.2;")
-      create(:zone, name: "example2.test.com", forwarders: "10.0.0.1;10.0.0.255;")
+      create(:zone, name: "example.test.com", forwarders: "127.0.0.1,127.0.0.2")
+      create(:zone, name: "example2.test.com", forwarders: "10.0.0.1,10.0.0.255")
     end
 
     let(:all_zones) { Zone.all }


### PR DESCRIPTION
# What
Updates the Zone forwarders to take a comma separated list of IPv4 addresses

# Why
Previously we were requesting a semicolon separated list and storing it in the database as such (ensuring it was formatted correctly for the kea config)

To maintain consistency with how we submit IPv4 addresses for Options and GlobalOptions, this changes the zone forwarders to be a comma separated list.

The Zone has a kea_forwarders method to format the list before sending it to KEA

# Screenshots
### Before
![ScreenShot 2020-10-12 at 15 01 13](https://user-images.githubusercontent.com/7527178/95755177-fb450200-0c9b-11eb-9494-2b6d596143b8.png)

### After
![ScreenShot 2020-10-12 at 15 01 55](https://user-images.githubusercontent.com/7527178/95755188-fed88900-0c9b-11eb-9489-27bd30fa8165.png)


# Notes
