### PR TITLE
Basic audit logging

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,7 @@ gem "ipaddress_2"
 gem "aws-sdk-ecs", "~> 1.8"
 gem "cancancan", "~> 3.1"
 gem "sentry-raven"
+gem "audited"
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -60,6 +60,8 @@ GEM
       public_suffix (>= 2.0.2, < 5.0)
     ansi (1.5.0)
     ast (2.4.1)
+    audited (4.9.0)
+      activerecord (>= 4.2, < 6.1)
     aws-eventstream (1.1.0)
     aws-partitions (1.357.0)
     aws-sdk-core (3.104.3)
@@ -324,6 +326,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  audited
   aws-sdk-ecs (~> 1.8)
   aws-sdk-s3 (~> 1.73)
   bootsnap (>= 1.4.2)

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ serve: stop start-db
 
 test: export ENV=test
 test:
-	$(DOCKER_COMPOSE) run --rm app bundle exec rake
+	$(DOCKER_COMPOSE) run -e COVERAGE=true --rm app bundle exec rake
 
 shell:
 	$(DOCKER_COMPOSE) run --rm app sh

--- a/app/controllers/audits_controller.rb
+++ b/app/controllers/audits_controller.rb
@@ -1,0 +1,5 @@
+class AuditsController < ApplicationController
+  def index
+    @audits = Audit.all
+  end
+end

--- a/app/controllers/audits_controller.rb
+++ b/app/controllers/audits_controller.rb
@@ -1,5 +1,5 @@
 class AuditsController < ApplicationController
   def index
-    @audits = Audit.all
+    @audits = Audit.order(created_at: 'DESC').all
   end
 end

--- a/app/controllers/audits_controller.rb
+++ b/app/controllers/audits_controller.rb
@@ -1,5 +1,5 @@
 class AuditsController < ApplicationController
   def index
-    @audits = Audit.order(created_at: 'DESC').all
+    @audits = Audit.order(created_at: "DESC").all
   end
 end

--- a/app/models/audit.rb
+++ b/app/models/audit.rb
@@ -1,0 +1,4 @@
+# Always interact with our own Audit model rather than
+# using Audited's internal model
+class Audit < Audited::Audit
+end

--- a/app/models/global_option.rb
+++ b/app/models/global_option.rb
@@ -9,6 +9,8 @@ class GlobalOption < ApplicationRecord
 
   validate :only_one_record
 
+  audited
+
   def routers
     return [] unless self[:routers]
     self[:routers].split(",")

--- a/app/models/option.rb
+++ b/app/models/option.rb
@@ -8,6 +8,8 @@ class Option < ApplicationRecord
 
   validate :at_least_one_option
 
+  audited
+
   def routers
     return [] unless self[:routers]
     self[:routers].split(",")

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -3,4 +3,6 @@ class Site < ApplicationRecord
 
   validates :fits_id, presence: true, uniqueness: {case_sensitive: false}
   validates :name, presence: true, uniqueness: {case_sensitive: false}
+
+  audited
 end

--- a/app/models/subnet.rb
+++ b/app/models/subnet.rb
@@ -11,6 +11,8 @@ class Subnet < ApplicationRecord
   validate :cidr_block_is_a_valid_ipv4_subnet, :start_address_is_a_valid_ipv4_address,
     :end_address_is_a_valid_ipv4_address, :cidr_block_address_is_unique
 
+  audited
+
   delegate :routers,
     :domain_name_servers,
     :domain_name,

--- a/app/models/zone.rb
+++ b/app/models/zone.rb
@@ -7,6 +7,8 @@ class Zone < ApplicationRecord
 
   before_save { name.downcase! }
 
+  audited
+
   def forwarders
     return [] unless self[:forwarders]
     self[:forwarders].split(",")

--- a/app/views/audits/index.html.erb
+++ b/app/views/audits/index.html.erb
@@ -7,6 +7,7 @@
       <th scope="col" class="govuk-table__header">User</th>
       <th scope="col" class="govuk-table__header">Action</th>
       <th scope="col" class="govuk-table__header">Record</th>
+      <th scope="col" class="govuk-table__header">Datetime</th>
     </tr>
   </thead>
   <tbody class="govuk-table__body">
@@ -15,6 +16,7 @@
         <td class="govuk-table__cell"><%= audit.user_id %></td>
         <td class="govuk-table__cell"><%= audit.action %></td>
         <td class="govuk-table__cell"><%= audit.revision.model_name.human %></td>
+        <td class="govuk-table__cell"><%= audit.created_at.to_s(:long) %></td>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/audits/index.html.erb
+++ b/app/views/audits/index.html.erb
@@ -1,0 +1,21 @@
+<h2 class="govuk-heading-l">Audit Log</h2>
+
+<table class="govuk-table">
+  <caption class="govuk-table__caption">List of audited changes</caption>
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th scope="col" class="govuk-table__header">User</th>
+      <th scope="col" class="govuk-table__header">Action</th>
+      <th scope="col" class="govuk-table__header">Record</th>
+    </tr>
+  </thead>
+  <tbody class="govuk-table__body">
+    <% @audits.each do |audit| %>
+      <tr class="govuk-table__row">
+        <td class="govuk-table__cell"><%= audit.user_id %></td>
+        <td class="govuk-table__cell"><%= audit.action %></td>
+        <td class="govuk-table__cell"><%= audit.revision.model_name.human %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/layouts/_navigation.html.erb
+++ b/app/views/layouts/_navigation.html.erb
@@ -9,6 +9,10 @@
         <%= link_to "DHCP", dhcp_path, class: "govuk-header__link", data: { topnav: "DHCP" } %>
       </li>
 
+      <li class="govuk-header__navigation-item<%= selected_class_if_controller('audit_log') %>">
+        <%= link_to "Audit log", audits_path, class: "govuk-header__link", data: { topnav: "Audit log" } %>
+      </li>
+
       <li class="govuk-header__navigation-item">
         <%= link_to "Sign out", destroy_user_session_path, method: :delete, class: "govuk-header__link" %>
       </li>

--- a/config/initializers/audited.rb
+++ b/config/initializers/audited.rb
@@ -1,0 +1,5 @@
+Rails.application.config.to_prepare do
+  Audited.config do |config|
+    config.audit_class = Audit
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,8 @@ Rails.application.routes.draw do
   end
   resources :global_options, only: [:index, :new, :create, :edit, :update, :destroy], path: "/global-options"
 
+  resources :audits, only: [:index]
+
   get "/healthcheck", to: "monitoring#healthcheck"
 
   root "home#index"

--- a/db/migrate/20201014102047_install_audited.rb
+++ b/db/migrate/20201014102047_install_audited.rb
@@ -1,0 +1,30 @@
+class InstallAudited < ActiveRecord::Migration[6.0]
+  def self.up
+    create_table :audits, :force => true do |t|
+      t.column :auditable_id, :integer
+      t.column :auditable_type, :string
+      t.column :associated_id, :integer
+      t.column :associated_type, :string
+      t.column :user_id, :integer
+      t.column :user_type, :string
+      t.column :username, :string
+      t.column :action, :string
+      t.column :audited_changes, :json
+      t.column :version, :integer, :default => 0
+      t.column :comment, :string
+      t.column :remote_address, :string
+      t.column :request_uuid, :string
+      t.column :created_at, :datetime
+    end
+
+    add_index :audits, [:auditable_type, :auditable_id, :version], :name => 'auditable_index'
+    add_index :audits, [:associated_type, :associated_id], :name => 'associated_index'
+    add_index :audits, [:user_id, :user_type], :name => 'user_index'
+    add_index :audits, :request_uuid
+    add_index :audits, :created_at
+  end
+
+  def self.down
+    drop_table :audits
+  end
+end

--- a/db/migrate/20201014102047_install_audited.rb
+++ b/db/migrate/20201014102047_install_audited.rb
@@ -1,6 +1,6 @@
 class InstallAudited < ActiveRecord::Migration[6.0]
   def self.up
-    create_table :audits, :force => true do |t|
+    create_table :audits, force: true do |t|
       t.column :auditable_id, :integer
       t.column :auditable_type, :string
       t.column :associated_id, :integer
@@ -10,16 +10,16 @@ class InstallAudited < ActiveRecord::Migration[6.0]
       t.column :username, :string
       t.column :action, :string
       t.column :audited_changes, :json
-      t.column :version, :integer, :default => 0
+      t.column :version, :integer, default: 0
       t.column :comment, :string
       t.column :remote_address, :string
       t.column :request_uuid, :string
       t.column :created_at, :datetime
     end
 
-    add_index :audits, [:auditable_type, :auditable_id, :version], :name => 'auditable_index'
-    add_index :audits, [:associated_type, :associated_id], :name => 'associated_index'
-    add_index :audits, [:user_id, :user_type], :name => 'user_index'
+    add_index :audits, [:auditable_type, :auditable_id, :version], name: "auditable_index"
+    add_index :audits, [:associated_type, :associated_id], name: "associated_index"
+    add_index :audits, [:user_id, :user_type], name: "user_index"
     add_index :audits, :request_uuid
     add_index :audits, :created_at
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,6 +11,29 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema.define(version: 2020_10_14_104412) do
+
+  create_table "audits", options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
+    t.integer "auditable_id"
+    t.string "auditable_type"
+    t.integer "associated_id"
+    t.string "associated_type"
+    t.integer "user_id"
+    t.string "user_type"
+    t.string "username"
+    t.string "action"
+    t.json "audited_changes"
+    t.integer "version", default: 0
+    t.string "comment"
+    t.string "remote_address"
+    t.string "request_uuid"
+    t.datetime "created_at"
+    t.index ["associated_type", "associated_id"], name: "associated_index"
+    t.index ["auditable_type", "auditable_id", "version"], name: "auditable_index"
+    t.index ["created_at"], name: "index_audits_on_created_at"
+    t.index ["request_uuid"], name: "index_audits_on_request_uuid"
+    t.index ["user_id", "user_type"], name: "user_index"
+  end
+
   create_table "global_options", options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
     t.string "routers", null: false
     t.string "domain_name_servers", null: false
@@ -67,6 +90,5 @@ ActiveRecord::Schema.define(version: 2020_10_14_104412) do
     t.datetime "updated_at", precision: 6, null: false
   end
 
-  add_foreign_key "options", "subnets"
   add_foreign_key "subnets", "sites"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,6 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema.define(version: 2020_10_14_104412) do
-
   create_table "audits", options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
     t.integer "auditable_id"
     t.string "auditable_type"

--- a/spec/acceptance/create_global_options_spec.rb
+++ b/spec/acceptance/create_global_options_spec.rb
@@ -52,7 +52,7 @@ describe "create global options", type: :feature do
 
       click_on "Audit log"
 
-      expect(page).to have_content("#{editor.id}")
+      expect(page).to have_content(editor.id.to_s)
       expect(page).to have_content("create")
       expect(page).to have_content("Global option")
     end

--- a/spec/acceptance/create_global_options_spec.rb
+++ b/spec/acceptance/create_global_options_spec.rb
@@ -28,8 +28,10 @@ describe "create global options", type: :feature do
   end
 
   context "when a user is logged in as an editor" do
+    let(:editor) { User.create!(editor: true) }
+
     before do
-      login_as User.create!(editor: true)
+      login_as editor
     end
 
     it "creates a new global option" do
@@ -47,6 +49,12 @@ describe "create global options", type: :feature do
       expect(page).to have_content("10.0.1.0,10.0.1.2")
       expect(page).to have_content("10.0.2.1,10.0.2.2")
       expect(page).to have_content("test.example.com")
+
+      click_on "Audit log"
+
+      expect(page).to have_content("#{editor.id}")
+      expect(page).to have_content("create")
+      expect(page).to have_content("Global option")
     end
 
     it "displays error if form cannot be submitted" do

--- a/spec/acceptance/create_options_spec.rb
+++ b/spec/acceptance/create_options_spec.rb
@@ -28,9 +28,12 @@ describe "create options", type: :feature do
   end
 
   context "when a user is logged in as an editor" do
+    let(:editor) { User.create!(editor: true) }
+
     before do
-      login_as User.create!(editor: true)
+      login_as editor
     end
+
 
     it "creates a new subnet option" do
       visit "/subnets/#{subnet.to_param}"
@@ -51,6 +54,12 @@ describe "create options", type: :feature do
       expect(page).to have_content("10.0.1.0,10.0.1.2")
       expect(page).to have_content("10.0.2.1,10.0.2.2")
       expect(page).to have_content("test.example.com")
+
+      click_on "Audit log"
+
+      expect(page).to have_content("#{editor.id}")
+      expect(page).to have_content("create")
+      expect(page).to have_content("Option")
     end
 
     it "displays error if form cannot be submitted" do

--- a/spec/acceptance/create_options_spec.rb
+++ b/spec/acceptance/create_options_spec.rb
@@ -34,7 +34,6 @@ describe "create options", type: :feature do
       login_as editor
     end
 
-
     it "creates a new subnet option" do
       visit "/subnets/#{subnet.to_param}"
 
@@ -57,7 +56,7 @@ describe "create options", type: :feature do
 
       click_on "Audit log"
 
-      expect(page).to have_content("#{editor.id}")
+      expect(page).to have_content(editor.id.to_s)
       expect(page).to have_content("create")
       expect(page).to have_content("Option")
     end

--- a/spec/acceptance/create_sites_spec.rb
+++ b/spec/acceptance/create_sites_spec.rb
@@ -26,8 +26,10 @@ describe "create sites", type: :feature do
   end
 
   context "when the user is an editor" do
+    let(:editor) { User.create!(editor: true) }
+
     before do
-      login_as User.create!(editor: true)
+      login_as editor
     end
 
     it "creates a new site" do
@@ -46,6 +48,12 @@ describe "create sites", type: :feature do
 
       expect(page).to have_content("MYFITS101")
       expect(page).to have_content("My London Site")
+
+      click_on "Audit log"
+
+      expect(page).to have_content("#{editor.id}")
+      expect(page).to have_content("create")
+      expect(page).to have_content("Site")
     end
 
     it "displays error if form cannot be submitted" do

--- a/spec/acceptance/create_sites_spec.rb
+++ b/spec/acceptance/create_sites_spec.rb
@@ -51,7 +51,7 @@ describe "create sites", type: :feature do
 
       click_on "Audit log"
 
-      expect(page).to have_content("#{editor.id}")
+      expect(page).to have_content(editor.id.to_s)
       expect(page).to have_content("create")
       expect(page).to have_content("Site")
     end

--- a/spec/acceptance/create_subnets_spec.rb
+++ b/spec/acceptance/create_subnets_spec.rb
@@ -1,9 +1,12 @@
 require "rails_helper"
 
 describe "create subnets", type: :feature do
+  let(:editor) { User.create!(editor: true) }
+
   before do
-    login_as User.create!(editor: true)
+    login_as editor
   end
+
 
   it "creates a new subnet" do
     site = create :site
@@ -24,6 +27,12 @@ describe "create subnets", type: :feature do
     expect(page).to have_content("10.0.1.0/24")
     expect(page).to have_content("10.0.1.1")
     expect(page).to have_content("10.0.1.255")
+
+    click_on "Audit log"
+
+    expect(page).to have_content("#{editor.id}")
+    expect(page).to have_content("create")
+    expect(page).to have_content("Subnet")
   end
 
   it "displays error if form cannot be submitted" do

--- a/spec/acceptance/create_subnets_spec.rb
+++ b/spec/acceptance/create_subnets_spec.rb
@@ -7,7 +7,6 @@ describe "create subnets", type: :feature do
     login_as editor
   end
 
-
   it "creates a new subnet" do
     site = create :site
     visit "/sites/#{site.to_param}"
@@ -30,7 +29,7 @@ describe "create subnets", type: :feature do
 
     click_on "Audit log"
 
-    expect(page).to have_content("#{editor.id}")
+    expect(page).to have_content(editor.id.to_s)
     expect(page).to have_content("create")
     expect(page).to have_content("Subnet")
   end

--- a/spec/acceptance/create_zones_spec.rb
+++ b/spec/acceptance/create_zones_spec.rb
@@ -7,7 +7,6 @@ describe "create zones", type: :feature do
     login_as editor
   end
 
-
   it "creates a new zone" do
     visit "/dns"
 
@@ -30,7 +29,7 @@ describe "create zones", type: :feature do
 
     click_on "Audit log"
 
-    expect(page).to have_content("#{editor.id}")
+    expect(page).to have_content(editor.id.to_s)
     expect(page).to have_content("create")
     expect(page).to have_content("Zone")
   end

--- a/spec/acceptance/create_zones_spec.rb
+++ b/spec/acceptance/create_zones_spec.rb
@@ -1,9 +1,12 @@
 require "rails_helper"
 
 describe "create zones", type: :feature do
+  let(:editor) { User.create!(editor: true) }
+
   before do
-    login_as User.create!(editor: true)
+    login_as editor
   end
+
 
   it "creates a new zone" do
     visit "/dns"
@@ -24,6 +27,12 @@ describe "create zones", type: :feature do
     expect(zone.name).to eq "test.example.com"
     expect(zone.forwarders).to eq ["10.1.1.25", "10.1.1.28"]
     expect(zone.purpose).to eq "Frontend Driven Test"
+
+    click_on "Audit log"
+
+    expect(page).to have_content("#{editor.id}")
+    expect(page).to have_content("create")
+    expect(page).to have_content("Zone")
   end
 
   it "displays error if form cannot be submitted" do

--- a/spec/acceptance/delete_global_options_spec.rb
+++ b/spec/acceptance/delete_global_options_spec.rb
@@ -22,7 +22,7 @@ describe "delete gobal options", type: :feature do
 
     click_on "Audit log"
 
-    expect(page).to have_content("#{editor.id}")
+    expect(page).to have_content(editor.id.to_s)
     expect(page).to have_content("destroy")
     expect(page).to have_content("Global option")
   end

--- a/spec/acceptance/delete_global_options_spec.rb
+++ b/spec/acceptance/delete_global_options_spec.rb
@@ -1,8 +1,10 @@
 require "rails_helper"
 
 describe "delete gobal options", type: :feature do
+  let(:editor) { User.create!(editor: true) }
+
   before do
-    login_as User.create!(editor: true)
+    login_as editor
   end
 
   it "delete global options" do
@@ -17,5 +19,11 @@ describe "delete gobal options", type: :feature do
 
     expect(page).to have_content("Successfully deleted global options")
     expect(page).not_to have_content(global_option.domain_name)
+
+    click_on "Audit log"
+
+    expect(page).to have_content("#{editor.id}")
+    expect(page).to have_content("destroy")
+    expect(page).to have_content("Global option")
   end
 end

--- a/spec/acceptance/delete_options_spec.rb
+++ b/spec/acceptance/delete_options_spec.rb
@@ -26,7 +26,7 @@ describe "delete options", type: :feature do
 
     click_on "Audit log"
 
-    expect(page).to have_content("#{editor.id}")
+    expect(page).to have_content(editor.id.to_s)
     expect(page).to have_content("destroy")
     expect(page).to have_content("Option")
   end

--- a/spec/acceptance/delete_options_spec.rb
+++ b/spec/acceptance/delete_options_spec.rb
@@ -3,9 +3,10 @@ require "rails_helper"
 describe "delete options", type: :feature do
   let(:option) { create :option }
   let(:subnet) { option.subnet }
+  let(:editor) { User.create!(editor: true) }
 
   before do
-    login_as User.create!(editor: true)
+    login_as editor
   end
 
   it "delete an option" do
@@ -22,5 +23,11 @@ describe "delete options", type: :feature do
 
     expect(page).to have_content("Successfully deleted option")
     expect(page).not_to have_content(option.domain_name)
+
+    click_on "Audit log"
+
+    expect(page).to have_content("#{editor.id}")
+    expect(page).to have_content("destroy")
+    expect(page).to have_content("Option")
   end
 end

--- a/spec/acceptance/delete_sites_spec.rb
+++ b/spec/acceptance/delete_sites_spec.rb
@@ -14,8 +14,10 @@ describe "delete sites", type: :feature do
   end
 
   context "when the user is an editor" do
+    let(:editor) { User.create!(editor: true) }
+
     before do
-      login_as User.create!(editor: true)
+      login_as editor
     end
 
     it "delete a site" do
@@ -32,6 +34,12 @@ describe "delete sites", type: :feature do
       expect(current_path).to eq("/dhcp")
       expect(page).to have_content("Successfully deleted site")
       expect(page).not_to have_content(site.name)
+
+      click_on "Audit log"
+
+      expect(page).to have_content("#{editor.id}")
+      expect(page).to have_content("destroy")
+      expect(page).to have_content("Site")
     end
   end
 end

--- a/spec/acceptance/delete_sites_spec.rb
+++ b/spec/acceptance/delete_sites_spec.rb
@@ -37,7 +37,7 @@ describe "delete sites", type: :feature do
 
       click_on "Audit log"
 
-      expect(page).to have_content("#{editor.id}")
+      expect(page).to have_content(editor.id.to_s)
       expect(page).to have_content("destroy")
       expect(page).to have_content("Site")
     end

--- a/spec/acceptance/delete_subnets_spec.rb
+++ b/spec/acceptance/delete_subnets_spec.rb
@@ -1,8 +1,10 @@
 require "rails_helper"
 
 describe "delete subnets", type: :feature do
+  let(:editor) { User.create!(editor: true) }
+
   before do
-    login_as User.create!(editor: true)
+    login_as editor
   end
 
   it "delete a subnet" do
@@ -18,5 +20,11 @@ describe "delete subnets", type: :feature do
 
     expect(page).to have_content("Successfully deleted subnet")
     expect(page).not_to have_content(subnet.cidr_block)
+
+    click_on "Audit log"
+
+    expect(page).to have_content("#{editor.id}")
+    expect(page).to have_content("destroy")
+    expect(page).to have_content("Subnet")
   end
 end

--- a/spec/acceptance/delete_subnets_spec.rb
+++ b/spec/acceptance/delete_subnets_spec.rb
@@ -23,7 +23,7 @@ describe "delete subnets", type: :feature do
 
     click_on "Audit log"
 
-    expect(page).to have_content("#{editor.id}")
+    expect(page).to have_content(editor.id.to_s)
     expect(page).to have_content("destroy")
     expect(page).to have_content("Subnet")
   end

--- a/spec/acceptance/delete_zones_spec.rb
+++ b/spec/acceptance/delete_zones_spec.rb
@@ -1,8 +1,10 @@
 require "rails_helper"
 
 describe "delete zones", type: :feature do
+  let(:editor) { User.create!(editor: true) }
+
   before do
-    login_as User.create!(editor: true)
+    login_as editor
   end
 
   it "delete a zone" do
@@ -19,5 +21,11 @@ describe "delete zones", type: :feature do
     expect(current_path).to eq("/dns")
     expect(page).to have_content("Successfully deleted zone")
     expect(page).not_to have_content(zone.name)
+
+    click_on "Audit log"
+
+    expect(page).to have_content("#{editor.id}")
+    expect(page).to have_content("destroy")
+    expect(page).to have_content("Zone")
   end
 end

--- a/spec/acceptance/delete_zones_spec.rb
+++ b/spec/acceptance/delete_zones_spec.rb
@@ -24,7 +24,7 @@ describe "delete zones", type: :feature do
 
     click_on "Audit log"
 
-    expect(page).to have_content("#{editor.id}")
+    expect(page).to have_content(editor.id.to_s)
     expect(page).to have_content("destroy")
     expect(page).to have_content("Zone")
   end

--- a/spec/acceptance/update_global_options_spec.rb
+++ b/spec/acceptance/update_global_options_spec.rb
@@ -28,8 +28,10 @@ describe "update global options", type: :feature do
   end
 
   context "when a user is logged in as an editor" do
+    let(:editor) { User.create!(editor: true) }
+
     before do
-      login_as User.create!(editor: true)
+      login_as editor
       global_option
     end
 
@@ -53,6 +55,12 @@ describe "update global options", type: :feature do
       expect(page).to have_content("10.0.1.1,10.0.1.3")
       expect(page).to have_content("10.0.2.2,10.0.2.3")
       expect(page).to have_content("testier.example.com")
+
+      click_on "Audit log"
+
+      expect(page).to have_content("#{editor.id}")
+      expect(page).to have_content("update")
+      expect(page).to have_content("Global option")
     end
 
     it "displays error if form cannot be submitted" do

--- a/spec/acceptance/update_global_options_spec.rb
+++ b/spec/acceptance/update_global_options_spec.rb
@@ -58,7 +58,7 @@ describe "update global options", type: :feature do
 
       click_on "Audit log"
 
-      expect(page).to have_content("#{editor.id}")
+      expect(page).to have_content(editor.id.to_s)
       expect(page).to have_content("update")
       expect(page).to have_content("Global option")
     end

--- a/spec/acceptance/update_options_spec.rb
+++ b/spec/acceptance/update_options_spec.rb
@@ -29,8 +29,10 @@ describe "update options", type: :feature do
   end
 
   context "when a user is logged in as an editor" do
+    let(:editor) { User.create!(editor: true) }
+
     before do
-      login_as User.create!(editor: true)
+      login_as editor
     end
 
     it "edits an existing option" do
@@ -56,6 +58,12 @@ describe "update options", type: :feature do
       expect(page).to have_content("10.0.1.1,10.0.1.3")
       expect(page).to have_content("10.0.2.2,10.0.2.3")
       expect(page).to have_content("testier.example.com")
+
+      click_on "Audit log"
+
+      expect(page).to have_content("#{editor.id}")
+      expect(page).to have_content("update")
+      expect(page).to have_content("Option")
     end
 
     it "displays error if form cannot be submitted" do

--- a/spec/acceptance/update_options_spec.rb
+++ b/spec/acceptance/update_options_spec.rb
@@ -61,7 +61,7 @@ describe "update options", type: :feature do
 
       click_on "Audit log"
 
-      expect(page).to have_content("#{editor.id}")
+      expect(page).to have_content(editor.id.to_s)
       expect(page).to have_content("update")
       expect(page).to have_content("Option")
     end

--- a/spec/acceptance/update_sites_spec.rb
+++ b/spec/acceptance/update_sites_spec.rb
@@ -28,8 +28,10 @@ describe "update sites", type: :feature do
   end
 
   context "when the user is an editor" do
+    let(:editor) { User.create!(editor: true) }
+
     before do
-      login_as User.create!(editor: true)
+      login_as editor
     end
 
     it "update an existing site" do
@@ -49,6 +51,12 @@ describe "update sites", type: :feature do
 
       expect(page).to have_content("MYFITS202")
       expect(page).to have_content("My Manchester Site")
+
+      click_on "Audit log"
+
+      expect(page).to have_content("#{editor.id}")
+      expect(page).to have_content("update")
+      expect(page).to have_content("Site")
     end
   end
 end

--- a/spec/acceptance/update_sites_spec.rb
+++ b/spec/acceptance/update_sites_spec.rb
@@ -54,7 +54,7 @@ describe "update sites", type: :feature do
 
       click_on "Audit log"
 
-      expect(page).to have_content("#{editor.id}")
+      expect(page).to have_content(editor.id.to_s)
       expect(page).to have_content("update")
       expect(page).to have_content("Site")
     end

--- a/spec/acceptance/update_subnets_spec.rb
+++ b/spec/acceptance/update_subnets_spec.rb
@@ -31,7 +31,7 @@ describe "update subnets", type: :feature do
 
     click_on "Audit log"
 
-    expect(page).to have_content("#{editor.id}")
+    expect(page).to have_content(editor.id.to_s)
     expect(page).to have_content("update")
     expect(page).to have_content("Subnet")
   end

--- a/spec/acceptance/update_subnets_spec.rb
+++ b/spec/acceptance/update_subnets_spec.rb
@@ -2,9 +2,10 @@ require "rails_helper"
 
 describe "update subnets", type: :feature do
   let!(:subnet) { create(:subnet) }
+  let(:editor) { User.create!(editor: true) }
 
   before do
-    login_as User.create!(editor: true)
+    login_as editor
   end
 
   it "update an existing subnet" do
@@ -27,5 +28,11 @@ describe "update subnets", type: :feature do
     expect(page).to have_content("10.1.1.0/24")
     expect(page).to have_content("10.1.1.1")
     expect(page).to have_content("10.1.1.255")
+
+    click_on "Audit log"
+
+    expect(page).to have_content("#{editor.id}")
+    expect(page).to have_content("update")
+    expect(page).to have_content("Subnet")
   end
 end

--- a/spec/acceptance/update_zones_spec.rb
+++ b/spec/acceptance/update_zones_spec.rb
@@ -2,9 +2,10 @@ require "rails_helper"
 
 describe "update zones", type: :feature do
   let!(:zone) { create(:zone) }
+  let(:editor) { User.create!(editor: true) }
 
   before do
-    login_as User.create!(editor: true)
+    login_as editor
   end
 
   it "update an existing zone" do
@@ -27,6 +28,12 @@ describe "update zones", type: :feature do
     expect(page).to have_content("test.example.com")
     expect(page).to have_content("127.0.0.2,127.0.0.1")
     expect(page).to have_content("UI Testing for Updating")
+
+    click_on "Audit log"
+
+    expect(page).to have_content("#{editor.id}")
+    expect(page).to have_content("update")
+    expect(page).to have_content("Zone")
   end
 
   it "displays error if form cannot be submitted" do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -2,7 +2,7 @@
 require "simplecov"
 require "simplecov-console"
 SimpleCov.formatter = SimpleCov::Formatter::Console
-SimpleCov.start "rails"
+SimpleCov.start "rails" if ENV["COVERAGE"]
 
 require "spec_helper"
 ENV["RAILS_ENV"] ||= "test"


### PR DESCRIPTION
# What
Add basic audit logging to all DNS/DHCP models. Whenever a change is made to these records the audit log will be updated with an extensive list of what the attributes changed from and to. 

# Why
Auditing is required to provide traceability of changes over time made by specific users.

# Screenshots
<img width="1005" alt="Screenshot 2020-10-14 at 14 58 44" src="https://user-images.githubusercontent.com/326561/96000280-a38ad000-0e2e-11eb-93d8-b981678f28f9.png">

# Notes
Currently the audit log only stores a record of the user's id. This essantially gives us audits based on a users session. Our database holds no personally identifiable information, however users can be inferred by tracing the `User#id` back to an Azure / Cognito tenant. If a user is deleted from our database, the link between the audit trail and and Azure tenant will be lost. 

We may also need to consider making it easier for users to reconcile a users id to an Azure tenant. 

Viewing the Audit log is not paginated. If the audit log gets large enough we will need to add pagination. We may also need to consider the lifetime of our audit trail should database tables begin to get out of hand.

