### PR TITLE
Strip whitespace from ReservationOption#routers before validation

### DIFF
--- a/app/models/reservation_option.rb
+++ b/app/models/reservation_option.rb
@@ -8,6 +8,8 @@ class ReservationOption < ApplicationRecord
 
   validate :at_least_one_option
 
+  before_validation :strip_whitespace
+
   audited
 
   def routers
@@ -20,5 +22,9 @@ class ReservationOption < ApplicationRecord
   def at_least_one_option
     return if routers.any? || domain_name.present?
     errors.add(:base, "At least one option must be filled out")
+  end
+
+  def strip_whitespace
+    self[:routers] = self[:routers]&.strip&.delete(" ")
   end
 end

--- a/spec/models/reservation_option_spec.rb
+++ b/spec/models/reservation_option_spec.rb
@@ -28,4 +28,10 @@ RSpec.describe ReservationOption, type: :model do
     expect(option).not_to be_valid
     expect(option.errors[:base]).to eq(["At least one option must be filled out"])
   end
+
+  it "strips all whitespace from routers before saving" do
+    reservation_option = create :reservation_option, routers: " 127.0.0.1, 127.0.0.1 "
+
+    expect(reservation_option.routers).to eq(["127.0.0.1", "127.0.0.1"])
+  end
 end


### PR DESCRIPTION
# What
Strip whitespace from the submitted routers value 

# Why
Allows users to submit a comma seperated list of IPv4 addresses with spaces between the commas (as they may be copying them over in a similar format from another source)