### PR TITLE
Fix audit email spec failures

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,7 +9,7 @@ class User < ApplicationRecord
 
   def self.from_omniauth(auth)
     user = find_or_initialize_by(provider: auth.provider, uid: auth.uid)
-    user.email = auth.extra.raw_info.identities[0].userId
+    user.email = auth.extra.raw_info[:identities][0].userId
     user.editor = auth.extra.raw_info["custom:app_role"] == EDITOR_ROLE
     user.save
     user

--- a/spec/acceptance/create_global_options_spec.rb
+++ b/spec/acceptance/create_global_options_spec.rb
@@ -13,7 +13,7 @@ describe "create global options", type: :feature do
 
   context "when a user is logged in as an viewer" do
     before do
-      login_as User.create!(editor: false)
+      login_as create(:user, :reader)
     end
 
     it "does not allow editing global options" do

--- a/spec/acceptance/create_global_options_spec.rb
+++ b/spec/acceptance/create_global_options_spec.rb
@@ -1,8 +1,6 @@
 require "rails_helper"
 
 describe "create global options", type: :feature do
-  let(:subnet) { create(:subnet) }
-
   context "when a user is not logged in" do
     it "it does not allow editing global_options" do
       visit "/global-options/new"
@@ -28,7 +26,7 @@ describe "create global options", type: :feature do
   end
 
   context "when a user is logged in as an editor" do
-    let(:editor) { User.create!(editor: true) }
+    let(:editor) { create :user, :editor }
 
     before do
       login_as editor
@@ -52,7 +50,7 @@ describe "create global options", type: :feature do
 
       click_on "Audit log"
 
-      expect(page).to have_content(editor.id.to_s)
+      expect(page).to have_content(editor.email)
       expect(page).to have_content("create")
       expect(page).to have_content("Global option")
     end

--- a/spec/acceptance/create_options_spec.rb
+++ b/spec/acceptance/create_options_spec.rb
@@ -1,7 +1,11 @@
 require "rails_helper"
 
 describe "create options", type: :feature do
-  let(:subnet) { create(:subnet) }
+  let(:subnet) do
+    Audited.audit_class.as_user(User.first) do
+      create(:subnet)
+    end
+  end
 
   context "when a user is not logged in" do
     it "it does not allow editing options" do
@@ -13,7 +17,7 @@ describe "create options", type: :feature do
 
   context "when a user is logged in as an viewer" do
     before do
-      login_as User.create!(editor: false)
+      login_as create(:user, :reader)
     end
 
     it "does not allow editing options" do
@@ -28,7 +32,7 @@ describe "create options", type: :feature do
   end
 
   context "when a user is logged in as an editor" do
-    let(:editor) { User.create!(editor: true) }
+    let(:editor) { create :user, :editor }
 
     before do
       login_as editor
@@ -56,7 +60,7 @@ describe "create options", type: :feature do
 
       click_on "Audit log"
 
-      expect(page).to have_content(editor.id.to_s)
+      expect(page).to have_content(editor.email)
       expect(page).to have_content("create")
       expect(page).to have_content("Option")
     end

--- a/spec/acceptance/create_sites_spec.rb
+++ b/spec/acceptance/create_sites_spec.rb
@@ -51,7 +51,7 @@ describe "create sites", type: :feature do
 
       click_on "Audit log"
 
-      expect(page).to have_content(editor.id.to_s)
+      expect(page).to have_content(editor.email)
       expect(page).to have_content("create")
       expect(page).to have_content("Site")
     end

--- a/spec/acceptance/create_sites_spec.rb
+++ b/spec/acceptance/create_sites_spec.rb
@@ -11,7 +11,7 @@ describe "create sites", type: :feature do
 
   context "when the user is a viewer" do
     before do
-      login_as User.create!(editor: false)
+      login_as create(:user, :reader)
     end
 
     it "does not allow creating sites" do
@@ -26,7 +26,7 @@ describe "create sites", type: :feature do
   end
 
   context "when the user is an editor" do
-    let(:editor) { User.create!(editor: true) }
+    let(:editor) { create(:user, :editor) }
 
     before do
       login_as editor

--- a/spec/acceptance/create_subnets_spec.rb
+++ b/spec/acceptance/create_subnets_spec.rb
@@ -8,7 +8,7 @@ describe "create subnets", type: :feature do
   end
 
   it "creates a new subnet" do
-    site = create :site
+    site = Audited.audit_class.as_user(editor) { create :site }
     visit "/sites/#{site.to_param}"
 
     click_on "Create a new subnet"
@@ -29,7 +29,7 @@ describe "create subnets", type: :feature do
 
     click_on "Audit log"
 
-    expect(page).to have_content(editor.id.to_s)
+    expect(page).to have_content(editor.email)
     expect(page).to have_content("create")
     expect(page).to have_content("Subnet")
   end

--- a/spec/acceptance/create_subnets_spec.rb
+++ b/spec/acceptance/create_subnets_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 describe "create subnets", type: :feature do
-  let(:editor) { User.create!(editor: true) }
+  let(:editor) { create(:user, :editor) }
 
   before do
     login_as editor

--- a/spec/acceptance/create_zones_spec.rb
+++ b/spec/acceptance/create_zones_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 describe "create zones", type: :feature do
-  let(:editor) { User.create!(editor: true) }
+  let(:editor) { create(:user, :editor) }
 
   before do
     login_as editor

--- a/spec/acceptance/create_zones_spec.rb
+++ b/spec/acceptance/create_zones_spec.rb
@@ -29,7 +29,7 @@ describe "create zones", type: :feature do
 
     click_on "Audit log"
 
-    expect(page).to have_content(editor.id.to_s)
+    expect(page).to have_content(editor.email)
     expect(page).to have_content("create")
     expect(page).to have_content("Zone")
   end

--- a/spec/acceptance/delete_global_options_spec.rb
+++ b/spec/acceptance/delete_global_options_spec.rb
@@ -8,7 +8,7 @@ describe "delete gobal options", type: :feature do
   end
 
   it "delete global options" do
-    global_option = create :global_option
+    global_option = Audited.audit_class.as_user(editor) { create :global_option }
     visit "/global-options"
 
     click_on "Delete global options"
@@ -22,7 +22,7 @@ describe "delete gobal options", type: :feature do
 
     click_on "Audit log"
 
-    expect(page).to have_content(editor.id.to_s)
+    expect(page).to have_content(editor.email)
     expect(page).to have_content("destroy")
     expect(page).to have_content("Global option")
   end

--- a/spec/acceptance/delete_global_options_spec.rb
+++ b/spec/acceptance/delete_global_options_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 describe "delete gobal options", type: :feature do
-  let(:editor) { User.create!(editor: true) }
+  let(:editor) { create(:user, :editor) }
 
   before do
     login_as editor

--- a/spec/acceptance/delete_options_spec.rb
+++ b/spec/acceptance/delete_options_spec.rb
@@ -1,7 +1,12 @@
 require "rails_helper"
 
 describe "delete options", type: :feature do
-  let(:option) { create :option }
+  let(:option) do
+    Audited.audit_class.as_user(editor) do
+      create :option
+    end
+  end
+
   let(:subnet) { option.subnet }
   let(:editor) { create(:user, :editor) }
 
@@ -26,7 +31,7 @@ describe "delete options", type: :feature do
 
     click_on "Audit log"
 
-    expect(page).to have_content(editor.id.to_s)
+    expect(page).to have_content(editor.email)
     expect(page).to have_content("destroy")
     expect(page).to have_content("Option")
   end

--- a/spec/acceptance/delete_options_spec.rb
+++ b/spec/acceptance/delete_options_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 describe "delete options", type: :feature do
   let(:option) { create :option }
   let(:subnet) { option.subnet }
-  let(:editor) { User.create!(editor: true) }
+  let(:editor) { create(:user, :editor) }
 
   before do
     login_as editor

--- a/spec/acceptance/delete_sites_spec.rb
+++ b/spec/acceptance/delete_sites_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 describe "delete sites", type: :feature do
   context "when the user is a viewer" do
     before do
-      login_as User.create!(editor: false)
+      login_as create(:user, :reader)
     end
 
     it "does not allow creating sites" do
@@ -14,7 +14,7 @@ describe "delete sites", type: :feature do
   end
 
   context "when the user is an editor" do
-    let(:editor) { User.create!(editor: true) }
+    let(:editor) { create(:user, :editor) }
 
     before do
       login_as editor

--- a/spec/acceptance/delete_sites_spec.rb
+++ b/spec/acceptance/delete_sites_spec.rb
@@ -21,7 +21,7 @@ describe "delete sites", type: :feature do
     end
 
     it "delete a site" do
-      site = create(:site)
+      site = Audited.audit_class.as_user(editor) { create(:site) }
 
       visit "/dhcp"
 
@@ -37,7 +37,7 @@ describe "delete sites", type: :feature do
 
       click_on "Audit log"
 
-      expect(page).to have_content(editor.id.to_s)
+      expect(page).to have_content(editor.email)
       expect(page).to have_content("destroy")
       expect(page).to have_content("Site")
     end

--- a/spec/acceptance/delete_subnets_spec.rb
+++ b/spec/acceptance/delete_subnets_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 describe "delete subnets", type: :feature do
-  let(:editor) { User.create!(editor: true) }
+  let(:editor) { create(:user, :editor) }
 
   before do
     login_as editor

--- a/spec/acceptance/delete_subnets_spec.rb
+++ b/spec/acceptance/delete_subnets_spec.rb
@@ -8,7 +8,7 @@ describe "delete subnets", type: :feature do
   end
 
   it "delete a subnet" do
-    subnet = create(:subnet)
+    subnet = Audited.audit_class.as_user(editor) { create(:subnet) }
 
     visit "/sites/#{subnet.site.to_param}"
 
@@ -23,7 +23,7 @@ describe "delete subnets", type: :feature do
 
     click_on "Audit log"
 
-    expect(page).to have_content(editor.id.to_s)
+    expect(page).to have_content(editor.email)
     expect(page).to have_content("destroy")
     expect(page).to have_content("Subnet")
   end

--- a/spec/acceptance/delete_zones_spec.rb
+++ b/spec/acceptance/delete_zones_spec.rb
@@ -8,7 +8,7 @@ describe "delete zones", type: :feature do
   end
 
   it "delete a zone" do
-    zone = create(:zone)
+    zone = Audited.audit_class.as_user(editor) { create(:zone) }
 
     visit "/dns"
 
@@ -24,7 +24,7 @@ describe "delete zones", type: :feature do
 
     click_on "Audit log"
 
-    expect(page).to have_content(editor.id.to_s)
+    expect(page).to have_content(editor.email)
     expect(page).to have_content("destroy")
     expect(page).to have_content("Zone")
   end

--- a/spec/acceptance/delete_zones_spec.rb
+++ b/spec/acceptance/delete_zones_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 describe "delete zones", type: :feature do
-  let(:editor) { User.create!(editor: true) }
+  let(:editor) { create(:user, :editor) }
 
   before do
     login_as editor

--- a/spec/acceptance/show_site_spec.rb
+++ b/spec/acceptance/show_site_spec.rb
@@ -11,7 +11,7 @@ describe "showing a site", type: :feature do
 
   context "when the user is authenticated" do
     before do
-      login_as User.create!
+      login_as create(:user, :reader)
     end
 
     context "when the site exists" do

--- a/spec/acceptance/show_subnet_spec.rb
+++ b/spec/acceptance/show_subnet_spec.rb
@@ -11,7 +11,7 @@ describe "showing a subnet", type: :feature do
 
   context "when the user is authenticated" do
     before do
-      login_as User.create!
+      login_as create(:user, :reader)
     end
 
     context "when the subnet exists" do

--- a/spec/acceptance/sign_in_spec.rb
+++ b/spec/acceptance/sign_in_spec.rb
@@ -12,7 +12,9 @@ RSpec.describe "GET /sign_in", type: :feature do
     before do
       # Simulate logging in via Cognito Omniauth provider
       OmniAuth.config.add_mock(:cognito, {
-        provider: "cognito", uid: "12345", extra: {raw_info: {"custom:app_role": "editor"}}
+        provider: "cognito", uid: "12345", extra: {
+          raw_info: {"custom:app_role": "editor", identities: [{userId: "test_sign_in@example.com"}]}
+        }
       })
 
       Rails.application.env_config["devise.mapping"] = Devise.mappings[:user]

--- a/spec/acceptance/sign_in_spec.rb
+++ b/spec/acceptance/sign_in_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe "GET /sign_in", type: :feature do
   end
 
   context "user signed in for more than 8 hours" do
-    let(:user) { User.create! }
+    let(:user) { create(:user, :reader) }
 
     before do
       login_as user

--- a/spec/acceptance/update_global_options_spec.rb
+++ b/spec/acceptance/update_global_options_spec.rb
@@ -13,7 +13,7 @@ describe "update global options", type: :feature do
 
   context "when a user is logged in as an viewer" do
     before do
-      login_as User.create!(editor: false)
+      login_as create(:user, :reader)
     end
 
     it "does not allow editing global options" do
@@ -28,7 +28,7 @@ describe "update global options", type: :feature do
   end
 
   context "when a user is logged in as an editor" do
-    let(:editor) { User.create!(editor: true) }
+    let(:editor) { create(:user, :editor) }
 
     before do
       login_as editor

--- a/spec/acceptance/update_global_options_spec.rb
+++ b/spec/acceptance/update_global_options_spec.rb
@@ -1,7 +1,11 @@
 require "rails_helper"
 
 describe "update global options", type: :feature do
-  let(:global_option) { create(:global_option) }
+  let(:global_option) do
+    Audited.audit_class.as_user(User.first) do
+      create(:global_option)
+    end
+  end
 
   context "when a user is not logged in" do
     it "it does not allow editing global options" do
@@ -58,7 +62,7 @@ describe "update global options", type: :feature do
 
       click_on "Audit log"
 
-      expect(page).to have_content(editor.id.to_s)
+      expect(page).to have_content(editor.email)
       expect(page).to have_content("update")
       expect(page).to have_content("Global option")
     end

--- a/spec/acceptance/update_options_spec.rb
+++ b/spec/acceptance/update_options_spec.rb
@@ -14,7 +14,7 @@ describe "update options", type: :feature do
 
   context "when a user is logged in as an viewer" do
     before do
-      login_as User.create!(editor: false)
+      login_as create(:user, :reader)
     end
 
     it "does not allow editing options" do
@@ -29,7 +29,7 @@ describe "update options", type: :feature do
   end
 
   context "when a user is logged in as an editor" do
-    let(:editor) { User.create!(editor: true) }
+    let(:editor) { create(:user, :editor) }
 
     before do
       login_as editor

--- a/spec/acceptance/update_options_spec.rb
+++ b/spec/acceptance/update_options_spec.rb
@@ -1,7 +1,12 @@
 require "rails_helper"
 
 describe "update options", type: :feature do
-  let(:option) { create(:option) }
+  let(:option) do
+    Audited.audit_class.as_user(User.first) do
+      create(:option)
+    end
+  end
+
   let(:subnet) { option.subnet }
 
   context "when a user is not logged in" do
@@ -61,7 +66,7 @@ describe "update options", type: :feature do
 
       click_on "Audit log"
 
-      expect(page).to have_content(editor.id.to_s)
+      expect(page).to have_content(editor.email)
       expect(page).to have_content("update")
       expect(page).to have_content("Option")
     end

--- a/spec/acceptance/update_sites_spec.rb
+++ b/spec/acceptance/update_sites_spec.rb
@@ -13,7 +13,7 @@ describe "update sites", type: :feature do
 
   context "when the user is a viewer" do
     before do
-      login_as User.create!(editor: false)
+      login_as create(:user, :reader)
     end
 
     it "does not allow editing sites" do
@@ -28,7 +28,7 @@ describe "update sites", type: :feature do
   end
 
   context "when the user is an editor" do
-    let(:editor) { User.create!(editor: true) }
+    let(:editor) { create(:user, :editor) }
 
     before do
       login_as editor

--- a/spec/acceptance/update_sites_spec.rb
+++ b/spec/acceptance/update_sites_spec.rb
@@ -1,7 +1,11 @@
 require "rails_helper"
 
 describe "update sites", type: :feature do
-  let!(:site) { create(:site) }
+  let(:site) do
+    Audited.audit_class.as_user(User.first) do
+      create(:site)
+    end
+  end
 
   context "when the user is a unauthenticated" do
     it "does not allow creating sites" do
@@ -32,6 +36,7 @@ describe "update sites", type: :feature do
 
     before do
       login_as editor
+      site
     end
 
     it "update an existing site" do
@@ -54,7 +59,7 @@ describe "update sites", type: :feature do
 
       click_on "Audit log"
 
-      expect(page).to have_content(editor.id.to_s)
+      expect(page).to have_content(editor.email)
       expect(page).to have_content("update")
       expect(page).to have_content("Site")
     end

--- a/spec/acceptance/update_subnets_spec.rb
+++ b/spec/acceptance/update_subnets_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 describe "update subnets", type: :feature do
   let!(:subnet) { create(:subnet) }
-  let(:editor) { User.create!(editor: true) }
+  let(:editor) { create(:user, :editor) }
 
   before do
     login_as editor

--- a/spec/acceptance/update_subnets_spec.rb
+++ b/spec/acceptance/update_subnets_spec.rb
@@ -1,7 +1,6 @@
 require "rails_helper"
 
 describe "update subnets", type: :feature do
-  let!(:subnet) { create(:subnet) }
   let(:editor) { create(:user, :editor) }
 
   before do
@@ -9,6 +8,7 @@ describe "update subnets", type: :feature do
   end
 
   it "update an existing subnet" do
+    subnet = Audited.audit_class.as_user(User.first) { create(:subnet) }
     visit "/sites/#{subnet.site.to_param}"
 
     click_on "Edit"
@@ -31,7 +31,7 @@ describe "update subnets", type: :feature do
 
     click_on "Audit log"
 
-    expect(page).to have_content(editor.id.to_s)
+    expect(page).to have_content(editor.email)
     expect(page).to have_content("update")
     expect(page).to have_content("Subnet")
   end

--- a/spec/acceptance/update_zones_spec.rb
+++ b/spec/acceptance/update_zones_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 describe "update zones", type: :feature do
   let!(:zone) { create(:zone) }
-  let(:editor) { User.create!(editor: true) }
+  let(:editor) { create(:user, :editor) }
 
   before do
     login_as editor

--- a/spec/acceptance/update_zones_spec.rb
+++ b/spec/acceptance/update_zones_spec.rb
@@ -1,7 +1,12 @@
 require "rails_helper"
 
 describe "update zones", type: :feature do
-  let!(:zone) { create(:zone) }
+  let!(:zone) do
+    Audited.audit_class.as_user(editor) do
+      create(:zone)
+    end
+  end
+
   let(:editor) { create(:user, :editor) }
 
   before do
@@ -31,7 +36,7 @@ describe "update zones", type: :feature do
 
     click_on "Audit log"
 
-    expect(page).to have_content(editor.id.to_s)
+    expect(page).to have_content(editor.email)
     expect(page).to have_content("update")
     expect(page).to have_content("Zone")
   end

--- a/spec/acceptance/zones_spec.rb
+++ b/spec/acceptance/zones_spec.rb
@@ -1,26 +1,21 @@
 require "rails_helper"
 
 describe "GET /zones", type: :feature do
-  before do
-    login_as User.create
-  end
-
-  it "lists zones" do
-    zone = create :zone
-    zone2 = create :zone, name: "test.example.com"
-
-    visit "/dns"
-    expect(page).to have_content zone.name
-    expect(page).to have_content zone.forwarders.join(",")
-    expect(page).to have_content zone.purpose
-
-    expect(page).to have_content zone2.name
-  end
-
   context "User with viewer permissions" do
     before do
-      login_as User.create!(editor: false)
-      create :zone
+      login_as create(:user, :reader)
+    end
+
+    it "lists zones" do
+      zone = create :zone
+      zone2 = create :zone, name: "test.example.com"
+
+      visit "/dns"
+      expect(page).to have_content zone.name
+      expect(page).to have_content zone.forwarders.join(",")
+      expect(page).to have_content zone.purpose
+
+      expect(page).to have_content zone2.name
     end
 
     it "can see the zone management links" do
@@ -34,7 +29,7 @@ describe "GET /zones", type: :feature do
 
   context "User with editor permissions" do
     before do
-      login_as User.create!(editor: true)
+      login_as create(:user, :editor)
       create :zone
     end
 

--- a/spec/controllers/sites_controller_spec.rb
+++ b/spec/controllers/sites_controller_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 describe SitesController, type: :controller do
   describe "GET index" do
     before do
-      sign_in User.create!
+      sign_in create(:user, :reader)
     end
 
     it "returns sites ordered by fits_id" do
@@ -19,7 +19,7 @@ describe SitesController, type: :controller do
 
   describe "GET show" do
     before do
-      sign_in User.create!
+      sign_in create(:user, :reader)
     end
 
     it "returns subnets ordered by cidr_block" do

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -1,0 +1,13 @@
+FactoryBot.define do
+  factory :user do
+    email { "test@example.com" }
+
+    trait :editor do
+      editor { true }
+    end
+
+    trait :reader do
+      editor { false }
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -3,10 +3,11 @@ require "rails_helper"
 describe User, type: :model do
   describe ".from_omniauth" do
     subject(:user) { User.from_omniauth(auth_hash) }
+    let(:role) { "" }
     let(:auth_hash) do
       # Mocking OmniAuth::AuthHash
       double(provider: "cognito", uid: "1",
-             extra: double(raw_info: {"custom:app_role" => role}))
+             extra: double(raw_info: {"custom:app_role" => role, :identities => [double(userId: "test_from_omniauth@example.com")]}))
     end
 
     context "editor app role" do
@@ -23,6 +24,10 @@ describe User, type: :model do
       it "sets editor to false" do
         expect(user.editor?).to eq false
       end
+    end
+
+    it "sets the email correctly" do
+      expect(user.email).to eq "test_from_omniauth@example.com"
     end
   end
 end


### PR DESCRIPTION
Fixes spec failures after changing the audited table to display an email instead of an id

In our acceptance tests, the audit log only stores the current user if the record was modified as part of a request. This means that creating a record directly in the test (e.g. `create(:subnet)`) will result in an audit log without a user assigned. This breaks the audit table as there is an expectation that all audit logs have a user assigned.

To get around this we can create records as a specific user (e.g. `Audited.audit_class.as_user(User.first) { create :site }`)

This PR also updates the cognito specs to include the identities array which we use to store the email on the User