### PR TITLE
Deploy DNS service when configuration updates were made

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -4,3 +4,5 @@ MYSQL_DATABASE=staff_device_dns_dhcp_admin_development
 DB_NAME=staff_device_dns_dhcp_admin_development
 DHCP_SERVICE_NAME=some-service
 DHCP_CLUSTER_NAME=some-cluster
+DNS_SERVICE_NAME=some-dns-service
+DNS_CLUSTER_NAME=some-dns-cluster

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -34,6 +34,16 @@ class ApplicationController < ActionController::Base
     ).execute
   end
 
+  def deploy_dns_service
+    UseCases::DeployService.new(
+      ecs_gateway: Gateways::Ecs.new(
+        cluster_name: ENV.fetch("DNS_CLUSTER_NAME"),
+        service_name: ENV.fetch("DNS_SERVICE_NAME"),
+        aws_config: Rails.application.config.ecs_aws_config
+      )
+    ).execute
+  end
+
   def publish_kea_config
     UseCases::PublishKeaConfig.new(
       destination_gateway: Gateways::S3.new(

--- a/app/controllers/zones_controller.rb
+++ b/app/controllers/zones_controller.rb
@@ -15,6 +15,7 @@ class ZonesController < ApplicationController
     authorize! :create, @zone
     if @zone.save
       publish_bind_config
+      deploy_dns_service
       redirect_to dns_path, notice: "Successfully created zone"
     else
       render :new
@@ -29,6 +30,7 @@ class ZonesController < ApplicationController
     authorize! :update, @zone
     if @zone.update(zone_params)
       publish_bind_config
+      deploy_dns_service
       redirect_to dns_path, notice: "Successfully updated DNS zone"
     else
       render :edit
@@ -40,6 +42,7 @@ class ZonesController < ApplicationController
     if confirmed?
       if @zone.destroy
         publish_bind_config
+        deploy_dns_service
         redirect_to dns_path, notice: "Successfully deleted zone"
       else
         redirect_to dns_path, error: "Failed to delete the zone"


### PR DESCRIPTION
# What

Deploy DNS service when configuration updates were made

# Why

We want to automatically roll out new changes when configurations change.
This is a zero downtime deployment.

# Screenshots

# Notes
