### PR TITLE
Leases frontend

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -7,3 +7,5 @@ DHCP_CLUSTER_NAME=some-cluster
 DNS_SERVICE_NAME=some-dns-service
 DNS_CLUSTER_NAME=some-dns-cluster
 PDNS_IPS="1.2.3.4,7.7.7.7"
+KEA_CONTROL_AGENT_URI=http://kea.example.com/
+

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ push:
 publish: build push
 
 lint:
-	$(DOCKER_COMPOSE) run --rm app bundle exec standardrb --fix
+	$(DOCKER_COMPOSE) run --rm app bundle exec rake standard:fix
 
 implode:
 	$(DOCKER_COMPOSE) rm

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,15 @@
 # Add your own tasks in files placed in lib/tasks ending in .rake,
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 
+require "standard/rake"
+
 require_relative "config/application"
 
 Rails.application.load_tasks
+
+Rake::Task["default"].clear
+
+task :default do
+  Rake::Task["standard:fix"].invoke
+  Rake::Task["spec"].invoke
+end

--- a/app/controllers/leases_controller.rb
+++ b/app/controllers/leases_controller.rb
@@ -1,5 +1,9 @@
 class LeasesController < ApplicationController
   def index
-    render json: Gateways::KeaControlAgent.new.fetch_leases
+    @subnet = Subnet.find(params[:subnet_id])
+    @leases = UseCases::FetchLeases.new(
+      gateway: Gateways::KeaControlAgent.new,
+      subnet_kea_id: @subnet.kea_id
+    ).execute
   end
 end

--- a/app/lib/gateways/kea_control_agent.rb
+++ b/app/lib/gateways/kea_control_agent.rb
@@ -3,14 +3,15 @@ require "json"
 
 module Gateways
   class KeaControlAgent
-    def fetch_leases
+    def fetch_leases(kea_subnet_id)
       req = Net::HTTP::Post.new(uri.path, "Content-Type" => "application/json")
       req.body = {
         command: "lease4-get-all",
-        service: ["dhcp4"]
+        service: ["dhcp4"],
+        arguments: {subnets: [kea_subnet_id]}
       }.to_json
 
-      http.request(req).body
+      parse_response(http.request(req).body).fetch("leases")
     end
 
     def fetch_stats
@@ -31,6 +32,10 @@ module Gateways
 
     def uri
       URI(ENV.fetch("KEA_CONTROL_AGENT_URI"))
+    end
+
+    def parse_response(response_body)
+      JSON.parse(response_body).first.fetch("arguments")
     end
   end
 end

--- a/app/lib/gateways/kea_control_agent.rb
+++ b/app/lib/gateways/kea_control_agent.rb
@@ -3,12 +3,12 @@ require "json"
 
 module Gateways
   class KeaControlAgent
-    def fetch_leases(kea_subnet_id)
+    def fetch_leases(subnet_kea_id)
       req = Net::HTTP::Post.new(uri.path, "Content-Type" => "application/json")
       req.body = {
         command: "lease4-get-all",
         service: ["dhcp4"],
-        arguments: {subnets: [kea_subnet_id]}
+        arguments: {subnets: [subnet_kea_id]}
       }.to_json
 
       parse_response(http.request(req).body).fetch("leases")

--- a/app/lib/use_cases/fetch_leases.rb
+++ b/app/lib/use_cases/fetch_leases.rb
@@ -1,0 +1,18 @@
+class UseCases::FetchLeases
+  attr_reader :gateway, :subnet_kea_id
+
+  def initialize(gateway:, subnet_kea_id:)
+    @gateway = gateway
+    @subnet_kea_id = subnet_kea_id
+  end
+
+  def execute
+    gateway.fetch_leases(subnet_kea_id).map do |lease_data|
+      Lease.new(
+        hw_address: lease_data["hw-address"],
+        ip_address: lease_data["ip-address"],
+        hostname: lease_data["hostname"]
+      )
+    end
+  end
+end

--- a/app/models/lease.rb
+++ b/app/models/lease.rb
@@ -1,0 +1,11 @@
+class Lease
+  attr_reader :hw_address,
+    :ip_address,
+    :hostname
+
+  def initialize(hw_address:, ip_address:, hostname:)
+    @hw_address = hw_address
+    @ip_address = ip_address
+    @hostname = hostname
+  end
+end

--- a/app/views/leases/index.html.erb
+++ b/app/views/leases/index.html.erb
@@ -1,0 +1,19 @@
+<table class="govuk-table">
+  <caption class="govuk-table__caption">Leases for <%= @subnet.cidr_block %></caption>
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th scope="col" class="govuk-table__header">HW address</th>
+      <th scope="col" class="govuk-table__header">IP address</th>
+      <th scope="col" class="govuk-table__header">Hostname</th>
+    </tr>
+  </thead>
+  <tbody class="govuk-table__body">
+    <% @leases.each do |lease| %>
+      <tr class="govuk-table__row">
+        <td class="govuk-table__cell"><%= lease.hw_address %></td>
+        <td class="govuk-table__cell"><%= lease.ip_address %></td>
+        <td class="govuk-table__cell"><%= lease.hostname %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/subnets/show.html.erb
+++ b/app/views/subnets/show.html.erb
@@ -17,9 +17,11 @@
   </div>
 </dl>
 
+<%= link_to "View leases", subnet_leases_path(@subnet), class: "govuk-button govuk-button--secondary" %>
+
 <h3 class="govuk-heading-m">Options</h3>
 <% if @subnet.option %>
-  
+
   <%= link_to "Edit options", edit_subnet_options_path(@subnet), class: "govuk-button" if can?(:update, @subnet.option) %>
 
   <%= link_to "Delete options", subnet_options_path(@subnet), class: "govuk-button govuk-button--secondary", method: :delete if can?(:destroy, @subnet.option) %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,12 +17,12 @@ Rails.application.routes.draw do
   resources :subnets, only: [:show, :edit, :update, :destroy] do
     resource :options, only: [:new, :create, :edit, :update, :destroy]
     resource :reservations, only: [:new, :create]
+    resources :leases, only: [:index]
   end
   resources :reservations, only: [:show, :edit, :update, :destroy] do
     resource :reservation_options, only: [:new, :create], path: "/options"
   end
   resources :reservation_options, only: [:edit, :update, :destroy]
-  resources :leases, only: [:index]
 
   resources :global_options, only: [:index, :new, :create, :edit, :update, :destroy], path: "/global-options"
 

--- a/spec/acceptance/list_leases_spec.rb
+++ b/spec/acceptance/list_leases_spec.rb
@@ -1,0 +1,49 @@
+require "rails_helper"
+
+RSpec.describe "Listing leases", type: :feature do
+  let(:user) { create :user, :editor }
+  let(:subnet) { create(:subnet) }
+
+  let(:hw_address) { "00:0c:01:02:03:05" }
+  let(:ip_address) { "172.0.0.2" }
+  let(:hostname) { "test.example.com" }
+
+  let(:kea_response) do
+    [
+      {
+        "arguments": {
+          "leases": [
+            {
+              "hw-address": hw_address,
+              "ip-address": ip_address,
+              "hostname": hostname
+            }
+          ]
+        }
+      }
+    ].to_json
+  end
+
+  before do
+    login_as user
+
+    stub_request(:post, ENV.fetch("KEA_CONTROL_AGENT_URI"))
+      .with(body: {
+        command: "lease4-get-all",
+        service: ["dhcp4"],
+        arguments: {subnets: [subnet.kea_id]}
+      }, headers: {
+        "Content-Type": "application/json"
+      })
+      .to_return(body: kea_response)
+  end
+
+  it "displays a list of leases" do
+    visit "/subnets/#{subnet.to_param}"
+    click_on "View leases"
+
+    expect(page).to have_content hw_address
+    expect(page).to have_content ip_address
+    expect(page).to have_content hostname
+  end
+end

--- a/spec/use_cases/fetch_leases_spec.rb
+++ b/spec/use_cases/fetch_leases_spec.rb
@@ -1,0 +1,50 @@
+require "rails_helper"
+
+RSpec.describe UseCases::FetchLeases do
+  subject(:use_case) do
+    described_class.new(
+      gateway: gateway,
+      subnet_kea_id: subnet_kea_id
+    )
+  end
+
+  let(:hw_address) { :hw_address }
+  let(:ip_address) { :ip_address }
+  let(:hostname) { :hostname }
+  let(:subnet_kea_id) { :subnet_kea_id }
+
+  let(:response) do
+    [
+      {
+        "hw-address" => hw_address,
+        "ip-address" => ip_address,
+        "hostname" => hostname
+      }
+    ]
+  end
+
+  let(:gateway) do
+    instance_double(Gateways::KeaControlAgent, fetch_leases: response)
+  end
+
+  it "returns an object with the correct attributes" do
+    expect(use_case.execute).to match_array([
+      have_attributes(
+        class: Lease,
+        hw_address: hw_address,
+        ip_address: ip_address,
+        hostname: hostname
+      )
+    ])
+  end
+
+  context "when no leases are returned from the gateway" do
+    let(:response) do
+      []
+    end
+
+    it "returns an empty array" do
+      expect(use_case.execute).to eq []
+    end
+  end
+end


### PR DESCRIPTION
# What
Adds a user frontend for the existing leases endpoint

# Why
So that users can view leases currently in operation on the kea dhcp server

# Screenshots

