### PR TITLE
Reduce the subnet scope for localhost

### DIFF
--- a/app/lib/use_cases/generate_kea_config.rb
+++ b/app/lib/use_cases/generate_kea_config.rb
@@ -208,10 +208,10 @@ module UseCases
             {
               pools: [
                 {
-                  pool: "172.0.0.1 - 172.0.2.0"
+                  pool: "127.0.0.1 - 127.0.2.0"
                 }
               ],
-              subnet: "127.0.0.1/0",
+              subnet: "127.0.0.1/24",
               id: 1 # This is the subnet used for smoke testing
             }
           ],


### PR DESCRIPTION
We run tests against localhost when the container boots.
This needs a dedicated pool and subnet for localhost.

Was set to /0, reduce the scope to /24

# What

# Why

# Screenshots

# Notes
