### PR TITLE
Domain name validation fixes

### DIFF
--- a/app/models/global_option.rb
+++ b/app/models/global_option.rb
@@ -5,7 +5,7 @@ class GlobalOption < ApplicationRecord
   validates :domain_name_servers,
     presence: {message: "must contain at least one IPv4 address separated using commas"},
     ipv4_list: {message: "contains an invalid IPv4 address or is not separated using commas"}
-  validates :domain_name, presence: true
+  validates :domain_name, presence: true, domain_name: true
   validates :valid_lifetime, numericality: {greater_than_or_equal_to: 0, only_integer: true},
                              allow_nil: true
 

--- a/app/models/option.rb
+++ b/app/models/option.rb
@@ -7,6 +7,7 @@ class Option < ApplicationRecord
   validates :domain_name_servers, ipv4_list: {message: INVALID_IPV4_LIST_MESSAGE}
   validates :valid_lifetime, numericality: {greater_than_or_equal_to: 0, only_integer: true},
                              allow_nil: true
+  validates :domain_name, domain_name: true
 
   validate :at_least_one_option
 

--- a/app/models/reservation_option.rb
+++ b/app/models/reservation_option.rb
@@ -6,8 +6,6 @@ class ReservationOption < ApplicationRecord
   validates :routers, ipv4_list: {message: INVALID_IPV4_LIST_MESSAGE}
   validates :domain_name, domain_name: true
 
-  validates_format_of :domain_name, with: /\A(http|https):\/\/|[a-z0-9]+([\-.]{1}[a-z0-9]+)*\.[a-z]{2,6}(:[0-9]{1,5})?(\/.*)?\z/ix, message: "contains an invalid domain name", allow_nil: true
-
   validate :at_least_one_option
 
   audited

--- a/spec/acceptance/create_reservation_options_spec.rb
+++ b/spec/acceptance/create_reservation_options_spec.rb
@@ -76,7 +76,7 @@ describe "create reservation options", type: :feature do
       click_on "Create reservation options"
 
       fill_in "Routers", with: "10.0.1.0,10.0.1.2"
-      fill_in "Domain name", with: "test.example"
+      fill_in "Domain name", with: "me.example/.co"
 
       click_on "Create"
 

--- a/spec/models/global_option_spec.rb
+++ b/spec/models/global_option_spec.rb
@@ -7,6 +7,14 @@ RSpec.describe GlobalOption, type: :model do
     expect(subject).to be_valid
   end
 
+  it { should allow_value("example.com").for(:domain_name) }
+  it { should allow_value("foo.example.com").for(:domain_name) }
+  it { should allow_value("foo-bar-1.abc.123.example.com").for(:domain_name) }
+  it { should allow_value("foo-BAR-1.ABC.123.example.com").for(:domain_name) }
+  it { should_not allow_value("i_contain_an_at_sign@gov.uk").for(:domain_name) }
+  it { should_not allow_value("测试.com").for(:domain_name) }
+  it { should_not allow_value("me.example/.co").for(:domain_name) }
+
   it do
     is_expected.to validate_presence_of(:routers)
       .with_message("must contain at least one IPv4 address separated using commas")

--- a/spec/models/option_spec.rb
+++ b/spec/models/option_spec.rb
@@ -12,6 +12,14 @@ RSpec.describe Option, type: :model do
   it { is_expected.to validate_numericality_of(:valid_lifetime).is_greater_than_or_equal_to(0) }
   it { is_expected.to validate_numericality_of(:valid_lifetime).only_integer }
 
+  it { should allow_value("example.com").for(:domain_name) }
+  it { should allow_value("foo.example.com").for(:domain_name) }
+  it { should allow_value("foo-bar-1.abc.123.example.com").for(:domain_name) }
+  it { should allow_value("foo-BAR-1.ABC.123.example.com").for(:domain_name) }
+  it { should_not allow_value("i_contain_an_at_sign@gov.uk").for(:domain_name) }
+  it { should_not allow_value("测试.com").for(:domain_name) }
+  it { should_not allow_value("me.example/.co").for(:domain_name) }
+
   it "is invalid if none of the options are completed" do
     subject.routers = nil
     subject.domain_name_servers = nil

--- a/spec/models/reservation_option_spec.rb
+++ b/spec/models/reservation_option_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe ReservationOption, type: :model do
   it { should allow_value("foo-BAR-1.ABC.123.example.com").for(:domain_name) }
   it { should_not allow_value("i_contain_an_at_sign@gov.uk").for(:domain_name) }
   it { should_not allow_value("测试.com").for(:domain_name) }
+  it { should_not allow_value("me.example/.co").for(:domain_name) }
 
   it "rejects an incorrect routers" do
     option = build :reservation_option, routers: "abcd,efg"


### PR DESCRIPTION
# What
Adds the domain name validator to the remaining domain name fields that had no validation on them.
Also removes the duplicated domain name validator in ReservationOption

# Why
To ensures that all domain name fields are validated correctly

# Screenshots

# Notes
The new domain name validation being removed from ReservationOption is a bit more strict than the DomainNameValidator (it only allows for TLDs that are between 2 and 6 characters long). This works for smaller TLDs but longer, valid TLDs will be marked as invalid (e.g. test.website).
