### PR TITLE
Implement 8 hour session timeout

### DIFF
--- a/app/lib/devise/models/hard_timeoutable.rb
+++ b/app/lib/devise/models/hard_timeoutable.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module Devise
+  module Models
+    # HardTimeoutable ensures that users are not signed in for longer then the max
+    # sign in duration. When a user has been signed in for longer then configured duration,
+    # the user will be asked for credentials again.
+
+    # It requires the following columns:
+    #
+    # * current_sign_in_at - A timestamp updated when the user signs in
+    #                        This comes from the trackable module
+    #
+    # == Options
+    #
+    # HardTimeoutable adds the following options to devise_for:
+    #
+    #   * +hard_timeout_in+: the interval to timeout the user session after sign in
+    #
+    # == Examples
+    #
+    #   user.hard_timedout?
+    #
+    module HardTimeoutable
+      extend ActiveSupport::Concern
+
+      def self.required_fields(klass)
+        [:current_sign_in_at]
+      end
+
+      # Checks whether the user session has expired based on configured time.
+      def hard_timedout?
+        hard_timeout_in.present? && current_sign_in_at.present? && current_sign_in_at <= hard_timeout_in.ago
+      end
+
+      def hard_timeout_in
+        self.class.hard_timeout_in
+      end
+
+      private
+
+      module ClassMethods
+        Devise::Models.config(self, :hard_timeout_in)
+      end
+    end
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,9 +1,11 @@
 class User < ApplicationRecord
   EDITOR_ROLE = "editor"
 
-  devise :omniauthable, :timeoutable, :trackable,
-         omniauth_providers: (Rails.env.development? ? %i[cognito developer] : %i[cognito])
+  MAX_SESSION_TIME = 8.hours
 
+  devise :omniauthable, :timeoutable, :trackable, :hard_timeoutable,
+    omniauth_providers: (Rails.env.development? ? %i[cognito developer] : %i[cognito]),
+    hard_timeout_in: MAX_SESSION_TIME
 
   def self.from_omniauth(auth)
     user = find_or_initialize_by(provider: auth.provider, uid: auth.uid)
@@ -21,6 +23,8 @@ class User < ApplicationRecord
 
   protected
 
+  # Method called by devise Trackable module to track IPs
+  # Removing this method will result in IPs being logged in the user table
   def extract_ip_from(request)
     # Skip IP logging in Trackable module
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,8 +1,9 @@
 class User < ApplicationRecord
   EDITOR_ROLE = "editor"
 
-  devise :omniauthable, :timeoutable,
-    omniauth_providers: (Rails.env.development? ? %i[cognito developer] : %i[cognito])
+  devise :omniauthable, :timeoutable, :trackable,
+         omniauth_providers: (Rails.env.development? ? %i[cognito developer] : %i[cognito])
+
 
   def self.from_omniauth(auth)
     user = find_or_initialize_by(provider: auth.provider, uid: auth.uid)
@@ -16,5 +17,11 @@ class User < ApplicationRecord
     user.editor = true
     user.save
     user
+  end
+
+  protected
+
+  def extract_ip_from(request)
+    # Skip IP logging in Trackable module
   end
 end

--- a/db/migrate/20201014104412_add_devise_trackable_to_users.rb
+++ b/db/migrate/20201014104412_add_devise_trackable_to_users.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class AddDeviseTrackableToUsers < ActiveRecord::Migration[6.0]
+  def change
+    ## Devise Trackable columns
+    add_column :users, :sign_in_count, :integer, default: 0, null: false
+    add_column :users, :current_sign_in_at, :datetime
+    add_column :users, :last_sign_in_at, :datetime
+    add_column :users, :current_sign_in_ip, :string
+    add_column :users, :last_sign_in_ip, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_12_115948) do
+ActiveRecord::Schema.define(version: 2020_10_14_104412) do
   create_table "global_options", options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
     t.string "routers", null: false
     t.string "domain_name_servers", null: false
@@ -52,6 +52,11 @@ ActiveRecord::Schema.define(version: 2020_10_12_115948) do
     t.string "provider"
     t.string "uid"
     t.boolean "editor", default: false
+    t.integer "sign_in_count", default: 0, null: false
+    t.datetime "current_sign_in_at"
+    t.datetime "last_sign_in_at"
+    t.string "current_sign_in_ip"
+    t.string "last_sign_in_ip"
   end
 
   create_table "zones", options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|

--- a/spec/acceptance/sign_in_spec.rb
+++ b/spec/acceptance/sign_in_spec.rb
@@ -25,4 +25,24 @@ RSpec.describe "GET /sign_in", type: :feature do
       expect(page).to have_content "DHCP / DNS Admin portal"
     end
   end
+
+  context "user signed in for more than 8 hours" do
+    let(:user) { User.create! }
+
+    before do
+      login_as user
+
+      visit "/"
+      expect(current_path).to eq "/"
+    end
+
+    it "signs the user out" do
+      user.update!(current_sign_in_at: 10.hours.ago)
+
+      visit "/"
+
+      expect(current_path).to eq "/sign_in"
+      expect(page).to have_content "Sign in"
+    end
+  end
 end


### PR DESCRIPTION
# What
Ensures that a user session cannot be longer than 8 hours

# Why
To follow OWASP guidance on session management (https://cheatsheetseries.owasp.org/cheatsheets/Session_Management_Cheat_Sheet.html#session-expiration) and limit how long an attacker could use a hijacked session.

# Screenshots

# Notes
