### PR TITLE
Add a show Audit page

### DIFF
--- a/app/controllers/audits_controller.rb
+++ b/app/controllers/audits_controller.rb
@@ -2,4 +2,8 @@ class AuditsController < ApplicationController
   def index
     @audits = Audit.order(created_at: "DESC").all
   end
+
+  def show
+    @audit = Audit.find(params[:id])
+  end
 end

--- a/app/views/audits/index.html.erb
+++ b/app/views/audits/index.html.erb
@@ -8,6 +8,7 @@
       <th scope="col" class="govuk-table__header">Action</th>
       <th scope="col" class="govuk-table__header">Record</th>
       <th scope="col" class="govuk-table__header">Datetime</th>
+      <th scope="col" class="govuk-table__header"><span class="govuk-visually-hidden">Actions</span></th>
     </tr>
   </thead>
   <tbody class="govuk-table__body">
@@ -17,6 +18,7 @@
         <td class="govuk-table__cell"><%= audit.action %></td>
         <td class="govuk-table__cell"><%= audit.revision.model_name.human %></td>
         <td class="govuk-table__cell"><%= audit.created_at.to_s(:long) %></td>
+        <td class="govuk-table__cell"><%= link_to "Details", audit_path(audit), class: "govuk-link" %></td>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/audits/index.html.erb
+++ b/app/views/audits/index.html.erb
@@ -16,7 +16,7 @@
       <tr class="govuk-table__row">
         <td class="govuk-table__cell"><%= audit.user_id %></td>
         <td class="govuk-table__cell"><%= audit.action %></td>
-        <td class="govuk-table__cell"><%= link_to audit.revision.model_name.human, audit.auditable %></td>
+        <td class="govuk-table__cell"><%= link_to audit.auditable_type, audit.auditable %></td>
         <td class="govuk-table__cell"><%= audit.created_at.to_s(:long) %></td>
         <td class="govuk-table__cell"><%= link_to "Details", audit_path(audit), class: "govuk-link" %></td>
       </tr>

--- a/app/views/audits/index.html.erb
+++ b/app/views/audits/index.html.erb
@@ -16,7 +16,7 @@
       <tr class="govuk-table__row">
         <td class="govuk-table__cell"><%= audit.user_id %></td>
         <td class="govuk-table__cell"><%= audit.action %></td>
-        <td class="govuk-table__cell"><%= audit.revision.model_name.human %></td>
+        <td class="govuk-table__cell"><%= link_to audit.revision.model_name.human, audit.auditable %></td>
         <td class="govuk-table__cell"><%= audit.created_at.to_s(:long) %></td>
         <td class="govuk-table__cell"><%= link_to "Details", audit_path(audit), class: "govuk-link" %></td>
       </tr>

--- a/app/views/audits/show.html.erb
+++ b/app/views/audits/show.html.erb
@@ -14,7 +14,7 @@
       Record
     </dt>
     <dd class="govuk-summary-list__value">
-      <%= @audit.revision.model_name.human %>
+      <%= link_to @audit.revision.model_name.human, @audit.auditable %>
     </dd>
   </div>
   <div class="govuk-summary-list__row">

--- a/app/views/audits/show.html.erb
+++ b/app/views/audits/show.html.erb
@@ -1,0 +1,45 @@
+<h2 class="govuk-heading-l">Audit Log</h2>
+
+<dl class="govuk-summary-list">
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
+      Action
+    </dt>
+    <dd class="govuk-summary-list__value">
+      <%= @audit.action %>
+    </dd>
+  </div>
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
+      Record
+    </dt>
+    <dd class="govuk-summary-list__value">
+      <%= @audit.revision.model_name.human %>
+    </dd>
+  </div>
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
+      Changes
+    </dt>
+    <dd class="govuk-summary-list__value">
+      <pre><%= JSON.pretty_generate(@audit.audited_changes) %></pre>
+    </dd>
+  </div>
+
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
+      User
+    </dt>
+    <dd class="govuk-summary-list__value">
+      <%= @audit.user_id %>
+    </dd>
+  </div>
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
+      Datetime
+    </dt>
+    <dd class="govuk-summary-list__value">
+      <%= @audit.created_at.to_s(:long) %>
+    </dd>
+  </div>
+</dl>

--- a/app/views/audits/show.html.erb
+++ b/app/views/audits/show.html.erb
@@ -14,7 +14,7 @@
       Record
     </dt>
     <dd class="govuk-summary-list__value">
-      <%= link_to @audit.revision.model_name.human, @audit.auditable %>
+      <%= link_to @audit.auditable_type, @audit.auditable %>
     </dd>
   </div>
   <div class="govuk-summary-list__row">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,7 +17,7 @@ Rails.application.routes.draw do
   end
   resources :global_options, only: [:index, :new, :create, :edit, :update, :destroy], path: "/global-options"
 
-  resources :audits, only: [:index]
+  resources :audits, only: [:index, :show]
 
   get "/healthcheck", to: "monitoring#healthcheck"
 


### PR DESCRIPTION
# What
Adds a show Audit page to display the audited changes for a given action

# Why
So that users can see exactly what changed for a given Audit log

# Screenshots
![ScreenShot 2020-10-16 at 12 28 50](https://user-images.githubusercontent.com/7527178/96253345-5849fc00-0fab-11eb-9223-98fa17e88127.png)
![ScreenShot 2020-10-16 at 12 29 07](https://user-images.githubusercontent.com/7527178/96253350-5a13bf80-0fab-11eb-9ff0-0fa73bb0c2bc.png)


# Notes
