### PR TITLE
Add basic navigation menu

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,4 +1,10 @@
 class HomeController < ApplicationController
   def index
   end
+
+  def dhcp
+  end
+
+  def dns
+  end
 end

--- a/app/controllers/sites_controller.rb
+++ b/app/controllers/sites_controller.rb
@@ -20,7 +20,7 @@ class SitesController < ApplicationController
     if @site.save
       publish_kea_config
       deploy_dhcp_service
-      redirect_to sites_path, notice: "Successfully created site"
+      redirect_to dhcp_path, notice: "Successfully created site"
     else
       render :new
     end
@@ -35,7 +35,7 @@ class SitesController < ApplicationController
     if @site.update(site_params)
       publish_kea_config
       deploy_dhcp_service
-      redirect_to sites_path, notice: "Successfully updated site"
+      redirect_to dhcp_path, notice: "Successfully updated site"
     else
       render :edit
     end
@@ -48,9 +48,9 @@ class SitesController < ApplicationController
       if @site.destroy
         publish_kea_config
         deploy_dhcp_service
-        redirect_to sites_path, notice: "Successfully deleted site"
+        redirect_to dhcp_path, notice: "Successfully deleted site"
       else
-        redirect_to sites_path, error: "Failed to delete the site"
+        redirect_to dhcp_path, error: "Failed to delete the site"
       end
     else
       render "sites/destroy"

--- a/app/controllers/zones_controller.rb
+++ b/app/controllers/zones_controller.rb
@@ -15,7 +15,7 @@ class ZonesController < ApplicationController
     authorize! :create, @zone
     if @zone.save
       publish_bind_config
-      redirect_to zones_path, notice: "Successfully created zone"
+      redirect_to dns_path, notice: "Successfully created zone"
     else
       render :new
     end
@@ -29,7 +29,7 @@ class ZonesController < ApplicationController
     authorize! :update, @zone
     if @zone.update(zone_params)
       publish_bind_config
-      redirect_to zones_path, notice: "Successfully updated DNS zone"
+      redirect_to dns_path, notice: "Successfully updated DNS zone"
     else
       render :edit
     end
@@ -40,9 +40,9 @@ class ZonesController < ApplicationController
     if confirmed?
       if @zone.destroy
         publish_bind_config
-        redirect_to zones_path, notice: "Successfully deleted zone"
+        redirect_to dns_path, notice: "Successfully deleted zone"
       else
-        redirect_to zones_path, error: "Failed to delete the zone"
+        redirect_to dns_path, error: "Failed to delete the zone"
       end
     end
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -5,7 +5,7 @@ module ApplicationHelper
 
   def selected_class_if_controller(controller_names)
     if [controller_names].flatten.include?(controller_name)
-      return ' govuk-header__navigation-item--active'
+      " govuk-header__navigation-item--active"
     end
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -2,4 +2,10 @@ module ApplicationHelper
   def field_error(resource, key)
     resource&.errors&.include?(key.to_sym) ? "govuk-form-group--error" : ""
   end
+
+  def selected_class_if_controller(controller_names)
+    if [controller_names].flatten.include?(controller_name)
+      return ' govuk-header__navigation-item--active'
+    end
+  end
 end

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,5 +1,1 @@
 <h2 class="govuk-heading-l">DHCP / DNS Admin portal</h2>
-
-<%= link_to "Manage sites", sites_path, class: "govuk-button" %>
-<%= link_to "Manage DNS configuration", zones_path, class: "govuk-button" %>
-<%= link_to "Manage global options", global_options_path, class: "govuk-button" %>

--- a/app/views/layouts/_navigation.html.erb
+++ b/app/views/layouts/_navigation.html.erb
@@ -5,7 +5,7 @@
         <%= link_to "DNS", dns_path, class: "govuk-header__link", data: { topnav: "DNS" } %>
       </li>
 
-      <li class="govuk-header__navigation-item<%= selected_class_if_controller('sites') %>">
+      <li class="govuk-header__navigation-item<%= selected_class_if_controller(['sites', 'global_options', 'subnets', 'options']) %>">
         <%= link_to "DHCP", dhcp_path, class: "govuk-header__link", data: { topnav: "DHCP" } %>
       </li>
 

--- a/app/views/layouts/_navigation.html.erb
+++ b/app/views/layouts/_navigation.html.erb
@@ -1,0 +1,17 @@
+<nav>
+  <ul id="navigation" class="govuk-header__navigation" aria-label="Top Level Navigation">
+    <% if user_signed_in? %>
+      <li class="govuk-header__navigation-item<%= selected_class_if_controller('sites') %>">
+        <%= link_to "DHCP", sites_path, class: "govuk-header__link", data: { topnav: "DHCP" } %>
+      </li>
+
+      <li class="govuk-header__navigation-item<%= selected_class_if_controller('zones') %>">
+        <%= link_to "DNS", zones_path, class: "govuk-header__link", data: { topnav: "DNS" } %>
+      </li>
+
+      <li class="govuk-header__navigation-item">
+        <%= link_to "Sign out", destroy_user_session_path, method: :delete, class: "govuk-header__link" %>
+      </li>
+    <% end %>
+  </ul>
+</nav>

--- a/app/views/layouts/_navigation.html.erb
+++ b/app/views/layouts/_navigation.html.erb
@@ -1,12 +1,12 @@
 <nav>
   <ul id="navigation" class="govuk-header__navigation" aria-label="Top Level Navigation">
     <% if user_signed_in? %>
-      <li class="govuk-header__navigation-item<%= selected_class_if_controller('sites') %>">
-        <%= link_to "DHCP", sites_path, class: "govuk-header__link", data: { topnav: "DHCP" } %>
+      <li class="govuk-header__navigation-item<%= selected_class_if_controller('zones') %>">
+        <%= link_to "DNS", dns_path, class: "govuk-header__link", data: { topnav: "DNS" } %>
       </li>
 
-      <li class="govuk-header__navigation-item<%= selected_class_if_controller('zones') %>">
-        <%= link_to "DNS", zones_path, class: "govuk-header__link", data: { topnav: "DNS" } %>
+      <li class="govuk-header__navigation-item<%= selected_class_if_controller('sites') %>">
+        <%= link_to "DHCP", dhcp_path, class: "govuk-header__link", data: { topnav: "DHCP" } %>
       </li>
 
       <li class="govuk-header__navigation-item">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -34,29 +34,29 @@
               </svg>
               <span class="govuk-header__logotype-text">GOV.UK</span>
             </span>
-            <span class="govuk-header__product-name">
-              GovUK DHCP Admin
-              <strong class="govuk-tag govuk-phase-banner__content__tag">
-                beta
-              </strong>
-            </span>
-            <%- end %>
+          <%- end %>
         </div>
+
         <div class="govuk-header__content">
           <button type="button" class="govuk-header__menu-button govuk-js-header-toggle" aria-controls="navigation" aria-label="Show or hide Top Level Navigation">Menu</button>
-          <nav>
-            <ul id="navigation" class="govuk-header__navigation " aria-label="Top Level Navigation" dir="RTL">
-              <% if user_signed_in? %>
-                <li class="govuk-header__navigation-item">
-                  <%= link_to "Sign out", destroy_user_session_path, method: :delete, class: "govuk-header__link" %>
-                </li>
-              <% end %>
-            </ul>
-          </nav>
+          <%= link_to "Staff device DNS / DHCP Admin", root_path, class: "govuk-header__link govuk-header__link--service-name" %>
+          <%= render "layouts/navigation" %>
         </div>
       </div>
     </header>
+
     <div class="govuk-width-container">
+      <div class="govuk-phase-banner">
+        <p class="govuk-phase-banner__content">
+          <strong class="govuk-tag govuk-phase-banner__content__tag">
+            beta
+          </strong>
+          <span class="govuk-phase-banner__text">
+            This is a new service.
+          </span>
+        </p>
+      </div>
+
       <% if user_signed_in? %>
         <hr class="govuk-section-break govuk-section-break--xs govuk-section-break--visible">
         <div class="govuk-grid-row">

--- a/app/views/sites/_form.html.erb
+++ b/app/views/sites/_form.html.erb
@@ -14,7 +14,7 @@
     "data-module" => "govuk-button"
   } %>
 
-  <%= link_to "Cancel", sites_path,
+  <%= link_to "Cancel", dhcp_path,
   class: "govuk-button govuk-button--secondary",
   data: {
     module: "govuk-button"

--- a/app/views/sites/destroy.html.erb
+++ b/app/views/sites/destroy.html.erb
@@ -20,7 +20,7 @@
     class: 'govuk-!-display-inline-block'
   }
 %>
-<%= link_to "Cancel", sites_path,
+<%= link_to "Cancel", dhcp_path,
   class: "govuk-button govuk-button--secondary",
   data: {
     module: "govuk-button"

--- a/app/views/sites/index.html.erb
+++ b/app/views/sites/index.html.erb
@@ -1,6 +1,8 @@
 <div>
   <h2 class="govuk-heading-l">Sites</h2>
 
+  <%= link_to "Global configuration", global_options_path, class: "govuk-button govuk-button--secondary" %>
+
   <% if can? :create, Site %>
     <%= link_to "Create a new site", new_site_path, class: "govuk-button" %>
   <% end %>

--- a/app/views/sites/index.html.erb
+++ b/app/views/sites/index.html.erb
@@ -1,7 +1,8 @@
 <div>
-  <h2 class="govuk-heading-l">Sites</h2>
+  <h2 class="govuk-heading-l">DHCP</h2>
+  <%= link_to "Global options", global_options_path, class: "govuk-button govuk-button--secondary" %>
 
-  <%= link_to "Global configuration", global_options_path, class: "govuk-button govuk-button--secondary" %>
+  <h3 class="govuk-heading-m">Sites</h3>
 
   <% if can? :create, Site %>
     <%= link_to "Create a new site", new_site_path, class: "govuk-button" %>

--- a/app/views/zones/destroy.html.erb
+++ b/app/views/zones/destroy.html.erb
@@ -15,7 +15,7 @@
     class: 'govuk-!-display-inline-block'
   }
 %>
-<%= link_to "Cancel", zones_path,
+<%= link_to "Cancel", dns_path,
   class: "govuk-button govuk-button--secondary",
   data: {
     module: "govuk-button"

--- a/app/views/zones/index.html.erb
+++ b/app/views/zones/index.html.erb
@@ -1,5 +1,6 @@
 <div>
-  <h2 class="govuk-heading-l">DNS Zones</h2>
+  <h2 class="govuk-heading-l">DNS</h2>
+  <h3 class="govuk-heading-l">Zones</h3>
 
   <% if can? :manage, Subnet %>
     <%= link_to "Create a new zone", new_zone_path, class: "govuk-button" %>
@@ -23,7 +24,7 @@
       <% @zones.each do |zone| %>
         <tr class="govuk-table__row">
           <td class="govuk-table__cell"><%= zone.name %></td>
-          <td class="govuk-table__cell"><%= zone.forwarders.join(",") %></td>
+          <td class="govuk-table__cell"><%= zone.forwarders.join(',') %></td>
           <td class="govuk-table__cell"><%= zone.purpose %></td>
           <% if can? :manage, Subnet %>
             <td class="govuk-table__cell">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,17 +5,17 @@ Rails.application.routes.draw do
     match "sign_out", to: "devise/sessions#destroy", as: :destroy_user_session, via: [:get, :delete]
   end
 
-  resources :sites do
+  get "/dns", to: "zones#index", as: :dns
+  resources :zones, except: [:index]
+
+  get "/dhcp", to: "sites#index", as: :dhcp
+  resources :sites, except: [:index] do
     resources :subnets, only: [:new, :create]
   end
-
   resources :subnets, only: [:show, :edit, :update, :destroy] do
     resource :options, only: [:new, :create, :edit, :update, :destroy]
   end
-
-  resources :zones, only: [:index, :new, :create, :edit, :update, :destroy]
-
-  resources :global_options, only: [:index, :new, :create, :edit, :update, :destroy]
+  resources :global_options, only: [:index, :new, :create, :edit, :update, :destroy], path: "/global-options"
 
   get "/healthcheck", to: "monitoring#healthcheck"
 

--- a/spec/acceptance/create_global_options_spec.rb
+++ b/spec/acceptance/create_global_options_spec.rb
@@ -5,7 +5,7 @@ describe "create global options", type: :feature do
 
   context "when a user is not logged in" do
     it "it does not allow editing global_options" do
-      visit "/global_options/new"
+      visit "/global-options/new"
 
       expect(page).to have_content("You need to sign in or sign up before continuing.")
     end
@@ -17,11 +17,11 @@ describe "create global options", type: :feature do
     end
 
     it "does not allow editing global options" do
-      visit "/global_options"
+      visit "/global-options"
 
       expect(page).not_to have_content("Create global options")
 
-      visit "/global_options/new"
+      visit "/global-options/new"
 
       expect(page).to have_content("You are not authorized to access this page.")
     end
@@ -33,7 +33,7 @@ describe "create global options", type: :feature do
     end
 
     it "creates a new global option" do
-      visit "/global_options"
+      visit "/global-options"
 
       click_on "Create global options"
 
@@ -50,7 +50,7 @@ describe "create global options", type: :feature do
     end
 
     it "displays error if form cannot be submitted" do
-      visit "/global_options/new"
+      visit "/global-options/new"
 
       click_on "Create"
 

--- a/spec/acceptance/create_sites_spec.rb
+++ b/spec/acceptance/create_sites_spec.rb
@@ -15,7 +15,7 @@ describe "create sites", type: :feature do
     end
 
     it "does not allow creating sites" do
-      visit "/sites"
+      visit "/dhcp"
 
       expect(page).not_to have_content "Create a new site"
 
@@ -31,7 +31,7 @@ describe "create sites", type: :feature do
     end
 
     it "creates a new site" do
-      visit "/sites"
+      visit "/dhcp"
 
       click_on "Create a new site"
 
@@ -42,7 +42,7 @@ describe "create sites", type: :feature do
 
       click_on "Create"
 
-      expect(current_path).to eq("/sites")
+      expect(current_path).to eq("/dhcp")
 
       expect(page).to have_content("MYFITS101")
       expect(page).to have_content("My London Site")

--- a/spec/acceptance/create_zones_spec.rb
+++ b/spec/acceptance/create_zones_spec.rb
@@ -6,7 +6,7 @@ describe "create zones", type: :feature do
   end
 
   it "creates a new zone" do
-    visit "/zones"
+    visit "/dns"
 
     click_on "Create a new zone"
 
@@ -18,7 +18,7 @@ describe "create zones", type: :feature do
 
     click_button "Create"
 
-    expect(current_path).to eq("/zones")
+    expect(current_path).to eq("/dns")
 
     zone = Zone.last
     expect(zone.name).to eq "test.example.com"

--- a/spec/acceptance/delete_global_options_spec.rb
+++ b/spec/acceptance/delete_global_options_spec.rb
@@ -7,7 +7,7 @@ describe "delete gobal options", type: :feature do
 
   it "delete global options" do
     global_option = create :global_option
-    visit "/global_options"
+    visit "/global-options"
 
     click_on "Delete global options"
 

--- a/spec/acceptance/delete_sites_spec.rb
+++ b/spec/acceptance/delete_sites_spec.rb
@@ -7,7 +7,7 @@ describe "delete sites", type: :feature do
     end
 
     it "does not allow creating sites" do
-      visit "/sites"
+      visit "/dhcp"
 
       expect(page).not_to have_content "Delete"
     end
@@ -21,7 +21,7 @@ describe "delete sites", type: :feature do
     it "delete a site" do
       site = create(:site)
 
-      visit "/sites"
+      visit "/dhcp"
 
       click_on "Delete"
 
@@ -29,7 +29,7 @@ describe "delete sites", type: :feature do
 
       click_on "Delete site"
 
-      expect(current_path).to eq("/sites")
+      expect(current_path).to eq("/dhcp")
       expect(page).to have_content("Successfully deleted site")
       expect(page).not_to have_content(site.name)
     end

--- a/spec/acceptance/delete_zones_spec.rb
+++ b/spec/acceptance/delete_zones_spec.rb
@@ -8,7 +8,7 @@ describe "delete zones", type: :feature do
   it "delete a zone" do
     zone = create(:zone)
 
-    visit "/zones"
+    visit "/dns"
 
     click_on "Delete"
 
@@ -16,7 +16,7 @@ describe "delete zones", type: :feature do
 
     click_on "Delete zone"
 
-    expect(current_path).to eq("/zones")
+    expect(current_path).to eq("/dns")
     expect(page).to have_content("Successfully deleted zone")
     expect(page).not_to have_content(zone.name)
   end

--- a/spec/acceptance/show_site_spec.rb
+++ b/spec/acceptance/show_site_spec.rb
@@ -21,7 +21,7 @@ describe "showing a site", type: :feature do
       let!(:subnet3) { create :subnet }
 
       it "allows viewing sites and its subnets" do
-        visit "/sites"
+        visit "/dhcp"
 
         click_on "View", match: :first
 

--- a/spec/acceptance/update_global_options_spec.rb
+++ b/spec/acceptance/update_global_options_spec.rb
@@ -5,7 +5,7 @@ describe "update global options", type: :feature do
 
   context "when a user is not logged in" do
     it "it does not allow editing global options" do
-      visit "/global_options/#{global_option.id}/edit"
+      visit "/global-options/#{global_option.id}/edit"
 
       expect(page).to have_content("You need to sign in or sign up before continuing.")
     end
@@ -17,11 +17,11 @@ describe "update global options", type: :feature do
     end
 
     it "does not allow editing global options" do
-      visit "/global_options"
+      visit "/global-options"
 
       expect(page).not_to have_content("Edit global option")
 
-      visit "/global_options/#{global_option.id}/edit"
+      visit "/global-options/#{global_option.id}/edit"
 
       expect(page).to have_content("You are not authorized to access this page.")
     end
@@ -34,7 +34,7 @@ describe "update global options", type: :feature do
     end
 
     it "edits an existing global option" do
-      visit "/global_options"
+      visit "/global-options"
 
       expect(page).not_to have_content("Create global options")
       click_on "Edit global option"
@@ -56,7 +56,7 @@ describe "update global options", type: :feature do
     end
 
     it "displays error if form cannot be submitted" do
-      visit "/global_options/#{global_option.id}/edit"
+      visit "/global-options/#{global_option.id}/edit"
 
       fill_in "Routers", with: ""
 

--- a/spec/acceptance/update_sites_spec.rb
+++ b/spec/acceptance/update_sites_spec.rb
@@ -17,7 +17,7 @@ describe "update sites", type: :feature do
     end
 
     it "does not allow editing sites" do
-      visit "/sites"
+      visit "/dhcp"
 
       expect(page).not_to have_content "Edit"
 
@@ -33,7 +33,7 @@ describe "update sites", type: :feature do
     end
 
     it "update an existing site" do
-      visit "/sites"
+      visit "/dhcp"
 
       click_on "Edit"
 
@@ -45,7 +45,7 @@ describe "update sites", type: :feature do
 
       click_on "Update"
 
-      expect(current_path).to eq("/sites")
+      expect(current_path).to eq("/dhcp")
 
       expect(page).to have_content("MYFITS202")
       expect(page).to have_content("My Manchester Site")

--- a/spec/acceptance/update_zones_spec.rb
+++ b/spec/acceptance/update_zones_spec.rb
@@ -8,7 +8,7 @@ describe "update zones", type: :feature do
   end
 
   it "update an existing zone" do
-    visit "/zones"
+    visit "/dns"
 
     click_on "Edit"
 
@@ -22,7 +22,7 @@ describe "update zones", type: :feature do
 
     click_button "Update"
 
-    expect(current_path).to eq("/zones")
+    expect(current_path).to eq("/dns")
 
     expect(page).to have_content("test.example.com")
     expect(page).to have_content("127.0.0.2,127.0.0.1")

--- a/spec/acceptance/zones_spec.rb
+++ b/spec/acceptance/zones_spec.rb
@@ -9,7 +9,7 @@ describe "GET /zones", type: :feature do
     zone = create :zone
     zone2 = create :zone, name: "test.example.com"
 
-    visit "/zones"
+    visit "/dns"
     expect(page).to have_content zone.name
     expect(page).to have_content zone.forwarders.join(",")
     expect(page).to have_content zone.purpose
@@ -24,7 +24,7 @@ describe "GET /zones", type: :feature do
     end
 
     it "can see the zone management links" do
-      visit "/zones"
+      visit "/dns"
 
       expect(page).to_not have_content "Create a new zone"
       expect(page).to_not have_content "Edit"
@@ -39,7 +39,7 @@ describe "GET /zones", type: :feature do
     end
 
     it "can see the zone management links" do
-      visit "/zones"
+      visit "/dns"
 
       expect(page).to have_content "Create a new zone"
       expect(page).to have_content "Edit"


### PR DESCRIPTION
Add navigation menu to the header bar and provide a helper to add an active
class to for the active menu item. We need to manage submenu items also.

# What
Add a navigation menu for use throughout the admin portal

# Why
Our old navigation links don't really adher to the design system and isnt persisted beyond the homepage.

# Screenshots
<img width="992" alt="Screenshot 2020-10-12 at 15 08 15" src="https://user-images.githubusercontent.com/326561/95755829-c6857a80-0c9c-11eb-8c6f-662a21880994.png">

# Notes
Decided to avoid sub nav drop downs here for the time being. Global options can be linked from the top level sites page (although this may not be communicated very well at the moment. Perhaps there is a better option?). We may want to consider namespacing/scoping routes in the future to avoid url duplicates such as `/dhcp/global-configuration` and `/dns/global-configuration`. Its not required for this PR but worth considering for the future.

