### PR TITLE
Add client class to generated kea config

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -52,7 +52,11 @@ class ApplicationController < ActionController::Base
         aws_config: Rails.application.config.s3_aws_config,
         content_type: "application/json"
       ),
-      generate_config: UseCases::GenerateKeaConfig.new(subnets: Subnet.all, global_option: GlobalOption.first)
+      generate_config: UseCases::GenerateKeaConfig.new(
+        subnets: Subnet.all,
+        global_option: GlobalOption.first,
+        client_class: ClientClass.first
+      )
     ).call
   end
 

--- a/app/lib/use_cases/generate_kea_config.rb
+++ b/app/lib/use_cases/generate_kea_config.rb
@@ -2,9 +2,10 @@ module UseCases
   class GenerateKeaConfig
     DEFAULT_VALID_LIFETIME_SECONDS = 4000
 
-    def initialize(subnets: [], global_option: nil)
+    def initialize(subnets: [], global_option: nil, client_class: nil)
       @subnets = subnets
       @global_option = global_option
+      @client_class = client_class
     end
 
     def call
@@ -151,6 +152,23 @@ module UseCases
       {"valid-lifetime": option.valid_lifetime}
     end
 
+    def client_class_config
+      return {} if @client_class.blank?
+
+      {
+        "client-classes": [
+          {
+            name: @client_class.name,
+            test: "option[61].hex == '#{@client_class.client_id}'",
+            "option-data": [
+              {name: "domain-name", data: @client_class.domain_name},
+              {name: "domain-name-servers", data: @client_class.domain_name_servers}
+            ]
+          }
+        ]
+      }
+    end
+
     def default_config
       {
         Dhcp4: {
@@ -216,7 +234,7 @@ module UseCases
               "library": "/usr/lib/kea/hooks/libdhcp_stat_cmds.so"
             }
           ]
-        }.merge(global_options_config).merge(valid_lifetime_config)
+        }.merge(global_options_config).merge(valid_lifetime_config).merge(client_class_config)
       }
     end
   end

--- a/spec/use_cases/generate_kea_config_spec.rb
+++ b/spec/use_cases/generate_kea_config_spec.rb
@@ -293,5 +293,26 @@ describe UseCases::GenerateKeaConfig do
         ]
       }))
     end
+
+    it "does not set client classes if none are passed in" do
+      config = UseCases::GenerateKeaConfig.new.call
+      expect(config[:Dhcp4].keys).to_not include :"client-classes"
+    end
+
+    it "adds client class to the config when a client class is passed in" do
+      client_class = create(:client_class)
+      config = UseCases::GenerateKeaConfig.new(client_class: client_class).call
+
+      expect(config.dig(:Dhcp4, :"client-classes")).to eq([
+        {
+          name: client_class.name,
+          test: "option[61].hex == '#{client_class.client_id}'",
+          "option-data": [
+            {name: "domain-name", data: client_class.domain_name},
+            {name: "domain-name-servers", data: client_class.domain_name_servers}
+          ]
+        }
+      ])
+    end
   end
 end


### PR DESCRIPTION
# What
Sets the client class in the kea config

# Why
So that the dhcp server picks up the changes to the client class

# Screenshots

# Notes
https://kea.readthedocs.io/en/kea-1.8.0/arm/classify.html#configuring-classes
