### PR TITLE
Use use cases for saving dhcp rrelated configuration

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -31,7 +31,7 @@ class ApplicationController < ActionController::Base
         service_name: ENV.fetch("DHCP_SERVICE_NAME"),
         aws_config: Rails.application.config.ecs_aws_config
       )
-    ).execute
+    ).call
   end
 
   def deploy_dns_service
@@ -41,7 +41,7 @@ class ApplicationController < ActionController::Base
         service_name: ENV.fetch("DNS_SERVICE_NAME"),
         aws_config: Rails.application.config.ecs_aws_config
       )
-    ).execute
+    ).call
   end
 
   def publish_kea_config
@@ -53,6 +53,6 @@ class ApplicationController < ActionController::Base
         content_type: "application/json"
       ),
       generate_config: UseCases::GenerateKeaConfig.new(subnets: Subnet.all, global_option: GlobalOption.first)
-    ).execute
+    ).call
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -55,4 +55,11 @@ class ApplicationController < ActionController::Base
       generate_config: UseCases::GenerateKeaConfig.new(subnets: Subnet.all, global_option: GlobalOption.first)
     ).call
   end
+
+  def save_dhcp_record(record)
+    UseCases::SaveDhcpDbRecord.new(
+      publish_kea_config: -> { publish_kea_config },
+      deploy_dhcp_service: -> { deploy_dhcp_service }
+    ).call(record)
+  end
 end

--- a/app/controllers/global_options_controller.rb
+++ b/app/controllers/global_options_controller.rb
@@ -13,9 +13,8 @@ class GlobalOptionsController < ApplicationController
   def create
     @global_option = GlobalOption.new(global_option_params)
     authorize! :create, @global_option
-    if @global_option.save
-      publish_kea_config
-      deploy_dhcp_service
+
+    if save_dhcp_record(@global_option)
       redirect_to global_options_path, notice: "Successfully created global options"
     else
       render :new
@@ -28,9 +27,9 @@ class GlobalOptionsController < ApplicationController
 
   def update
     authorize! :update, @global_option
-    if @global_option.update(global_option_params)
-      publish_kea_config
-      deploy_dhcp_service
+    @global_option.assign_attributes(global_option_params)
+
+    if save_dhcp_record(@global_option)
       redirect_to global_options_path, notice: "Successfully updated global options"
     else
       render :edit

--- a/app/controllers/leases_controller.rb
+++ b/app/controllers/leases_controller.rb
@@ -4,6 +4,6 @@ class LeasesController < ApplicationController
     @leases = UseCases::FetchLeases.new(
       gateway: Gateways::KeaControlAgent.new,
       subnet_kea_id: @subnet.kea_id
-    ).execute
+    ).call
   end
 end

--- a/app/controllers/options_controller.rb
+++ b/app/controllers/options_controller.rb
@@ -10,9 +10,8 @@ class OptionsController < ApplicationController
   def create
     @option = @subnet.build_option(option_params)
     authorize! :create, @option
-    if @option.save
-      publish_kea_config
-      deploy_dhcp_service
+
+    if save_dhcp_record(@option)
       redirect_to subnet_path(@option.subnet), notice: "Successfully created options"
     else
       render :new
@@ -25,9 +24,9 @@ class OptionsController < ApplicationController
 
   def update
     authorize! :update, @option
-    if @option.update(option_params)
-      publish_kea_config
-      deploy_dhcp_service
+    @option.assign_attributes(option_params)
+
+    if save_dhcp_record(@option)
       redirect_to subnet_path(@option.subnet), notice: "Successfully updated options"
     else
       render :edit

--- a/app/controllers/reservation_options_controller.rb
+++ b/app/controllers/reservation_options_controller.rb
@@ -10,9 +10,8 @@ class ReservationOptionsController < ApplicationController
   def create
     @reservation_option = @reservation.build_reservation_option(reservation_option_params)
     authorize! :create, @reservation_option
-    if @reservation_option.save
-      publish_kea_config
-      deploy_dhcp_service
+
+    if save_dhcp_record(@reservation_option)
       redirect_to reservation_path(@reservation), notice: "Successfully created reservation options"
     else
       render :new
@@ -25,9 +24,8 @@ class ReservationOptionsController < ApplicationController
 
   def update
     authorize! :update, @reservation_option
-    if @reservation_option.update(reservation_option_params)
-      publish_kea_config
-      deploy_dhcp_service
+    @reservation_option.assign_attributes(reservation_option_params)
+    if save_dhcp_record(@reservation_option)
       redirect_to reservation_path(@reservation_option.reservation), notice: "Successfully updated reservation options"
     else
       render :edit

--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -76,11 +76,4 @@ class ReservationsController < ApplicationController
   def confirmed?
     params.fetch(:confirm, false)
   end
-
-  def save_dhcp_record(record)
-    UseCases::SaveDhcpDbRecord.new(
-      publish_kea_config: -> { publish_kea_config },
-      deploy_dhcp_service: -> { deploy_dhcp_service }
-    ).call(record)
-  end
 end

--- a/app/controllers/sites_controller.rb
+++ b/app/controllers/sites_controller.rb
@@ -17,9 +17,8 @@ class SitesController < ApplicationController
   def create
     @site = Site.new(site_params)
     authorize! :create, @site
-    if @site.save
-      publish_kea_config
-      deploy_dhcp_service
+
+    if save_dhcp_record(@site)
       redirect_to dhcp_path, notice: "Successfully created site"
     else
       render :new
@@ -32,9 +31,9 @@ class SitesController < ApplicationController
 
   def update
     authorize! :update, @site
-    if @site.update(site_params)
-      publish_kea_config
-      deploy_dhcp_service
+    @site.assign_attributes(site_params)
+
+    if save_dhcp_record(@site)
       redirect_to dhcp_path, notice: "Successfully updated site"
     else
       render :edit

--- a/app/controllers/subnets_controller.rb
+++ b/app/controllers/subnets_controller.rb
@@ -10,9 +10,8 @@ class SubnetsController < ApplicationController
   def create
     @subnet = @site.subnets.build(subnet_params)
     authorize! :create, @subnet
-    if @subnet.save
-      publish_kea_config
-      deploy_dhcp_service
+
+    if save_dhcp_record(@subnet)
       redirect_to @site, notice: "Successfully created subnet"
     else
       render :new
@@ -28,9 +27,9 @@ class SubnetsController < ApplicationController
 
   def update
     authorize! :update, @subnet
-    if @subnet.update(subnet_params)
-      publish_kea_config
-      deploy_dhcp_service
+    @subnet.assign_attributes(subnet_params)
+
+    if save_dhcp_record(@subnet)
       redirect_to @subnet.site, notice: "Successfully updated subnet"
     else
       render :edit

--- a/app/controllers/zones_controller.rb
+++ b/app/controllers/zones_controller.rb
@@ -77,6 +77,6 @@ class ZonesController < ApplicationController
         content_type: "application/octet-stream"
       ),
       generate_config: UseCases::GenerateBindConfig.new(zones: Zone.all, pdns_ips: ENV["PDNS_IPS"])
-    ).execute
+    ).call
   end
 end

--- a/app/lib/use_cases/deploy_service.rb
+++ b/app/lib/use_cases/deploy_service.rb
@@ -4,7 +4,7 @@ module UseCases
       @ecs_gateway = ecs_gateway
     end
 
-    def execute
+    def call
       ecs_gateway.update_service
     end
 

--- a/app/lib/use_cases/fetch_leases.rb
+++ b/app/lib/use_cases/fetch_leases.rb
@@ -6,7 +6,7 @@ class UseCases::FetchLeases
     @subnet_kea_id = subnet_kea_id
   end
 
-  def execute
+  def call
     gateway.fetch_leases(subnet_kea_id).map do |lease_data|
       Lease.new(
         hw_address: lease_data["hw-address"],

--- a/app/lib/use_cases/generate_bind_config.rb
+++ b/app/lib/use_cases/generate_bind_config.rb
@@ -4,7 +4,7 @@ class UseCases::GenerateBindConfig
     @pdns_ips = parse_pdns_ips(pdns_ips)
   end
 
-  def execute
+  def call
     %(
 options {
   directory "/var/bind";

--- a/app/lib/use_cases/generate_kea_config.rb
+++ b/app/lib/use_cases/generate_kea_config.rb
@@ -7,7 +7,7 @@ module UseCases
       @global_option = global_option
     end
 
-    def execute
+    def call
       config = default_config
 
       config[:Dhcp4][:subnet4] += @subnets.map { |subnet| subnet_config(subnet) }

--- a/app/lib/use_cases/publish_bind_config.rb
+++ b/app/lib/use_cases/publish_bind_config.rb
@@ -4,8 +4,8 @@ class UseCases::PublishBindConfig
     @generate_config = generate_config
   end
 
-  def execute
-    payload = generate_config.execute
+  def call
+    payload = generate_config.call
     destination_gateway.write(data: payload)
   end
 

--- a/app/lib/use_cases/publish_kea_config.rb
+++ b/app/lib/use_cases/publish_kea_config.rb
@@ -4,8 +4,8 @@ class UseCases::PublishKeaConfig
     @generate_config = generate_config
   end
 
-  def execute
-    payload = generate_config.execute
+  def call
+    payload = generate_config.call
     destination_gateway.write(data: JSON.generate(payload))
   end
 

--- a/app/lib/use_cases/save_dhcp_db_record.rb
+++ b/app/lib/use_cases/save_dhcp_db_record.rb
@@ -1,0 +1,23 @@
+module UseCases
+  class SaveDhcpDbRecord
+    def initialize(publish_kea_config:, deploy_dhcp_service:)
+      @publish_kea_config = publish_kea_config
+      @deploy_dhcp_service = deploy_dhcp_service
+    end
+
+    def call(record)
+      if record.save
+        publish_kea_config.call
+        deploy_dhcp_service.call
+        true
+      else
+        false
+      end
+    end
+
+    private
+
+    attr_reader :publish_kea_config,
+      :deploy_dhcp_service
+  end
+end

--- a/spec/acceptance/create_reservations_spec.rb
+++ b/spec/acceptance/create_reservations_spec.rb
@@ -48,8 +48,8 @@ describe "create reservations", type: :feature do
       fill_in "Hostname", with: "test.example2.com"
       fill_in "Description", with: "Test reservation"
 
-      # expect_config_to_be_published
-      # expect_service_to_be_rebooted
+      expect_config_to_be_published
+      expect_service_to_be_rebooted
 
       click_on "Create"
 

--- a/spec/use_cases/deploy_service_spec.rb
+++ b/spec/use_cases/deploy_service_spec.rb
@@ -10,7 +10,7 @@ describe UseCases::DeployService do
   let(:ecs_gateway) { instance_spy(Gateways::Ecs) }
 
   before do
-    use_case.execute
+    use_case.call
   end
 
   it "deploys the DHCP service" do

--- a/spec/use_cases/fetch_leases_spec.rb
+++ b/spec/use_cases/fetch_leases_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe UseCases::FetchLeases do
   end
 
   it "returns an object with the correct attributes" do
-    expect(use_case.execute).to match_array([
+    expect(use_case.call).to match_array([
       have_attributes(
         class: Lease,
         hw_address: hw_address,
@@ -44,7 +44,7 @@ RSpec.describe UseCases::FetchLeases do
     end
 
     it "returns an empty array" do
-      expect(use_case.execute).to eq []
+      expect(use_case.call).to eq []
     end
   end
 end

--- a/spec/use_cases/generate_bind_config_spec.rb
+++ b/spec/use_cases/generate_bind_config_spec.rb
@@ -1,9 +1,9 @@
 require "rails_helper"
 
 describe UseCases::GenerateBindConfig do
-  let(:generated_config) { UseCases::GenerateBindConfig.new(zones: all_zones, pdns_ips: "7.7.7.7,5.5.5.5").execute }
+  let(:generated_config) { UseCases::GenerateBindConfig.new(zones: all_zones, pdns_ips: "7.7.7.7,5.5.5.5").call }
 
-  describe "#execute" do
+  describe "#call" do
     let(:all_zones) { [] }
 
     it "generates a BIND template with no dynamic zones" do
@@ -79,7 +79,7 @@ zone "example2.test.com" IN {
   end
 
   describe "Unset pdns ips" do
-    let(:generated_config) { UseCases::GenerateBindConfig.new(pdns_ips: "").execute }
+    let(:generated_config) { UseCases::GenerateBindConfig.new(pdns_ips: "").call }
 
     it "raises an error when PDNS IPs have not been defined" do
       expect { generated_config }.to raise_error("PDNS IPs have not been set")

--- a/spec/use_cases/generate_kea_config_spec.rb
+++ b/spec/use_cases/generate_kea_config_spec.rb
@@ -1,9 +1,9 @@
 require "rails_helper"
 
 describe UseCases::GenerateKeaConfig do
-  describe "#execute" do
+  describe "#call" do
     it "returns a default subnet used for smoke testing" do
-      config = UseCases::GenerateKeaConfig.new.execute
+      config = UseCases::GenerateKeaConfig.new.call
 
       expect(config.dig(:Dhcp4, :subnet4)).to match_array([
         {
@@ -23,7 +23,7 @@ describe UseCases::GenerateKeaConfig do
       subnet1 = build_stubbed(:subnet, cidr_block: "10.0.1.0/24", start_address: "10.0.1.1", end_address: "10.0.1.255", site: site)
       subnet2 = build_stubbed(:subnet, cidr_block: "10.0.2.0/24", start_address: "10.0.2.1", end_address: "10.0.2.255", site: site)
 
-      config = UseCases::GenerateKeaConfig.new(subnets: [subnet1, subnet2]).execute
+      config = UseCases::GenerateKeaConfig.new(subnets: [subnet1, subnet2]).call
 
       expect(config.dig(:Dhcp4, :subnet4)).to match_array([
         {
@@ -65,7 +65,7 @@ describe UseCases::GenerateKeaConfig do
     end
 
     it "returns a kea config with the correct keys" do
-      config = UseCases::GenerateKeaConfig.new.execute
+      config = UseCases::GenerateKeaConfig.new.call
       expect(config).to have_key :Dhcp4
       expect(config[:Dhcp4].keys).to match_array([
         :"host-reservation-identifiers", :"hosts-database", :"interfaces-config",
@@ -78,7 +78,7 @@ describe UseCases::GenerateKeaConfig do
       subnet1 = build_stubbed(:subnet, id: 1, cidr_block: "10.0.1.0/24")
       subnet2 = build_stubbed(:subnet, id: 2, cidr_block: "10.0.2.0/24")
 
-      config = UseCases::GenerateKeaConfig.new(subnets: [subnet1, subnet2]).execute
+      config = UseCases::GenerateKeaConfig.new(subnets: [subnet1, subnet2]).call
 
       expect(config.dig(:Dhcp4, :subnet4)).to match_array([
         hash_including(subnet: "127.0.0.1/0", id: 1),
@@ -90,7 +90,7 @@ describe UseCases::GenerateKeaConfig do
     it "appends options to the subnet" do
       option = build_stubbed(:option, routers: nil, valid_lifetime: 1234)
 
-      config = UseCases::GenerateKeaConfig.new(subnets: [option.subnet]).execute
+      config = UseCases::GenerateKeaConfig.new(subnets: [option.subnet]).call
 
       expect(config.dig(:Dhcp4, :subnet4)).to include(hash_including({
         "valid-lifetime": 1234,
@@ -110,7 +110,7 @@ describe UseCases::GenerateKeaConfig do
     it "includes global options in the config" do
       global_option = build_stubbed(:global_option)
 
-      config = UseCases::GenerateKeaConfig.new(subnets: [], global_option: global_option).execute
+      config = UseCases::GenerateKeaConfig.new(subnets: [], global_option: global_option).call
 
       expect(config.dig(:Dhcp4, :"option-data")).to match_array([
         {
@@ -129,47 +129,47 @@ describe UseCases::GenerateKeaConfig do
     end
 
     it "does not set the global options if none are passed in" do
-      config = UseCases::GenerateKeaConfig.new(subnets: [], global_option: nil).execute
+      config = UseCases::GenerateKeaConfig.new(subnets: [], global_option: nil).call
       expect(config[:Dhcp4].keys).to_not include :"option-data"
     end
 
     it "sets a default valid lifetime if a global option is not passed in" do
-      config = UseCases::GenerateKeaConfig.new(subnets: [], global_option: nil).execute
+      config = UseCases::GenerateKeaConfig.new(subnets: [], global_option: nil).call
 
       expect(config.dig(:Dhcp4, :"valid-lifetime")).to eq 4000
     end
 
     it "sets a default valid lifetime if the global option has no valid lifetime set" do
       global_option = build_stubbed(:global_option, valid_lifetime: nil)
-      config = UseCases::GenerateKeaConfig.new(subnets: [], global_option: global_option).execute
+      config = UseCases::GenerateKeaConfig.new(subnets: [], global_option: global_option).call
 
       expect(config.dig(:Dhcp4, :"valid-lifetime")).to eq 4000
     end
 
     it "sets the valid-lifetime using the global option valid lifetime" do
       global_option = build_stubbed(:global_option, valid_lifetime: 600)
-      config = UseCases::GenerateKeaConfig.new(subnets: [], global_option: global_option).execute
+      config = UseCases::GenerateKeaConfig.new(subnets: [], global_option: global_option).call
 
       expect(config.dig(:Dhcp4, :"valid-lifetime")).to eq 600
     end
 
     it "does not set the valid lifetime for a subnet if the subnet option is not set" do
       subnet = build_stubbed(:subnet, option: nil)
-      config = UseCases::GenerateKeaConfig.new(subnets: [subnet]).execute
+      config = UseCases::GenerateKeaConfig.new(subnets: [subnet]).call
 
       expect(config.dig(:Dhcp4, :subnet4)).to_not include(hash_including(:"valid-lifetime"))
     end
 
     it "does not set the valid lifetime for a subnet if the subnet option does not set a valid lifetime" do
       option = build_stubbed(:option, valid_lifetime: nil)
-      config = UseCases::GenerateKeaConfig.new(subnets: [option.subnet]).execute
+      config = UseCases::GenerateKeaConfig.new(subnets: [option.subnet]).call
 
       expect(config.dig(:Dhcp4, :subnet4)).to_not include(hash_including(:"valid-lifetime"))
     end
 
     it "sets the valid-lifetime for a subnet using the subnet option" do
       option = build_stubbed(:option, valid_lifetime: 1800)
-      config = UseCases::GenerateKeaConfig.new(subnets: [option.subnet]).execute
+      config = UseCases::GenerateKeaConfig.new(subnets: [option.subnet]).call
 
       expect(config.dig(:Dhcp4, :subnet4)).to include(hash_including("valid-lifetime": 1800))
     end
@@ -177,7 +177,7 @@ describe UseCases::GenerateKeaConfig do
     it "appends reservation to the subnet" do
       reservation = create(:reservation)
 
-      config = UseCases::GenerateKeaConfig.new(subnets: [reservation.subnet]).execute
+      config = UseCases::GenerateKeaConfig.new(subnets: [reservation.subnet]).call
 
       expect(config.dig(:Dhcp4, :subnet4)).to include(hash_including({
         "reservations": [
@@ -197,7 +197,7 @@ describe UseCases::GenerateKeaConfig do
       reservation_option = create(:reservation_option)
       reservation = reservation_option.reservation
 
-      config = UseCases::GenerateKeaConfig.new(subnets: [reservation.subnet]).execute
+      config = UseCases::GenerateKeaConfig.new(subnets: [reservation.subnet]).call
 
       expect(config.dig(:Dhcp4, :subnet4)).to include(hash_including({
         "reservations": [
@@ -227,7 +227,7 @@ describe UseCases::GenerateKeaConfig do
       reservation_option = create(:reservation_option, domain_name: nil)
       reservation = reservation_option.reservation
 
-      config = UseCases::GenerateKeaConfig.new(subnets: [reservation.subnet]).execute
+      config = UseCases::GenerateKeaConfig.new(subnets: [reservation.subnet]).call
 
       expect(config.dig(:Dhcp4, :subnet4)).to include(hash_including({
         "reservations": [
@@ -252,7 +252,7 @@ describe UseCases::GenerateKeaConfig do
     it "appends reservation without description to the subnet" do
       reservation = create(:reservation, description: nil)
 
-      config = UseCases::GenerateKeaConfig.new(subnets: [reservation.subnet]).execute
+      config = UseCases::GenerateKeaConfig.new(subnets: [reservation.subnet]).call
 
       expect(config.dig(:Dhcp4, :subnet4)).to include(hash_including({
         "reservations": [
@@ -270,7 +270,7 @@ describe UseCases::GenerateKeaConfig do
       reservation1 = create(:reservation, subnet: subnet, ip_address: "10.7.4.2")
       reservation2 = create(:reservation, subnet: subnet, ip_address: "10.7.4.3", hostname: "reservation2.example.com", hw_address: "01:bb:cc:dd:ee:ee")
 
-      config = UseCases::GenerateKeaConfig.new(subnets: [reservation1.subnet]).execute
+      config = UseCases::GenerateKeaConfig.new(subnets: [reservation1.subnet]).call
 
       expect(config.dig(:Dhcp4, :subnet4)).to include(hash_including({
         "reservations": [

--- a/spec/use_cases/publish_bind_config_spec.rb
+++ b/spec/use_cases/publish_bind_config_spec.rb
@@ -8,7 +8,7 @@ describe UseCases::PublishBindConfig do
     )
   end
 
-  let(:generate_config) { double(execute: config) }
+  let(:generate_config) { double(call: config) }
 
   let(:s3_gateway) { instance_spy(Gateways::S3) }
   let(:config) do
@@ -22,7 +22,7 @@ describe UseCases::PublishBindConfig do
   end
 
   before do
-    use_case.execute
+    use_case.call
   end
 
   it "publishes the BIND config" do

--- a/spec/use_cases/publish_kea_config_spec.rb
+++ b/spec/use_cases/publish_kea_config_spec.rb
@@ -10,7 +10,7 @@ describe UseCases::PublishKeaConfig do
 
   let(:generate_config) do
     double(
-      execute: config
+      call: config
     )
   end
   let(:s3_gateway) { instance_spy(Gateways::S3) }
@@ -19,7 +19,7 @@ describe UseCases::PublishKeaConfig do
   end
 
   before do
-    use_case.execute
+    use_case.call
   end
 
   it "publishes the Kea config" do

--- a/spec/use_cases/save_dhcp_db_record_spec.rb
+++ b/spec/use_cases/save_dhcp_db_record_spec.rb
@@ -1,0 +1,49 @@
+require "rails_helper"
+
+RSpec.describe UseCases::SaveDhcpDbRecord do
+  let(:publish_kea_config) { spy(:publish_kea_config) }
+  let(:deploy_dhcp_service) { spy(:deploy_dhcp_service) }
+  let(:record) { build(:reservation) }
+
+  subject(:use_case) do
+    described_class.new(
+      publish_kea_config: publish_kea_config,
+      deploy_dhcp_service: deploy_dhcp_service
+    )
+  end
+
+  describe "#call" do
+    context "when the record is saved" do
+      it "saves the record" do
+        use_case.call(record)
+        expect(record).to be_persisted
+      end
+
+      it "publishes the kea config" do
+        use_case.call(record)
+        expect(publish_kea_config).to have_received(:call)
+      end
+
+      it "deploys the dhcp service" do
+        use_case.call(record)
+        expect(deploy_dhcp_service).to have_received(:call)
+      end
+
+      it "returns true" do
+        result = use_case.call(record)
+        expect(result).to eql(true)
+      end
+    end
+
+    context "when the record fails to save" do
+      before do
+        allow(record).to receive(:valid?).and_return(false)
+      end
+
+      it "returns false" do
+        result = use_case.call(record)
+        expect(result).to eql(false)
+      end
+    end
+  end
+end


### PR DESCRIPTION
# What
Move saving of DHCP config relation models into a use case which encapsulates publishing and deploying the dhcp service.

# Why
This will allow us to wrap up config verification, publishing and deployment in a transaction so that invalid configuratiuons are not saved in the db 