### PR TITLE
Update hard timeoutable module to use session to store timestamp

### DIFF
--- a/app/lib/devise/models/hard_timeoutable.rb
+++ b/app/lib/devise/models/hard_timeoutable.rb
@@ -5,11 +5,6 @@ module Devise
     # HardTimeoutable ensures that users are not signed in for longer then the max
     # sign in duration. When a user has been signed in for longer then configured duration,
     # the user will be asked for credentials again.
-
-    # It requires the following columns:
-    #
-    # * current_sign_in_at - A timestamp updated when the user signs in
-    #                        This comes from the trackable module
     #
     # == Options
     #
@@ -25,12 +20,12 @@ module Devise
       extend ActiveSupport::Concern
 
       def self.required_fields(klass)
-        [:current_sign_in_at]
+        []
       end
 
       # Checks whether the user session has expired based on configured time.
-      def hard_timedout?
-        hard_timeout_in.present? && current_sign_in_at.present? && current_sign_in_at <= hard_timeout_in.ago
+      def hard_timedout?(signed_in_at)
+        hard_timeout_in.present? && signed_in_at.present? && signed_in_at <= hard_timeout_in.ago
       end
 
       def hard_timeout_in

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,7 +3,7 @@ class User < ApplicationRecord
 
   MAX_SESSION_TIME = 8.hours
 
-  devise :omniauthable, :timeoutable, :trackable, :hard_timeoutable,
+  devise :omniauthable, :timeoutable, :hard_timeoutable,
     omniauth_providers: (Rails.env.development? ? %i[cognito developer] : %i[cognito]),
     hard_timeout_in: MAX_SESSION_TIME
 
@@ -19,13 +19,5 @@ class User < ApplicationRecord
     user.editor = true
     user.save
     user
-  end
-
-  protected
-
-  # Method called by devise Trackable module to track IPs
-  # Removing this method will result in IPs being logged in the user table
-  def extract_ip_from(request)
-    # Skip IP logging in Trackable module
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,8 +3,9 @@ class User < ApplicationRecord
 
   MAX_SESSION_TIME = 8.hours
 
-  devise :omniauthable, :timeoutable, :trackable,
-    omniauth_providers: (Rails.env.development? ? %i[cognito developer] : %i[cognito])
+  devise :omniauthable, :timeoutable, :trackable, :hard_timeoutable,
+    omniauth_providers: (Rails.env.development? ? %i[cognito developer] : %i[cognito]),
+    hard_timeout_in: MAX_SESSION_TIME
 
   def self.from_omniauth(auth)
     user = find_or_initialize_by(provider: auth.provider, uid: auth.uid)

--- a/db/migrate/20201016101903_remove_devise_trackable_from_users.rb
+++ b/db/migrate/20201016101903_remove_devise_trackable_from_users.rb
@@ -1,0 +1,10 @@
+class RemoveDeviseTrackableFromUsers < ActiveRecord::Migration[6.0]
+  def change
+    ## Devise Trackable columns
+    remove_column :users, :sign_in_count, :integer, default: 0, null: false
+    remove_column :users, :current_sign_in_at, :datetime
+    remove_column :users, :last_sign_in_at, :datetime
+    remove_column :users, :current_sign_in_ip, :string
+    remove_column :users, :last_sign_in_ip, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_14_104412) do
-
+ActiveRecord::Schema.define(version: 2020_10_16_101903) do
   create_table "audits", options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
     t.integer "auditable_id"
     t.string "auditable_type"
@@ -75,11 +74,6 @@ ActiveRecord::Schema.define(version: 2020_10_14_104412) do
     t.string "provider"
     t.string "uid"
     t.boolean "editor", default: false
-    t.integer "sign_in_count", default: 0, null: false
-    t.datetime "current_sign_in_at"
-    t.datetime "last_sign_in_at"
-    t.string "current_sign_in_ip"
-    t.string "last_sign_in_ip"
   end
 
   create_table "zones", options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|

--- a/spec/acceptance/sign_in_spec.rb
+++ b/spec/acceptance/sign_in_spec.rb
@@ -1,4 +1,5 @@
 require "rails_helper"
+include ActiveSupport::Testing::TimeHelpers
 
 RSpec.describe "GET /sign_in", type: :feature do
   it "displays sign in when not signed in" do
@@ -26,7 +27,7 @@ RSpec.describe "GET /sign_in", type: :feature do
     end
   end
 
-  xcontext "user signed in for more than 8 hours" do
+  context "user signed in for more than 8 hours" do
     let(:user) { User.create! }
 
     before do
@@ -37,7 +38,7 @@ RSpec.describe "GET /sign_in", type: :feature do
     end
 
     it "signs the user out" do
-      user.update!(current_sign_in_at: 10.hours.ago)
+      travel_to 10.hours.from_now
 
       visit "/"
 


### PR DESCRIPTION
# What
Uses a timestamp stored in the session to handle the hard timeout and removes the dependency on the trackable module

# Why
The dependancy on the trackable module was resulting in a bug caused by the order in which the warden callbacks ran for each module. This change makes the hard timeoutable module self sufficient.

# Screenshots

# Notes
