### PR TITLE
Reservation options

### DIFF
--- a/app/views/reservations/_list.html.erb
+++ b/app/views/reservations/_list.html.erb
@@ -25,8 +25,12 @@
           <% end %>
         </td>
       </tr>
-      <% unless reservation.reservation_option.nil? %>
-      <%= puts reservation.reservation_option.routers.join(",") %>
+      <% if reservation.reservation_option.nil? %>
+        <tr class="govuk-table__row">
+          <td class="govuk-table__header">Options:</td>
+          <td class="govuk-table__cell"><%= link_to "Create reservation options", new_reservation_reservation_options_path(reservation), class: "govuk-link" if can?(:create, ReservationOption) %></td>
+        </tr>
+      <% else %>
         <tr class="govuk-table__row">
           <td class="govuk-table__header">Options:</td>
           <td class="govuk-table__cell"><%= reservation.reservation_option.routers.join(",") %></td>

--- a/spec/acceptance/create_reservation_options_spec.rb
+++ b/spec/acceptance/create_reservation_options_spec.rb
@@ -43,7 +43,7 @@ describe "create reservation options", type: :feature do
       
       # expect(page).not_to have_content("Edit reservation options")
       # click_on "Create reservation options"
-      visit "/reservations/#{reservation.subnet.to_param}/reservation_options/new"
+      visit "/reservations/#{reservation.to_param}/reservation_options/new"
 
       fill_in "Routers", with: "10.0.1.0,10.0.1.2"
       fill_in "Domain name", with: "test.example.com"

--- a/spec/acceptance/create_reservation_options_spec.rb
+++ b/spec/acceptance/create_reservation_options_spec.rb
@@ -40,7 +40,7 @@ describe "create reservation options", type: :feature do
 
     it "creates a new reservation option" do
       visit "/subnets/#{reservation.subnet.to_param}"
-      
+
       expect(page).not_to have_content("Edit reservation options")
       click_on "Create reservation options"
 

--- a/spec/acceptance/create_reservation_options_spec.rb
+++ b/spec/acceptance/create_reservation_options_spec.rb
@@ -39,10 +39,10 @@ describe "create reservation options", type: :feature do
     end
 
     it "creates a new reservation option" do
-      # visit "/subnets/#{reservation.subnet.to_param}"
+      visit "/subnets/#{reservation.subnet.to_param}"
       
-      # expect(page).not_to have_content("Edit reservation options")
-      # click_on "Create reservation options"
+      expect(page).not_to have_content("Edit reservation options")
+      click_on "Create reservation options"
       visit "/reservations/#{reservation.to_param}/reservation_options/new"
 
       fill_in "Routers", with: "10.0.1.0,10.0.1.2"


### PR DESCRIPTION
Link to the 'create reservation options' form added underneath a reservation if it does not already have options

# Screenshots
<img width="726" alt="Screenshot 2020-11-02 at 11 55 02" src="https://user-images.githubusercontent.com/54268863/97865708-872dd500-1d02-11eb-9ed4-8794794b983f.png">

<img width="726" alt="Screenshot 2020-11-02 at 11 55 10" src="https://user-images.githubusercontent.com/54268863/97865722-8ac15c00-1d02-11eb-90e9-3b05c17b4e22.png">

