### PR TITLE
Set valid lifetime global option

### DIFF
--- a/app/controllers/global_options_controller.rb
+++ b/app/controllers/global_options_controller.rb
@@ -57,7 +57,7 @@ class GlobalOptionsController < ApplicationController
   end
 
   def global_option_params
-    params.require(:global_option).permit(:routers, :domain_name_servers, :domain_name)
+    params.require(:global_option).permit(:routers, :domain_name_servers, :domain_name, :valid_lifetime)
   end
 
   def confirmed?

--- a/app/lib/use_cases/generate_kea_config.rb
+++ b/app/lib/use_cases/generate_kea_config.rb
@@ -81,6 +81,15 @@ module UseCases
       }
     end
 
+    def valid_lifetime_config
+      return {} if @global_option.blank?
+      return {} if @global_option.valid_lifetime.blank?
+
+      {
+        "valid-lifetime": @global_option.valid_lifetime
+      }
+    end
+
     def default_config
       {
         Dhcp4: {
@@ -134,7 +143,7 @@ module UseCases
               severity: "DEBUG"
             }
           ]
-        }.merge(global_options_config)
+        }.merge(global_options_config).merge(valid_lifetime_config)
       }
     end
   end

--- a/app/lib/use_cases/generate_kea_config.rb
+++ b/app/lib/use_cases/generate_kea_config.rb
@@ -1,5 +1,7 @@
 module UseCases
   class GenerateKeaConfig
+    DEFAULT_VALID_LIFETIME_SECONDS = 4000
+
     def initialize(subnets: [], global_option: nil)
       @subnets = subnets
       @global_option = global_option
@@ -106,7 +108,7 @@ module UseCases
             host: "<DB_HOST>",
             port: 3306
           },
-          "valid-lifetime": 4000,
+          "valid-lifetime": DEFAULT_VALID_LIFETIME_SECONDS,
           "host-reservation-identifiers": [
             "circuit-id",
             "hw-address",

--- a/app/models/global_option.rb
+++ b/app/models/global_option.rb
@@ -6,6 +6,8 @@ class GlobalOption < ApplicationRecord
     presence: {message: "must contain at least one IPv4 address separated using commas"},
     ipv4_list: {message: "contains an invalid IPv4 address or is not separated using commas"}
   validates :domain_name, presence: true
+  validates :valid_lifetime, numericality: {greater_than_or_equal_to: 0, only_integer: true},
+                             allow_nil: true
 
   validate :only_one_record
 

--- a/app/views/global_options/_form.html.erb
+++ b/app/views/global_options/_form.html.erb
@@ -3,7 +3,7 @@
               local: true do |f| %>
   <div class="govuk-form-group <%= field_error(f.object, :routers )%>">
     <%= f.label :routers, class: "govuk-label" %>
-    <div id="zone_forwarders-hint" class="govuk-hint">
+    <div id="global_option_routers-hint" class="govuk-hint">
       Must be in the form: 127.0.0.1,127.0.0.2
     </div>
     <%= f.text_area :routers, value: f.object.routers.join(","), class: "govuk-input" %>
@@ -11,7 +11,7 @@
 
   <div class="govuk-form-group <%= field_error(f.object, :domain_name_servers) %>">
     <%= f.label :domain_name_servers, class: "govuk-label" %>
-    <div id="zone_forwarders-hint" class="govuk-hint">
+    <div id="global_option_domain_name_servers-hint" class="govuk-hint">
       Must be in the form: 127.0.0.1,127.0.0.2
     </div>
     <%= f.text_area :domain_name_servers, value: f.object.domain_name_servers.join(","), class: "govuk-input" %>
@@ -19,7 +19,7 @@
 
   <div class="govuk-form-group <%= field_error(f.object, :domain_name) %>">
     <%= f.label :domain_name, class: "govuk-label" %>
-    <div id="zone_name-hint" class="govuk-hint">
+    <div id="global_option_domain_name-hint" class="govuk-hint">
       Must be in the form: test.example.com
     </div>
     <%= f.text_field :domain_name, class: "govuk-input" %>

--- a/app/views/global_options/_form.html.erb
+++ b/app/views/global_options/_form.html.erb
@@ -25,6 +25,14 @@
     <%= f.text_field :domain_name, class: "govuk-input" %>
   </div>
 
+  <div class="govuk-form-group <%= field_error(f.object, :valid_lifetime) %>">
+    <%= f.label :valid_lifetime, class: "govuk-label" %>
+    <div id="global_option_valid_lifetime-hint" class="govuk-hint">
+      How long the addresses (leases) given out by the server are valid for in seconds. Defaults to 4000 seconds
+    </div>
+    <%= f.text_field :valid_lifetime, class: "govuk-input" %>
+  </div>
+
   <%= f.submit f.object.new_record? ? "Create" : "Update", {
     class: "govuk-button",
     "data-module" => "govuk-button"

--- a/app/views/global_options/index.html.erb
+++ b/app/views/global_options/index.html.erb
@@ -29,6 +29,15 @@
           <%= @global_option.domain_name %>
         </dd>
       </div>
+
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Valid lifetime
+        </dt>
+        <dd class="govuk-summary-list__value">
+          <%= @global_option.valid_lifetime %>
+        </dd>
+      </div>
     </dl>
     <% if can? :manage, GlobalOption %>
       <%= link_to "Edit global options", edit_global_option_path(@global_option.id), class:"govuk-button" %>

--- a/db/migrate/20201023095801_add_valid_lifetime_to_global_options.rb
+++ b/db/migrate/20201023095801_add_valid_lifetime_to_global_options.rb
@@ -1,0 +1,5 @@
+class AddValidLifetimeToGlobalOptions < ActiveRecord::Migration[6.0]
+  def change
+    add_column :global_options, :valid_lifetime, :integer, unsigned: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_20_153648) do
+ActiveRecord::Schema.define(version: 2020_10_23_095801) do
   create_table "audits", options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
     t.integer "auditable_id"
     t.string "auditable_type"
@@ -39,6 +39,7 @@ ActiveRecord::Schema.define(version: 2020_10_20_153648) do
     t.string "domain_name", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.integer "valid_lifetime", unsigned: true
   end
 
   create_table "options", options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|

--- a/spec/acceptance/create_global_options_spec.rb
+++ b/spec/acceptance/create_global_options_spec.rb
@@ -40,6 +40,7 @@ describe "create global options", type: :feature do
       fill_in "Routers", with: "10.0.1.0,10.0.1.2"
       fill_in "Domain name servers", with: "10.0.2.1,10.0.2.2"
       fill_in "Domain name", with: "test.example.com"
+      fill_in "Valid lifetime", with: 12345
 
       click_on "Create"
 
@@ -47,6 +48,7 @@ describe "create global options", type: :feature do
       expect(page).to have_content("10.0.1.0,10.0.1.2")
       expect(page).to have_content("10.0.2.1,10.0.2.2")
       expect(page).to have_content("test.example.com")
+      expect(page).to have_content("12345")
 
       click_on "Audit log"
 

--- a/spec/models/global_option_spec.rb
+++ b/spec/models/global_option_spec.rb
@@ -18,6 +18,8 @@ RSpec.describe GlobalOption, type: :model do
   end
 
   it { is_expected.to validate_presence_of :domain_name }
+  it { is_expected.to validate_numericality_of(:valid_lifetime).is_greater_than_or_equal_to(0) }
+  it { is_expected.to validate_numericality_of(:valid_lifetime).only_integer }
 
   it "rejects an incorrect routers" do
     option = build :option, routers: ["abcd", "efg"]

--- a/spec/use_cases/generate_kea_config_spec.rb
+++ b/spec/use_cases/generate_kea_config_spec.rb
@@ -130,5 +130,25 @@ describe UseCases::GenerateKeaConfig do
       config = UseCases::GenerateKeaConfig.new(subnets: [], global_option: nil).execute
       expect(config[:Dhcp4].keys).to_not include :"option-data"
     end
+
+    it "sets a default valid lifetime if a global option is not passed in" do
+      config = UseCases::GenerateKeaConfig.new(subnets: [], global_option: nil).execute
+
+      expect(config.dig(:Dhcp4, :"valid-lifetime")).to eq 4000
+    end
+
+    it "sets a default valid lifetime if the global option has no valid lifetime set" do
+      global_option = build_stubbed(:global_option, valid_lifetime: nil)
+      config = UseCases::GenerateKeaConfig.new(subnets: [], global_option: global_option).execute
+
+      expect(config.dig(:Dhcp4, :"valid-lifetime")).to eq 4000
+    end
+
+    it "sets the valid-lifetime using the global option valid lifetime" do
+      global_option = build_stubbed(:global_option, valid_lifetime: 600)
+      config = UseCases::GenerateKeaConfig.new(subnets: [], global_option: global_option).execute
+
+      expect(config.dig(:Dhcp4, :"valid-lifetime")).to eq 600
+    end
   end
 end


### PR DESCRIPTION
# What
Adds the ability to set the valid lifetime (how long the addresses (leases) given out by the server are valid) as a global option

# Why
So that we can manage the valid lifetime of leases for all subnets

# Screenshots
![ScreenShot 2020-10-23 at 12 16 53](https://user-images.githubusercontent.com/7527178/96997425-aa4dcd00-1529-11eb-9d4a-4bb32922d7c0.png)


# Notes
https://kea.readthedocs.io/en/kea-1.8.0/arm/dhcp4-srv.html#dhcpv4-server-configuration
