### PR TITLE
Add an endpoint for viewing stats in the admin interface

### DIFF
--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -1,0 +1,5 @@
+class StatsController < ApplicationController
+  def dhcp
+    render json: Gateways::KeaControlAgent.new.fetch_stats
+  end
+end

--- a/app/lib/gateways/kea_control_agent.rb
+++ b/app/lib/gateways/kea_control_agent.rb
@@ -4,8 +4,6 @@ require "json"
 module Gateways
   class KeaControlAgent
     def fetch_leases
-      uri = URI(ENV.fetch("KEA_CONTROL_AGENT_URI"))
-      http = Net::HTTP.new(uri.host, uri.port)
       req = Net::HTTP::Post.new(uri.path, "Content-Type" => "application/json")
       req.body = {
         command: "lease4-get-all",
@@ -13,6 +11,26 @@ module Gateways
       }.to_json
 
       http.request(req).body
+    end
+
+    def fetch_stats
+      req = Net::HTTP::Post.new(uri.path, "Content-Type" => "application/json")
+      req.body = {
+        command: "statistic-get-all",
+        service: ["dhcp4"]
+      }.to_json
+
+      http.request(req).body
+    end
+
+    private
+
+    def http
+      @http ||= Net::HTTP.new(uri.host, uri.port)
+    end
+
+    def uri
+      URI(ENV.fetch("KEA_CONTROL_AGENT_URI"))
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,8 @@ Rails.application.routes.draw do
   resources :zones, except: [:index]
 
   get "/dhcp", to: "sites#index", as: :dhcp
+  get "/dhcp/stats", to: "stats#dhcp", as: :dhcp_stats
+
   resources :sites, except: [:index] do
     resources :subnets, only: [:new, :create]
   end


### PR DESCRIPTION
In order to test API responses and which stats are included we need an accessible api endpojnt in the admin app to view it. 
