### PR TITLE
Verify kea configuration before publishing

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -58,6 +58,7 @@ class ApplicationController < ActionController::Base
   def save_dhcp_record(record)
     UseCases::SaveDhcpDbRecord.new(
       generate_kea_config: -> { generate_kea_config.call },
+      verify_kea_config: verify_kea_config,
       publish_kea_config: ->(config) { publish_kea_config(config) },
       deploy_dhcp_service: -> { deploy_dhcp_service }
     ).call(record)
@@ -74,6 +75,12 @@ class ApplicationController < ActionController::Base
   def kea_control_agent_gateway
     Gateways::KeaControlAgent.new(
       uri: ENV.fetch("KEA_CONTROL_AGENT_URI")
+    )
+  end
+
+  def verify_kea_config
+    UseCases::VerifyKeaConfig.new(
+      kea_control_agent_gateway: kea_control_agent_gateway
     )
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -70,4 +70,10 @@ class ApplicationController < ActionController::Base
       client_class: ClientClass.first
     )
   end
+
+  def kea_control_agent_gateway
+    Gateways::KeaControlAgent.new(
+      uri: ENV.fetch("KEA_CONTROL_AGENT_URI")
+    )
+  end
 end

--- a/app/controllers/leases_controller.rb
+++ b/app/controllers/leases_controller.rb
@@ -2,7 +2,7 @@ class LeasesController < ApplicationController
   def index
     @subnet = Subnet.find(params[:subnet_id])
     @leases = UseCases::FetchLeases.new(
-      gateway: Gateways::KeaControlAgent.new,
+      gateway: kea_control_agent_gateway,
       subnet_kea_id: @subnet.kea_id
     ).call
   end

--- a/app/lib/gateways/kea_control_agent.rb
+++ b/app/lib/gateways/kea_control_agent.rb
@@ -8,18 +8,18 @@ module Gateways
     end
 
     def fetch_leases(subnet_kea_id)
-      req = Net::HTTP::Post.new(uri.path, "Content-Type" => "application/json")
+      req = Net::HTTP::Post.new(uri.path, headers)
       req.body = {
         command: "lease4-get-all",
         service: ["dhcp4"],
         arguments: {subnets: [subnet_kea_id]}
       }.to_json
 
-      parse_response(http.request(req).body).fetch("leases")
+      parse_response(http.request(req).body).fetch("arguments").fetch("leases")
     end
 
     def fetch_stats
-      req = Net::HTTP::Post.new(uri.path, "Content-Type" => "application/json")
+      req = Net::HTTP::Post.new(uri.path, headers)
       req.body = {
         command: "statistic-get-all",
         service: ["dhcp4"]
@@ -28,17 +28,33 @@ module Gateways
       http.request(req).body
     end
 
+    def verify_config(config)
+      req = Net::HTTP::Post.new(uri.path, headers)
+      req.body = {
+        command: "config-test",
+        service: ["dhcp4"],
+        arguments: config
+      }.to_json
+
+      parse_response(http.request(req).body)
+    end
+
     private
 
     attr_reader :uri
+
+    def headers
+      {
+        "Content-Type" => "application/json"
+      }
+    end
 
     def http
       @http ||= Net::HTTP.new(uri.host, uri.port)
     end
 
-
     def parse_response(response_body)
-      JSON.parse(response_body).first.fetch("arguments")
+      JSON.parse(response_body).first
     end
   end
 end

--- a/app/lib/gateways/kea_control_agent.rb
+++ b/app/lib/gateways/kea_control_agent.rb
@@ -3,6 +3,10 @@ require "json"
 
 module Gateways
   class KeaControlAgent
+    def initialize(uri:)
+      @uri = URI(uri)
+    end
+
     def fetch_leases(subnet_kea_id)
       req = Net::HTTP::Post.new(uri.path, "Content-Type" => "application/json")
       req.body = {
@@ -26,13 +30,12 @@ module Gateways
 
     private
 
+    attr_reader :uri
+
     def http
       @http ||= Net::HTTP.new(uri.host, uri.port)
     end
 
-    def uri
-      URI(ENV.fetch("KEA_CONTROL_AGENT_URI"))
-    end
 
     def parse_response(response_body)
       JSON.parse(response_body).first.fetch("arguments")

--- a/app/lib/use_cases/save_dhcp_db_record.rb
+++ b/app/lib/use_cases/save_dhcp_db_record.rb
@@ -1,26 +1,39 @@
 module UseCases
   class SaveDhcpDbRecord
-    def initialize(generate_kea_config:, publish_kea_config:, deploy_dhcp_service:)
+    def initialize(generate_kea_config:, verify_kea_config:, publish_kea_config:, deploy_dhcp_service:)
       @generate_kea_config = generate_kea_config
+      @verify_kea_config = verify_kea_config
       @publish_kea_config = publish_kea_config
       @deploy_dhcp_service = deploy_dhcp_service
     end
 
     def call(record)
-      if record.save
-        kea_config = generate_kea_config.call
-        publish_kea_config.call(kea_config)
-        deploy_dhcp_service.call
-        true
-      else
-        false
+      record.transaction do
+        if record.save
+          kea_config = generate_kea_config.call
+          if verify_kea_config.call(kea_config)
+            publish_kea_config.call(kea_config)
+            deploy_dhcp_service.call
+            return true
+          else
+            raise KeaConfigInvalidError
+          end
+        else
+          return false
+        end
+      rescue KeaConfigInvalidError
+        record.errors.add(:base, "These changes would result in an invalid DHCP configuration")
+        return false
       end
     end
 
     private
 
     attr_reader :generate_kea_config,
+      :verify_kea_config,
       :publish_kea_config,
       :deploy_dhcp_service
+
+    class KeaConfigInvalidError < StandardError; end
   end
 end

--- a/app/lib/use_cases/verify_kea_config.rb
+++ b/app/lib/use_cases/verify_kea_config.rb
@@ -1,0 +1,15 @@
+module UseCases
+  class VerifyKeaConfig
+    def initialize(kea_control_agent_gateway:)
+      @kea_control_agent_gateway = kea_control_agent_gateway
+    end
+
+    def call(config)
+      kea_control_agent_gateway.verify_config(config).fetch("result") == 0
+    end
+
+    private
+
+    attr_reader :kea_control_agent_gateway
+  end
+end

--- a/spec/acceptance/create_client_classes_spec.rb
+++ b/spec/acceptance/create_client_classes_spec.rb
@@ -42,6 +42,10 @@ describe "create client class", type: :feature do
       fill_in "Domain name servers", with: "10.0.2.1,10.0.2.2"
       fill_in "Domain name", with: "test.example.com"
 
+      expect_config_to_be_verified
+      expect_config_to_be_published
+      expect_service_to_be_rebooted
+
       click_on "Create"
 
       expect(page).to have_content("Successfully created client class")

--- a/spec/acceptance/create_global_options_spec.rb
+++ b/spec/acceptance/create_global_options_spec.rb
@@ -42,6 +42,10 @@ describe "create global options", type: :feature do
       fill_in "Domain name", with: "test.example.com"
       fill_in "Valid lifetime", with: 12345
 
+      expect_config_to_be_verified
+      expect_config_to_be_published
+      expect_service_to_be_rebooted
+
       click_on "Create"
 
       expect(page).to have_content("Successfully created global option")

--- a/spec/acceptance/create_options_spec.rb
+++ b/spec/acceptance/create_options_spec.rb
@@ -49,6 +49,7 @@ describe "create options", type: :feature do
       fill_in "Domain name", with: "test.example.com"
       fill_in "Valid lifetime", with: "12345"
 
+      expect_config_to_be_verified
       expect_config_to_be_published
       expect_service_to_be_rebooted
 

--- a/spec/acceptance/create_reservation_options_spec.rb
+++ b/spec/acceptance/create_reservation_options_spec.rb
@@ -48,6 +48,7 @@ describe "create reservation options", type: :feature do
       fill_in "Routers", with: "10.0.1.0,10.0.1.2"
       fill_in "Domain name", with: "sub.domain.my-example.com"
 
+      expect_config_to_be_verified
       expect_config_to_be_published
       expect_service_to_be_rebooted
 

--- a/spec/acceptance/create_reservations_spec.rb
+++ b/spec/acceptance/create_reservations_spec.rb
@@ -48,6 +48,7 @@ describe "create reservations", type: :feature do
       fill_in "Hostname", with: "test.example2.com"
       fill_in "Description", with: "Test reservation"
 
+      expect_config_to_be_verified
       expect_config_to_be_published
       expect_service_to_be_rebooted
 

--- a/spec/acceptance/create_sites_spec.rb
+++ b/spec/acceptance/create_sites_spec.rb
@@ -42,9 +42,13 @@ describe "create sites", type: :feature do
       fill_in "FITS id", with: "MYFITS101"
       fill_in "Name", with: "My London Site"
 
+      expect_config_to_be_verified
+      expect_config_to_be_published
+      expect_service_to_be_rebooted
+
       click_on "Create"
 
-      expect(current_path).to eq("/dhcp")
+      expect(page).to have_content("Successfully created site")
 
       expect(page).to have_content("MYFITS101")
       expect(page).to have_content("My London Site")

--- a/spec/acceptance/create_subnets_spec.rb
+++ b/spec/acceptance/create_subnets_spec.rb
@@ -19,6 +19,10 @@ describe "create subnets", type: :feature do
     fill_in "Start address", with: "10.0.1.1"
     fill_in "End address", with: "10.0.1.255"
 
+    expect_config_to_be_verified
+    expect_config_to_be_published
+    expect_service_to_be_rebooted
+
     click_button "Create"
 
     expect(current_path).to eq("/sites/#{site.to_param}")

--- a/spec/acceptance/update_client_classes_spec.rb
+++ b/spec/acceptance/update_client_classes_spec.rb
@@ -55,6 +55,10 @@ describe "update client class", type: :feature do
       fill_in "Domain name servers", with: "10.0.2.3,10.0.2.4"
       fill_in "Domain name", with: "tester.example.com"
 
+      expect_config_to_be_verified
+      expect_config_to_be_published
+      expect_service_to_be_rebooted
+
       click_on "Update"
 
       expect(page).to have_content("Successfully updated client class")

--- a/spec/acceptance/update_global_options_spec.rb
+++ b/spec/acceptance/update_global_options_spec.rb
@@ -53,6 +53,10 @@ describe "update global options", type: :feature do
       fill_in "Domain name servers", with: "10.0.2.2,10.0.2.3"
       fill_in "Domain name", with: "testier.example.com"
 
+      expect_config_to_be_verified
+      expect_config_to_be_published
+      expect_service_to_be_rebooted
+
       click_on "Update"
 
       expect(page).to have_content("Successfully updated global option")

--- a/spec/acceptance/update_options_spec.rb
+++ b/spec/acceptance/update_options_spec.rb
@@ -54,6 +54,7 @@ describe "update options", type: :feature do
       fill_in "Domain name servers", with: "10.0.2.2,10.0.2.3"
       fill_in "Domain name", with: "testier.example.com"
 
+      expect_config_to_be_verified
       expect_config_to_be_published
       expect_service_to_be_rebooted
 

--- a/spec/acceptance/update_reservation_options_spec.rb
+++ b/spec/acceptance/update_reservation_options_spec.rb
@@ -52,6 +52,7 @@ describe "update reservation options", type: :feature do
       fill_in "Routers", with: "10.0.1.1,10.0.1.100"
       fill_in "Domain name", with: "testing.example.com"
 
+      expect_config_to_be_verified
       expect_config_to_be_published
       expect_service_to_be_rebooted
 

--- a/spec/acceptance/update_reservations_spec.rb
+++ b/spec/acceptance/update_reservations_spec.rb
@@ -55,8 +55,9 @@ describe "update reservations", type: :feature do
       fill_in "Hostname", with: "testier.example.com"
       fill_in "Description", with: "Changed test reservation"
 
-      # expect_config_to_be_published
-      # expect_service_to_be_rebooted
+      expect_config_to_be_verified
+      expect_config_to_be_published
+      expect_service_to_be_rebooted
 
       click_on "Update"
 

--- a/spec/acceptance/update_sites_spec.rb
+++ b/spec/acceptance/update_sites_spec.rb
@@ -50,6 +50,10 @@ describe "update sites", type: :feature do
       fill_in "FITS id", with: "MYFITS202"
       fill_in "Name", with: "My Manchester Site"
 
+      expect_config_to_be_verified
+      expect_config_to_be_published
+      expect_service_to_be_rebooted
+
       click_on "Update"
 
       expect(current_path).to eq("/dhcp")

--- a/spec/acceptance/update_subnets_spec.rb
+++ b/spec/acceptance/update_subnets_spec.rb
@@ -21,6 +21,10 @@ describe "update subnets", type: :feature do
     fill_in "Start address", with: "10.1.1.1"
     fill_in "End address", with: "10.1.1.255"
 
+    expect_config_to_be_verified
+    expect_config_to_be_published
+    expect_service_to_be_rebooted
+
     click_button "Update"
 
     expect(page).to have_content("Successfully updated subnet")

--- a/spec/support/configuration_publishing_asssertions.rb
+++ b/spec/support/configuration_publishing_asssertions.rb
@@ -9,6 +9,6 @@ module ConfigurationPublishingAssertions
 
   def expect_config_to_be_verified
     expect_any_instance_of(Gateways::KeaControlAgent).to receive(:verify_config)
-      .and_return({ "result" => 0 })
+      .and_return({"result" => 0})
   end
 end

--- a/spec/support/configuration_publishing_asssertions.rb
+++ b/spec/support/configuration_publishing_asssertions.rb
@@ -6,4 +6,9 @@ module ConfigurationPublishingAssertions
   def expect_service_to_be_rebooted
     expect_any_instance_of(Gateways::Ecs).to receive(:update_service)
   end
+
+  def expect_config_to_be_verified
+    expect_any_instance_of(Gateways::KeaControlAgent).to receive(:verify_config)
+      .and_return({ "result" => 0 })
+  end
 end

--- a/spec/use_cases/save_dhcp_db_record_spec.rb
+++ b/spec/use_cases/save_dhcp_db_record_spec.rb
@@ -2,6 +2,7 @@ require "rails_helper"
 
 RSpec.describe UseCases::SaveDhcpDbRecord do
   let(:generate_kea_config) { spy(:generate_kea_config) }
+  let(:verify_kea_config) { spy(:verify_kea_config) }
   let(:publish_kea_config) { spy(:publish_kea_config) }
   let(:deploy_dhcp_service) { spy(:deploy_dhcp_service) }
   let(:record) { build(:reservation) }
@@ -9,6 +10,7 @@ RSpec.describe UseCases::SaveDhcpDbRecord do
   subject(:use_case) do
     described_class.new(
       generate_kea_config: generate_kea_config,
+      verify_kea_config: verify_kea_config,
       publish_kea_config: publish_kea_config,
       deploy_dhcp_service: deploy_dhcp_service
     )
@@ -24,6 +26,11 @@ RSpec.describe UseCases::SaveDhcpDbRecord do
       it "generates the kea config" do
         use_case.call(record)
         expect(generate_kea_config).to have_received(:call)
+      end
+
+      it "verifies the kea config" do
+        use_case.call(record)
+        expect(verify_kea_config).to have_received(:call)
       end
 
       it "publishes the kea config" do

--- a/spec/use_cases/verify_kea_config_spec.rb
+++ b/spec/use_cases/verify_kea_config_spec.rb
@@ -1,0 +1,32 @@
+require "rails_helper"
+
+RSpec.describe UseCases::VerifyKeaConfig do
+  let(:kea_control_agent_gateway) { instance_double(Gateways::KeaControlAgent) }
+  let(:config) { double(:config) }
+
+  subject(:use_case) do
+    described_class.new(kea_control_agent_gateway: kea_control_agent_gateway)
+  end
+
+  describe "#call" do
+    context "when the config is valid" do
+      before do
+        allow(kea_control_agent_gateway).to receive(:verify_config).and_return({ "result" => 0 })
+      end
+
+      it "returns true" do
+        expect(use_case.call(config)).to eql(true)
+      end
+    end
+
+    context "when the config is invalid" do
+      before do
+        allow(kea_control_agent_gateway).to receive(:verify_config).and_return({ "result" => 1 })
+      end
+
+      it "returns false" do
+        expect(use_case.call(config)).to eql(false)
+      end
+    end
+  end
+end

--- a/spec/use_cases/verify_kea_config_spec.rb
+++ b/spec/use_cases/verify_kea_config_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe UseCases::VerifyKeaConfig do
   describe "#call" do
     context "when the config is valid" do
       before do
-        allow(kea_control_agent_gateway).to receive(:verify_config).and_return({ "result" => 0 })
+        allow(kea_control_agent_gateway).to receive(:verify_config).and_return({"result" => 0})
       end
 
       it "returns true" do
@@ -21,7 +21,7 @@ RSpec.describe UseCases::VerifyKeaConfig do
 
     context "when the config is invalid" do
       before do
-        allow(kea_control_agent_gateway).to receive(:verify_config).and_return({ "result" => 1 })
+        allow(kea_control_agent_gateway).to receive(:verify_config).and_return({"result" => 1})
       end
 
       it "returns false" do


### PR DESCRIPTION
# What
Verify Kea configuration is valid before publishing and revert changes if the expected config is invalid

# Why
To protect the kea server from being in a broken state should an invalid change be made to the database 
