### PR TITLE
Throw a KeaAPIError if the leases API does not return a successful response

### DIFF
--- a/app/lib/gateways/kea_control_agent.rb
+++ b/app/lib/gateways/kea_control_agent.rb
@@ -15,7 +15,12 @@ module Gateways
         arguments: {subnets: [subnet_kea_id]}
       }.to_json
 
-      parse_response(http.request(req).body).fetch("arguments").fetch("leases")
+      response = parse_response(http.request(req).body)
+      if response.fetch("result") != 0
+        raise KeaAPIError.new response.fetch("text")
+      end
+
+      response.fetch("arguments").fetch("leases")
     end
 
     def fetch_stats
@@ -56,5 +61,7 @@ module Gateways
     def parse_response(response_body)
       JSON.parse(response_body).first
     end
+
+    class KeaAPIError < StandardError; end
   end
 end

--- a/spec/acceptance/list_leases_spec.rb
+++ b/spec/acceptance/list_leases_spec.rb
@@ -19,7 +19,8 @@ RSpec.describe "Listing leases", type: :feature do
               "hostname": hostname
             }
           ]
-        }
+        },
+        "result": 0
       }
     ].to_json
   end


### PR DESCRIPTION
See https://kea.readthedocs.io/en/latest/arm/ctrl-channel.html#data-syntax for
info on error responses ("result 0")

# Why
Allow us to see why the API is failing
