### PR TITLE
Add errors to models when config is invalid

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -55,13 +55,13 @@ class ApplicationController < ActionController::Base
     ).call(config)
   end
 
-  def update_dhcp_config(record)
+  def update_dhcp_config(record, operation)
     UseCases::TransactionallyUpdateDhcpConfig.new(
       generate_kea_config: -> { generate_kea_config.call },
       verify_kea_config: verify_kea_config,
       publish_kea_config: ->(config) { publish_kea_config(config) },
       deploy_dhcp_service: -> { deploy_dhcp_service }
-    ).call(record)
+    ).call(record, operation)
   end
 
   def generate_kea_config

--- a/app/controllers/client_classes_controller.rb
+++ b/app/controllers/client_classes_controller.rb
@@ -14,7 +14,7 @@ class ClientClassesController < ApplicationController
     @client_class = ClientClass.new(client_class_params)
     authorize! :create, @client_class
 
-    if update_dhcp_config(-> { @client_class.save })
+    if update_dhcp_config(@client_class, -> { @client_class.save })
       redirect_to client_classes_path, notice: "Successfully created client class"
     else
       render :new
@@ -29,7 +29,7 @@ class ClientClassesController < ApplicationController
     authorize! :update, @client_class
     @client_class.assign_attributes(client_class_params)
 
-    if update_dhcp_config(-> { @client_class.save })
+    if update_dhcp_config(@client_class, -> { @client_class.save })
       redirect_to client_classes_path, notice: "Successfully updated client class"
     else
       render :edit
@@ -39,7 +39,7 @@ class ClientClassesController < ApplicationController
   def destroy
     authorize! :destroy, @client_class
     if confirmed?
-      if update_dhcp_config(-> { @client_class.destroy })
+      if update_dhcp_config(@client_class, -> { @client_class.destroy })
         redirect_to client_classes_path, notice: "Successfully deleted client class"
       else
         redirect_to client_classes_path, error: "Failed to delete the client class"

--- a/app/controllers/global_options_controller.rb
+++ b/app/controllers/global_options_controller.rb
@@ -14,7 +14,7 @@ class GlobalOptionsController < ApplicationController
     @global_option = GlobalOption.new(global_option_params)
     authorize! :create, @global_option
 
-    if update_dhcp_config(-> { @global_option.save })
+    if update_dhcp_config(@global_options, -> { @global_option.save })
       redirect_to global_options_path, notice: "Successfully created global options"
     else
       render :new
@@ -29,7 +29,7 @@ class GlobalOptionsController < ApplicationController
     authorize! :update, @global_option
     @global_option.assign_attributes(global_option_params)
 
-    if update_dhcp_config(-> { @global_option.save })
+    if update_dhcp_config(@global_options, -> { @global_option.save })
       redirect_to global_options_path, notice: "Successfully updated global options"
     else
       render :edit
@@ -39,7 +39,7 @@ class GlobalOptionsController < ApplicationController
   def destroy
     authorize! :destroy, @global_option
     if confirmed?
-      if update_dhcp_config(-> { @global_option.destroy })
+      if update_dhcp_config(@global_options, -> { @global_option.destroy })
         redirect_to global_options_path, notice: "Successfully deleted global options"
       else
         redirect_to global_options_path, error: "Failed to delete the global options"

--- a/app/controllers/options_controller.rb
+++ b/app/controllers/options_controller.rb
@@ -11,7 +11,7 @@ class OptionsController < ApplicationController
     @option = @subnet.build_option(option_params)
     authorize! :create, @option
 
-    if update_dhcp_config(-> { @option.save })
+    if update_dhcp_config(@option, -> { @option.save })
       redirect_to subnet_path(@option.subnet), notice: "Successfully created options"
     else
       render :new
@@ -26,7 +26,7 @@ class OptionsController < ApplicationController
     authorize! :update, @option
     @option.assign_attributes(option_params)
 
-    if update_dhcp_config(-> { @option.save })
+    if update_dhcp_config(@option, -> { @option.save })
       redirect_to subnet_path(@option.subnet), notice: "Successfully updated options"
     else
       render :edit
@@ -36,7 +36,7 @@ class OptionsController < ApplicationController
   def destroy
     authorize! :destroy, @option
     if confirmed?
-      if update_dhcp_config(-> { @option.destroy })
+      if update_dhcp_config(@option, -> { @option.destroy })
         redirect_to subnet_path(@option.subnet), notice: "Successfully deleted option"
       else
         redirect_to subnet_path(@option.subnet), error: "Failed to delete the option"

--- a/app/controllers/reservation_options_controller.rb
+++ b/app/controllers/reservation_options_controller.rb
@@ -11,7 +11,7 @@ class ReservationOptionsController < ApplicationController
     @reservation_option = @reservation.build_reservation_option(reservation_option_params)
     authorize! :create, @reservation_option
 
-    if update_dhcp_config(-> { @reservation_option.save })
+    if update_dhcp_config(@reservation_option, -> { @reservation_option.save })
       redirect_to reservation_path(@reservation), notice: "Successfully created reservation options"
     else
       render :new
@@ -25,7 +25,7 @@ class ReservationOptionsController < ApplicationController
   def update
     authorize! :update, @reservation_option
     @reservation_option.assign_attributes(reservation_option_params)
-    if update_dhcp_config(-> { @reservation_option.save })
+    if update_dhcp_config(@reservation_option, -> { @reservation_option.save })
       redirect_to reservation_path(@reservation_option.reservation), notice: "Successfully updated reservation options"
     else
       render :edit
@@ -35,7 +35,7 @@ class ReservationOptionsController < ApplicationController
   def destroy
     authorize! :destroy, @reservation_option
     if confirmed?
-      if update_dhcp_config(-> { @reservation_option.destroy })
+      if update_dhcp_config(@reservation_options, -> { @reservation_option.destroy })
         redirect_to reservation_path(@reservation_option.reservation), notice: "Successfully deleted reservation options"
       else
         redirect_to reservation_path(@reservation_option.reservation), error: "Failed to delete the reservation options"

--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -11,7 +11,7 @@ class ReservationsController < ApplicationController
     @reservation = @subnet.reservations.build(reservation_params)
     authorize! :create, @reservation
 
-    if update_dhcp_config(-> { @reservation.save })
+    if update_dhcp_config(@reservation, -> { @reservation.save })
       redirect_to subnet_path(@reservation.subnet), notice: "Successfully created reservation"
     else
       render :new
@@ -29,7 +29,7 @@ class ReservationsController < ApplicationController
     authorize! :update, @reservation
     @reservation.assign_attributes(reservation_params)
 
-    if update_dhcp_config(-> { @reservation.save })
+    if update_dhcp_config(@reservation, -> { @reservation.save })
       redirect_to subnet_path(@reservation.subnet), notice: "Successfully updated reservation"
     else
       render :edit
@@ -39,7 +39,7 @@ class ReservationsController < ApplicationController
   def destroy
     authorize! :destroy, @reservation
     if confirmed?
-      if update_dhcp_config(-> { @reservation.destroy })
+      if update_dhcp_config(@reservation, -> { @reservation.destroy })
         redirect_to subnet_path(@reservation.subnet), notice: "Successfully deleted reservation"
       else
         redirect_to subnet_path(@reservation.subnet), error: "Failed to delete the reservation"

--- a/app/controllers/sites_controller.rb
+++ b/app/controllers/sites_controller.rb
@@ -18,7 +18,7 @@ class SitesController < ApplicationController
     @site = Site.new(site_params)
     authorize! :create, @site
 
-    if update_dhcp_config(-> { @site.save })
+    if update_dhcp_config(@site, -> { @site.save })
       redirect_to dhcp_path, notice: "Successfully created site"
     else
       render :new
@@ -33,7 +33,7 @@ class SitesController < ApplicationController
     authorize! :update, @site
     @site.assign_attributes(site_params)
 
-    if update_dhcp_config(-> { @site.save })
+    if update_dhcp_config(@site, -> { @site.save })
       redirect_to dhcp_path, notice: "Successfully updated site"
     else
       render :edit
@@ -44,7 +44,7 @@ class SitesController < ApplicationController
     authorize! :destroy, @site
     @subnets = @site.subnets.sort_by(&:ip_addr)
     if confirmed?
-      if update_dhcp_config(-> { @site.destroy })
+      if update_dhcp_config(@site, -> { @site.destroy })
         redirect_to dhcp_path, notice: "Successfully deleted site"
       else
         redirect_to dhcp_path, error: "Failed to delete the site"

--- a/app/controllers/subnets_controller.rb
+++ b/app/controllers/subnets_controller.rb
@@ -11,7 +11,7 @@ class SubnetsController < ApplicationController
     @subnet = @site.subnets.build(subnet_params)
     authorize! :create, @subnet
 
-    if update_dhcp_config(-> { @subnet.save })
+    if update_dhcp_config(@subnet, -> { @subnet.save })
       redirect_to @site, notice: "Successfully created subnet"
     else
       render :new
@@ -29,7 +29,7 @@ class SubnetsController < ApplicationController
     authorize! :update, @subnet
     @subnet.assign_attributes(subnet_params)
 
-    if update_dhcp_config(-> { @subnet.save })
+    if update_dhcp_config(@subnet, -> { @subnet.save })
       redirect_to @subnet.site, notice: "Successfully updated subnet"
     else
       render :edit
@@ -39,7 +39,7 @@ class SubnetsController < ApplicationController
   def destroy
     authorize! :destroy, @subnet
     if confirmed?
-      if update_dhcp_config(-> { @subnet.destroy })
+      if update_dhcp_config(@subnet, -> { @subnet.destroy })
         redirect_to @subnet.site, notice: "Successfully deleted subnet"
       else
         redirect_to @subnet.site, error: "Failed to delete the subnet"

--- a/app/lib/use_cases/transactionally_update_dhcp_config.rb
+++ b/app/lib/use_cases/transactionally_update_dhcp_config.rb
@@ -7,7 +7,7 @@ module UseCases
       @deploy_dhcp_service = deploy_dhcp_service
     end
 
-    def call(operation)
+    def call(record, operation)
       ApplicationRecord.transaction do
         if operation.call
           kea_config = generate_kea_config.call

--- a/spec/use_cases/transactionally_update_dhcp_config_spec.rb
+++ b/spec/use_cases/transactionally_update_dhcp_config_spec.rb
@@ -20,32 +20,32 @@ RSpec.describe UseCases::TransactionallyUpdateDhcpConfig do
   describe "#call" do
     context "when the operation is saved" do
       it "saves the operation" do
-        use_case.call(operation)
+        use_case.call(record, operation)
         expect(record).to be_persisted
       end
 
       it "generates the kea config" do
-        use_case.call(operation)
+        use_case.call(record, operation)
         expect(generate_kea_config).to have_received(:call)
       end
 
       it "verifies the kea config" do
-        use_case.call(operation)
+        use_case.call(record, operation)
         expect(verify_kea_config).to have_received(:call)
       end
 
       it "publishes the kea config" do
-        use_case.call(operation)
+        use_case.call(record, operation)
         expect(publish_kea_config).to have_received(:call)
       end
 
       it "deploys the dhcp service" do
-        use_case.call(operation)
+        use_case.call(record, operation)
         expect(deploy_dhcp_service).to have_received(:call)
       end
 
       it "returns true" do
-        result = use_case.call(operation)
+        result = use_case.call(record, operation)
         expect(result).to eql(true)
       end
     end
@@ -56,8 +56,19 @@ RSpec.describe UseCases::TransactionallyUpdateDhcpConfig do
       end
 
       it "returns false" do
-        result = use_case.call(operation)
+        result = use_case.call(record, operation)
         expect(result).to eql(false)
+      end
+    end
+
+    context "when the kea config is invalid" do
+      before do
+        allow(verify_kea_config).to receive(:call).and_return(false)
+      end
+
+      it "adds errors to the record" do
+        use_case.call(record, operation)
+        expect(record.errors[:base]).not_to be_empty
       end
     end
   end


### PR DESCRIPTION
Make sure we pass both the operation and the model object so we can add errors when the kea config is invalid
