### PR TITLE
Add a reservation to the smoke testing subnet

### DIFF
--- a/app/lib/use_cases/generate_kea_config.rb
+++ b/app/lib/use_cases/generate_kea_config.rb
@@ -212,7 +212,16 @@ module UseCases
                 }
               ],
               subnet: "127.0.0.1/0",
-              id: 1 # This is the subnet used for smoke testing
+              id: 1, # This is the subnet used for smoke testing
+              reservations: [
+                {
+                  "hw-address": "00:0c:01:02:03:04",
+                  "ip-address": "172.0.0.1",
+                  "user-context": {
+                    "description": "Smoke testing reservation"
+                  }
+                }
+              ]
             }
           ],
           loggers: [

--- a/spec/use_cases/generate_kea_config_spec.rb
+++ b/spec/use_cases/generate_kea_config_spec.rb
@@ -13,7 +13,16 @@ describe UseCases::GenerateKeaConfig do
             }
           ],
           subnet: "127.0.0.1/0",
-          id: 1
+          id: 1, # This is the subnet used for smoke testing
+          reservations: [
+            {
+              "hw-address": "00:0c:01:02:03:04",
+              "ip-address": "172.0.0.1",
+              "user-context": {
+                "description": "Smoke testing reservation"
+              }
+            }
+          ]
         }
       ])
     end
@@ -33,7 +42,16 @@ describe UseCases::GenerateKeaConfig do
             }
           ],
           subnet: "127.0.0.1/0",
-          id: 1
+          id: 1, # This is the subnet used for smoke testing
+          reservations: [
+            {
+              "hw-address": "00:0c:01:02:03:04",
+              "ip-address": "172.0.0.1",
+              "user-context": {
+                "description": "Smoke testing reservation"
+              }
+            }
+          ]
         },
         {
           pools: [


### PR DESCRIPTION
Allows us to test IP leasing using a test MAC address

Co-authored-by: Joshua-Luke Bevan <joshua.bevan@madetech.com>