### PR TITLE
Set valid lifetime subnet option

### DIFF
--- a/app/controllers/options_controller.rb
+++ b/app/controllers/options_controller.rb
@@ -64,7 +64,7 @@ class OptionsController < ApplicationController
   end
 
   def option_params
-    params.require(:option).permit(:routers, :domain_name_servers, :domain_name)
+    params.require(:option).permit(:routers, :domain_name_servers, :domain_name, :valid_lifetime)
   end
 
   def confirmed?

--- a/app/lib/use_cases/generate_kea_config.rb
+++ b/app/lib/use_cases/generate_kea_config.rb
@@ -31,6 +31,7 @@ module UseCases
           "site-name": subnet.site.name
         }
       }.merge(options_config(subnet.option))
+        .merge(subnet_valid_lifetime_config(subnet.option))
     end
 
     def options_config(option)
@@ -90,6 +91,12 @@ module UseCases
       {
         "valid-lifetime": @global_option.valid_lifetime
       }
+    end
+
+    def subnet_valid_lifetime_config(option)
+      return {} if option&.valid_lifetime.blank?
+
+      {"valid-lifetime": option.valid_lifetime}
     end
 
     def default_config

--- a/app/models/option.rb
+++ b/app/models/option.rb
@@ -5,6 +5,8 @@ class Option < ApplicationRecord
   INVALID_IPV4_LIST_MESSAGE = "contains an invalid IPv4 address or is not separated using commas"
   validates :routers, ipv4_list: {message: INVALID_IPV4_LIST_MESSAGE}
   validates :domain_name_servers, ipv4_list: {message: INVALID_IPV4_LIST_MESSAGE}
+  validates :valid_lifetime, numericality: {greater_than_or_equal_to: 0, only_integer: true},
+                             allow_nil: true
 
   validate :at_least_one_option
 

--- a/app/models/subnet.rb
+++ b/app/models/subnet.rb
@@ -18,6 +18,7 @@ class Subnet < ApplicationRecord
   delegate :routers,
     :domain_name_servers,
     :domain_name,
+    :valid_lifetime,
     to: :option
 
   def ip_addr

--- a/app/views/options/_details.html.erb
+++ b/app/views/options/_details.html.erb
@@ -25,4 +25,13 @@
       <%= @subnet.domain_name %>
     </dd>
   </div>
+
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
+      Valid lifetime
+    </dt>
+    <dd class="govuk-summary-list__value">
+      <%= @subnet.valid_lifetime %>
+    </dd>
+  </div>
 </dl>

--- a/app/views/options/_form.html.erb
+++ b/app/views/options/_form.html.erb
@@ -4,7 +4,7 @@
               local: true do |f| %>
   <div class="govuk-form-group <%= field_error(f.object, :routers )%>">
     <%= f.label :routers, class: "govuk-label" %>
-    <div id="zone_forwarders-hint" class="govuk-hint">
+    <div id="options_routers-hint" class="govuk-hint">
       Must be in the form: 127.0.0.1,127.0.0.2
     </div>
     <%= f.text_area :routers, value: f.object.routers.join(","), class: "govuk-input" %>
@@ -12,7 +12,7 @@
 
   <div class="govuk-form-group <%= field_error(f.object, :domain_name_servers) %>">
     <%= f.label :domain_name_servers, class: "govuk-label" %>
-    <div id="zone_forwarders-hint" class="govuk-hint">
+    <div id="options_domain_name_servers-hint" class="govuk-hint">
       Must be in the form: 127.0.0.1,127.0.0.2
     </div>
     <%= f.text_area :domain_name_servers, value: f.object.domain_name_servers.join(","), class: "govuk-input" %>
@@ -20,7 +20,7 @@
 
   <div class="govuk-form-group <%= field_error(f.object, :domain_name) %>">
     <%= f.label :domain_name, class: "govuk-label" %>
-    <div id="zone_name-hint" class="govuk-hint">
+    <div id="options_domain_name-hint" class="govuk-hint">
       Must be in the form: test.example.com
     </div>
     <%= f.text_field :domain_name, class: "govuk-input" %>

--- a/app/views/options/_form.html.erb
+++ b/app/views/options/_form.html.erb
@@ -26,6 +26,14 @@
     <%= f.text_field :domain_name, class: "govuk-input" %>
   </div>
 
+  <div class="govuk-form-group <%= field_error(f.object, :valid_lifetime) %>">
+    <%= f.label :valid_lifetime, class: "govuk-label" %>
+    <div id="options_valid_lifetime-hint" class="govuk-hint">
+      How long the addresses (leases) given out by the server for this subnet are valid for in seconds
+    </div>
+    <%= f.text_field :valid_lifetime, class: "govuk-input" %>
+  </div>
+
   <%= f.submit f.object.new_record? ? "Create" : "Update", {
     class: "govuk-button",
     "data-module" => "govuk-button"

--- a/db/migrate/20201023115012_add_valid_lifetime_to_options.rb
+++ b/db/migrate/20201023115012_add_valid_lifetime_to_options.rb
@@ -1,0 +1,5 @@
+class AddValidLifetimeToOptions < ActiveRecord::Migration[6.0]
+  def change
+    add_column :options, :valid_lifetime, :integer, unsigned: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_23_095801) do
+ActiveRecord::Schema.define(version: 2020_10_23_115012) do
   create_table "audits", options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
     t.integer "auditable_id"
     t.string "auditable_type"
@@ -49,6 +49,7 @@ ActiveRecord::Schema.define(version: 2020_10_23_095801) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.bigint "subnet_id", null: false
+    t.integer "valid_lifetime", unsigned: true
     t.index ["subnet_id"], name: "index_options_on_subnet_id"
   end
 

--- a/spec/acceptance/create_options_spec.rb
+++ b/spec/acceptance/create_options_spec.rb
@@ -47,6 +47,7 @@ describe "create options", type: :feature do
       fill_in "Routers", with: "10.0.1.0,10.0.1.2"
       fill_in "Domain name servers", with: "10.0.2.1,10.0.2.2"
       fill_in "Domain name", with: "test.example.com"
+      fill_in "Valid lifetime", with: "12345"
 
       expect_config_to_be_published
       expect_service_to_be_rebooted
@@ -57,6 +58,7 @@ describe "create options", type: :feature do
       expect(page).to have_content("10.0.1.0,10.0.1.2")
       expect(page).to have_content("10.0.2.1,10.0.2.2")
       expect(page).to have_content("test.example.com")
+      expect(page).to have_content("12345")
 
       click_on "Audit log"
 

--- a/spec/models/option_spec.rb
+++ b/spec/models/option_spec.rb
@@ -9,6 +9,9 @@ RSpec.describe Option, type: :model do
 
   it { is_expected.to validate_presence_of :subnet }
 
+  it { is_expected.to validate_numericality_of(:valid_lifetime).is_greater_than_or_equal_to(0) }
+  it { is_expected.to validate_numericality_of(:valid_lifetime).only_integer }
+
   it "is invalid if none of the options are completed" do
     subject.routers = nil
     subject.domain_name_servers = nil


### PR DESCRIPTION
# What
Adds the ability to set the valid lifetime (how long the addresses (leases) given out by the server are valid) as a subnet option

# Why
So that we can customise the valid lifetime at the subnet level

# Screenshots
<img width="1065" alt="ScreenShot 2020-10-23 at 13 18 37@2x" src="https://user-images.githubusercontent.com/7527178/97002770-5dbabf80-1532-11eb-95c7-bf219ed51db8.png">


# Notes
