### PR TITLE
Add presenters to display descriptive name of records in the audit log

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -8,4 +8,9 @@ module ApplicationHelper
       " govuk-header__navigation-item--active"
     end
   end
+
+  def present(model)
+    presenter = "#{model.class}Presenter".constantize
+    presenter.new(model)
+  end
 end

--- a/app/presenters/audit_presenter.rb
+++ b/app/presenters/audit_presenter.rb
@@ -1,0 +1,21 @@
+class AuditPresenter < BasePresenter
+  def name
+    string = record.auditable_type.underscore.humanize
+
+    return string if record.auditable.blank?
+
+    if auditable_presenter.display_name.present?
+      string += " (#{auditable_presenter.display_name})"
+    end
+
+    string
+  end
+
+  private
+
+  def auditable_presenter
+    model = record.auditable
+    presenter = "#{model.class}Presenter".constantize
+    presenter.new(model)
+  end
+end

--- a/app/presenters/base_presenter.rb
+++ b/app/presenters/base_presenter.rb
@@ -1,0 +1,7 @@
+class BasePresenter
+  attr_reader :record
+
+  def initialize(record)
+    @record = record
+  end
+end

--- a/app/presenters/global_option_presenter.rb
+++ b/app/presenters/global_option_presenter.rb
@@ -1,0 +1,5 @@
+class GlobalOptionPresenter < BasePresenter
+  def display_name
+    nil
+  end
+end

--- a/app/presenters/option_presenter.rb
+++ b/app/presenters/option_presenter.rb
@@ -1,0 +1,7 @@
+class OptionPresenter < BasePresenter
+  delegate :subnet, to: :record
+
+  def display_name
+    subnet.cidr_block
+  end
+end

--- a/app/presenters/site_presenter.rb
+++ b/app/presenters/site_presenter.rb
@@ -1,0 +1,5 @@
+class SitePresenter < BasePresenter
+  def display_name
+    record.name
+  end
+end

--- a/app/presenters/subnet_presenter.rb
+++ b/app/presenters/subnet_presenter.rb
@@ -1,0 +1,5 @@
+class SubnetPresenter < BasePresenter
+  def display_name
+    record.cidr_block
+  end
+end

--- a/app/presenters/zone_presenter.rb
+++ b/app/presenters/zone_presenter.rb
@@ -1,0 +1,5 @@
+class ZonePresenter < BasePresenter
+  def display_name
+    record.name
+  end
+end

--- a/app/views/audits/index.html.erb
+++ b/app/views/audits/index.html.erb
@@ -13,10 +13,11 @@
   </thead>
   <tbody class="govuk-table__body">
     <% @audits.each do |audit| %>
+      <% presenter = present(audit) %>
       <tr class="govuk-table__row">
         <td class="govuk-table__cell"><%= audit.user_id %></td>
         <td class="govuk-table__cell"><%= audit.action %></td>
-        <td class="govuk-table__cell"><%= audit.auditable_type.underscore.humanize %></td>
+        <td class="govuk-table__cell"><%= presenter.name %></td>
         <td class="govuk-table__cell"><%= audit.created_at.to_s(:long) %></td>
         <td class="govuk-table__cell"><%= link_to "Details", audit_path(audit), class: "govuk-link" %></td>
       </tr>

--- a/app/views/audits/show.html.erb
+++ b/app/views/audits/show.html.erb
@@ -1,3 +1,5 @@
+<% presenter = present(@audit) %>
+
 <h2 class="govuk-heading-l">Audit Log</h2>
 
 <dl class="govuk-summary-list">
@@ -14,7 +16,7 @@
       Record
     </dt>
     <dd class="govuk-summary-list__value">
-      <%= @audit.auditable_type.underscore.humanize %>
+      <%= presenter.name %>
     </dd>
   </div>
   <div class="govuk-summary-list__row">

--- a/spec/presenters/audit_presenter_spec.rb
+++ b/spec/presenters/audit_presenter_spec.rb
@@ -1,0 +1,28 @@
+require "rails_helper"
+
+describe AuditPresenter do
+  describe "#name" do
+    it "returns the auditable type if the auditable is nil (i.e deleted)" do
+      audit = double(auditable_type: "Site", auditable: nil)
+      presenter = AuditPresenter.new(audit)
+
+      expect(presenter.name).to eq("Site")
+    end
+
+    it "appends the display name of the auditable presenter to the auditable type" do
+      auditable = build_stubbed(:subnet, cidr_block: "10.0.0.1/23")
+      audit = double(auditable_type: "Subnet", auditable: auditable)
+      presenter = AuditPresenter.new(audit)
+
+      expect(presenter.name).to eq("Subnet (10.0.0.1/23)")
+    end
+
+    it "does not use the auditable display name if it is blank" do
+      auditable = build_stubbed(:global_option)
+      audit = double(auditable_type: "GlobalOption", auditable: auditable)
+      presenter = AuditPresenter.new(audit)
+
+      expect(presenter.name).to eq("Global option")
+    end
+  end
+end

--- a/spec/presenters/option_presenter_spec.rb
+++ b/spec/presenters/option_presenter_spec.rb
@@ -1,0 +1,12 @@
+require "rails_helper"
+
+describe OptionPresenter do
+  describe "#display_name" do
+    it "returns the subnet cidr_block" do
+      option = build_stubbed(:option)
+      presenter = OptionPresenter.new(option)
+
+      expect(presenter.display_name).to eq(option.subnet.cidr_block)
+    end
+  end
+end


### PR DESCRIPTION
In the audit log we want to add a description for each record so that it is clear which record is being changed. Previously this simply listed the class name being changed (e.g. Site, Option name).

This change adds more information to the record name in the audit logs (e.g. 'Site (London)', 'Zone (test.example.com)').

This change also introduces presenters to ensure presentation logic is left out of the models.

# Screenshots
![ScreenShot 2020-10-19 at 10 39 29](https://user-images.githubusercontent.com/7527178/96428275-7c9a1880-11f7-11eb-9f50-411c2f476ba1.png)


# Notes
