### PR TITLE
Timeout user session after 5 minutes of inactivity

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,7 +1,8 @@
 class User < ApplicationRecord
   EDITOR_ROLE = "editor"
 
-  devise :omniauthable, omniauth_providers: Rails.env.development? ? %i[cognito developer] : %i[cognito]
+  devise :omniauthable, :timeoutable,
+    omniauth_providers: (Rails.env.development? ? %i[cognito developer] : %i[cognito])
 
   def self.from_omniauth(auth)
     user = find_or_initialize_by(provider: auth.provider, uid: auth.uid)

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -190,7 +190,7 @@ Devise.setup do |config|
   # ==> Configuration for :timeoutable
   # The time you want to timeout the user session without activity. After this
   # time the user will be asked for credentials again. Default is 30 minutes.
-  # config.timeout_in = 30.minutes
+  config.timeout_in = 5.minutes
 
   # ==> Configuration for :lockable
   # Defines which strategy will be used to lock an account.


### PR DESCRIPTION
# What
Timeout user session after 5 minutes of inactivity

# Why
To ensure users are logged out if they become inactive

# Screenshots

# Notes
