### PR TITLE
Ensure rollback happens when config is invalid

### DIFF
--- a/app/lib/use_cases/transactionally_update_dhcp_config.rb
+++ b/app/lib/use_cases/transactionally_update_dhcp_config.rb
@@ -21,10 +21,10 @@ module UseCases
         else
           return false
         end
-      rescue KeaConfigInvalidError
-        record.errors.add(:base, "These changes would result in an invalid DHCP configuration")
-        return false
       end
+    rescue KeaConfigInvalidError
+      record.errors.add(:base, "These changes would result in an invalid DHCP configuration")
+      return false
     end
 
     private

--- a/app/lib/use_cases/transactionally_update_dhcp_config.rb
+++ b/app/lib/use_cases/transactionally_update_dhcp_config.rb
@@ -24,7 +24,7 @@ module UseCases
       end
     rescue KeaConfigInvalidError
       record.errors.add(:base, "These changes would result in an invalid DHCP configuration")
-      return false
+      false
     end
 
     private

--- a/spec/use_cases/transactionally_update_dhcp_config_spec.rb
+++ b/spec/use_cases/transactionally_update_dhcp_config_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe UseCases::TransactionallyUpdateDhcpConfig do
       end
     end
 
-    context "when the operation fails to save" do
+    context "when the operation fails" do
       before do
         allow(record).to receive(:valid?).and_return(false)
       end
@@ -64,6 +64,11 @@ RSpec.describe UseCases::TransactionallyUpdateDhcpConfig do
     context "when the kea config is invalid" do
       before do
         allow(verify_kea_config).to receive(:call).and_return(false)
+      end
+
+      it "does not save the record" do
+        use_case.call(record, operation)
+        expect(record).not_to be_persisted
       end
 
       it "adds errors to the record" do


### PR DESCRIPTION
This fixes a bug relating to rollbacks. Rescuing the invalid config error needs to
happen outside of the transaction in order foir the transaction rollback
to be triggered.