### PR TITLE
Validate that the Subnet start and end address are within the Subnets range

### DIFF
--- a/spec/acceptance/show_site_spec.rb
+++ b/spec/acceptance/show_site_spec.rb
@@ -16,9 +16,9 @@ describe "showing a site", type: :feature do
 
     context "when the site exists" do
       let!(:site) { create :site }
-      let!(:subnet) { create :subnet, site: site }
-      let!(:subnet2) { create :subnet, site: site }
-      let!(:subnet3) { create :subnet }
+      let!(:subnet) { create :subnet, index: 1, site: site }
+      let!(:subnet2) { create :subnet, index: 2, site: site }
+      let!(:subnet3) { create :subnet, index: 3 }
 
       it "allows viewing sites and its subnets" do
         visit "/dhcp"

--- a/spec/acceptance/update_zones_spec.rb
+++ b/spec/acceptance/update_zones_spec.rb
@@ -31,7 +31,7 @@ describe "update zones", type: :feature do
 
     click_on "Audit log"
 
-    expect(page).to have_content("#{editor.id}")
+    expect(page).to have_content(editor.id.to_s)
     expect(page).to have_content("update")
     expect(page).to have_content("Zone")
   end

--- a/spec/controllers/sites_controller_spec.rb
+++ b/spec/controllers/sites_controller_spec.rb
@@ -23,9 +23,9 @@ describe SitesController, type: :controller do
     end
 
     it "returns subnets ordered by cidr_block" do
-      subnet1 = create :subnet, cidr_block: "10.0.12.0/24"
-      subnet2 = create :subnet, cidr_block: "10.0.3.0/24", site: subnet1.site
-      subnet3 = create :subnet, cidr_block: "10.0.10.0/24", site: subnet1.site
+      subnet1 = create :subnet, start_address: "10.1.12.1", end_address: "10.1.12.100", cidr_block: "10.1.12.0/24"
+      subnet2 = create :subnet, start_address: "10.1.3.1", end_address: "10.1.3.100", cidr_block: "10.1.3.0/24", site: subnet1.site
+      subnet3 = create :subnet, start_address: "10.1.10.1", end_address: "10.1.10.100", cidr_block: "10.1.10.0/24", site: subnet1.site
 
       get :show, params: {id: subnet1.site_id}
 

--- a/spec/factories/subnets.rb
+++ b/spec/factories/subnets.rb
@@ -1,8 +1,12 @@
 FactoryBot.define do
   factory :subnet do
-    sequence(:cidr_block) { |n| "10.#{n}.4.0/24" }
-    start_address { "10.0.4.1" }
-    end_address { "10.0.4.255" }
+    transient do
+      index { 0 }
+    end
+
+    cidr_block { "10.#{index}.4.0/24" }
+    start_address { "10.#{index}.4.1" }
+    end_address { "10.#{index}.4.255" }
 
     site
   end

--- a/spec/models/subnet_spec.rb
+++ b/spec/models/subnet_spec.rb
@@ -60,4 +60,28 @@ RSpec.describe Subnet, type: :model do
     expect(subnet).not_to be_valid
     expect(subnet.errors[:cidr_block]).to_not include "matches a subnet with the same address"
   end
+
+  it "validates the start address is within the subnet range" do
+    subnet = build :subnet, cidr_block: "10.0.4.0/30", start_address: "10.0.4.20", end_address: "10.0.4.100"
+    expect(subnet).not_to be_valid
+    expect(subnet.errors[:start_address]).to include("is not within the subnet range")
+  end
+
+  it "validates the end address is within the subnet range" do
+    subnet = build :subnet, cidr_block: "10.0.4.0/30", start_address: "10.0.4.1", end_address: "10.0.4.20"
+    expect(subnet).not_to be_valid
+    expect(subnet.errors[:end_address]).to eq(["is not within the subnet range"])
+  end
+
+  it "validates the start address matches the host address" do
+    subnet = build :subnet, cidr_block: "10.0.4.0/24", start_address: "10.0.5.1", end_address: "10.0.4.100"
+    expect(subnet).not_to be_valid
+    expect(subnet.errors[:start_address]).to eq(["is not within the subnet range"])
+  end
+
+  it "validates the end address matches the host address" do
+    subnet = build :subnet, cidr_block: "10.0.4.0/24", start_address: "10.0.4.1", end_address: "10.0.5.100"
+    expect(subnet).not_to be_valid
+    expect(subnet.errors[:end_address]).to eq(["is not within the subnet range"])
+  end
 end


### PR DESCRIPTION
# What
Validate that the Subnet start and end address are within the Subnets range

# Why
Ensures that we cannot create invalid Subnets that would result in invalid KEA configurations

# Screenshots

# Notes
