### PR TITLE
Remove unused setters

### DIFF
--- a/app/models/global_option.rb
+++ b/app/models/global_option.rb
@@ -20,25 +20,9 @@ class GlobalOption < ApplicationRecord
     self[:routers].split(",")
   end
 
-  def routers=(val)
-    self[:routers] = if val.respond_to?(:join)
-      val.join(",")
-    else
-      val
-    end
-  end
-
   def domain_name_servers
     return [] unless self[:domain_name_servers]
     self[:domain_name_servers].split(",")
-  end
-
-  def domain_name_servers=(val)
-    self[:domain_name_servers] = if val.respond_to?(:join)
-      val.join(",")
-    else
-      val
-    end
   end
 
   private

--- a/app/models/option.rb
+++ b/app/models/option.rb
@@ -19,25 +19,9 @@ class Option < ApplicationRecord
     self[:routers].split(",")
   end
 
-  def routers=(val)
-    self[:routers] = if val.respond_to?(:join)
-      val.join(",")
-    else
-      val
-    end
-  end
-
   def domain_name_servers
     return [] unless self[:domain_name_servers]
     self[:domain_name_servers].split(",")
-  end
-
-  def domain_name_servers=(val)
-    self[:domain_name_servers] = if val.respond_to?(:join)
-      val.join(",")
-    else
-      val
-    end
   end
 
   private

--- a/spec/factories/global_options.rb
+++ b/spec/factories/global_options.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :global_option do
-    routers { ["10.0.4.0", "10.0.4.2"] }
-    domain_name_servers { ["12.0.4.1", "12.0.4.5"] }
+    routers { "10.0.4.0,10.0.4.2" }
+    domain_name_servers { "12.0.4.1,12.0.4.5" }
     domain_name { "www.example.com" }
   end
 end

--- a/spec/factories/options.rb
+++ b/spec/factories/options.rb
@@ -1,8 +1,8 @@
 FactoryBot.define do
   factory :option do
     subnet
-    routers { ["10.0.4.0", "10.0.4.2"] }
-    domain_name_servers { ["12.0.4.1", "12.0.4.5"] }
+    routers { "10.0.4.0,10.0.4.2" }
+    domain_name_servers { "12.0.4.1,12.0.4.5" }
     domain_name { "www.examgitple.com" }
   end
 end

--- a/spec/models/global_option_spec.rb
+++ b/spec/models/global_option_spec.rb
@@ -21,14 +21,14 @@ RSpec.describe GlobalOption, type: :model do
   it { is_expected.to validate_numericality_of(:valid_lifetime).is_greater_than_or_equal_to(0) }
   it { is_expected.to validate_numericality_of(:valid_lifetime).only_integer }
 
-  it "rejects an incorrect routers" do
-    option = build :option, routers: ["abcd", "efg"]
+  it "rejects invalid routers" do
+    option = build :option, routers: "abcd,efg"
     expect(option).not_to be_valid
     expect(option.errors[:routers]).to eq(["contains an invalid IPv4 address or is not separated using commas"])
   end
 
-  it "rejects an incorrect domain_name_server" do
-    option = build :option, domain_name_servers: ["abcd", "efg"]
+  it "rejects invalid domain_name_servers" do
+    option = build :option, domain_name_servers: "abcd,efg"
     expect(option).not_to be_valid
     expect(option.errors[:domain_name_servers]).to eq(["contains an invalid IPv4 address or is not separated using commas"])
   end
@@ -59,16 +59,6 @@ RSpec.describe GlobalOption, type: :model do
     context "when the value is a string" do
       before do
         subject.routers = "192.168.0.2,192.168.0.3"
-      end
-
-      it "returns an empty array" do
-        expect(subject.routers).to eq(["192.168.0.2", "192.168.0.3"])
-      end
-    end
-
-    context "when the value is an array" do
-      before do
-        subject.routers = ["192.168.0.2", "192.168.0.3"]
       end
 
       it "returns an empty array" do
@@ -111,16 +101,6 @@ RSpec.describe GlobalOption, type: :model do
     context "when the value is a string" do
       before do
         subject.domain_name_servers = "192.168.0.2,192.168.0.3"
-      end
-
-      it "returns an empty array" do
-        expect(subject.domain_name_servers).to eq(["192.168.0.2", "192.168.0.3"])
-      end
-    end
-
-    context "when the value is an array" do
-      before do
-        subject.domain_name_servers = ["192.168.0.2", "192.168.0.3"]
       end
 
       it "returns an empty array" do

--- a/spec/models/global_option_spec.rb
+++ b/spec/models/global_option_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe GlobalOption, type: :model do
         subject.routers = "192.168.0.2,192.168.0.3"
       end
 
-      it "returns an empty array" do
+      it "stores the routers correctly" do
         expect(subject.routers).to eq(["192.168.0.2", "192.168.0.3"])
       end
     end
@@ -61,7 +61,7 @@ RSpec.describe GlobalOption, type: :model do
         subject.routers = "192.168.0.2,192.168.0.3"
       end
 
-      it "returns an empty array" do
+      it "stores the routers correctly" do
         expect(subject.routers).to eq(["192.168.0.2", "192.168.0.3"])
       end
     end
@@ -91,7 +91,7 @@ RSpec.describe GlobalOption, type: :model do
         subject.domain_name_servers = "192.168.0.2,192.168.0.3"
       end
 
-      it "returns an empty array" do
+      it "stores the domain_name_servers correctly" do
         expect(subject.domain_name_servers).to eq(["192.168.0.2", "192.168.0.3"])
       end
     end
@@ -103,7 +103,7 @@ RSpec.describe GlobalOption, type: :model do
         subject.domain_name_servers = "192.168.0.2,192.168.0.3"
       end
 
-      it "returns an empty array" do
+      it "stores the domain_name_servers correctly" do
         expect(subject.domain_name_servers).to eq(["192.168.0.2", "192.168.0.3"])
       end
     end
@@ -111,7 +111,7 @@ RSpec.describe GlobalOption, type: :model do
     context "when the value is an string with whitespace" do
       subject { create :global_option, domain_name_servers: " 192.168.0.2, 192.168.0.3  " }
 
-      it "stores the routers correctly" do
+      it "stores the domain_name_servers correctly" do
         expect(subject.domain_name_servers).to eq(["192.168.0.2", "192.168.0.3"])
       end
     end

--- a/spec/models/option_spec.rb
+++ b/spec/models/option_spec.rb
@@ -22,13 +22,13 @@ RSpec.describe Option, type: :model do
   end
 
   it "rejects an incorrect routers" do
-    option = build :option, routers: ["abcd", "efg"]
+    option = build :option, routers: "abcd,efg"
     expect(option).not_to be_valid
     expect(option.errors[:routers]).to eq(["contains an invalid IPv4 address or is not separated using commas"])
   end
 
   it "rejects an incorrect domain_name_server" do
-    option = build :option, domain_name_servers: ["abcd", "efg"]
+    option = build :option, domain_name_servers: "abcd,efg"
     expect(option).not_to be_valid
     expect(option.errors[:domain_name_servers]).to eq(["contains an invalid IPv4 address or is not separated using commas"])
   end
@@ -59,16 +59,6 @@ RSpec.describe Option, type: :model do
     context "when the value is a string" do
       before do
         subject.routers = "192.168.0.2,192.168.0.3"
-      end
-
-      it "returns an empty array" do
-        expect(subject.routers).to eq(["192.168.0.2", "192.168.0.3"])
-      end
-    end
-
-    context "when the value is an array" do
-      before do
-        subject.routers = ["192.168.0.2", "192.168.0.3"]
       end
 
       it "returns an empty array" do
@@ -111,16 +101,6 @@ RSpec.describe Option, type: :model do
     context "when the value is a string" do
       before do
         subject.domain_name_servers = "192.168.0.2,192.168.0.3"
-      end
-
-      it "returns an empty array" do
-        expect(subject.domain_name_servers).to eq(["192.168.0.2", "192.168.0.3"])
-      end
-    end
-
-    context "when the value is an array" do
-      before do
-        subject.domain_name_servers = ["192.168.0.2", "192.168.0.3"]
       end
 
       it "returns an empty array" do


### PR DESCRIPTION
# What
Removes overridden setters that were only used in tests

# Why
To remove complexity from the models and provide a single way of submitting data for these attributes (String instead of 'String or Array')

# Screenshots

# Notes
