### PR TITLE
Configure lease http query api

### DIFF
--- a/app/lib/use_cases/generate_kea_config.rb
+++ b/app/lib/use_cases/generate_kea_config.rb
@@ -133,6 +133,11 @@ module UseCases
               ],
               severity: "DEBUG"
             }
+          ],
+          "hooks-libraries": [
+            {
+              "library": "/usr/lib/kea/hooks/libdhcp_lease_cmds.so"
+            }
           ]
         }.merge(global_options_config)
       }

--- a/app/lib/use_cases/generate_kea_config.rb
+++ b/app/lib/use_cases/generate_kea_config.rb
@@ -113,8 +113,8 @@ module UseCases
             port: 3306
           },
           "control-socket": {
-              "socket-type": "unix",
-              "socket-name": "/tmp/dhcp4-socket"
+            "socket-type": "unix",
+            "socket-name": "/tmp/dhcp4-socket"
           },
           subnet4: [
             {

--- a/app/lib/use_cases/generate_kea_config.rb
+++ b/app/lib/use_cases/generate_kea_config.rb
@@ -112,6 +112,10 @@ module UseCases
             host: "<DB_HOST>",
             port: 3306
           },
+          "control-socket": {
+              "socket-type": "unix",
+              "socket-name": "/tmp/dhcp4-socket"
+          },
           subnet4: [
             {
               pools: [


### PR DESCRIPTION
# What
Add control socket and leases configuration to Kea config

# Why
So that the kea control agent is configured to connect to the dhcp server and allows requesting of leases 
