### PR TITLE
Use comma seperated domain name servers for client classes in the kea config

### DIFF
--- a/app/lib/use_cases/generate_kea_config.rb
+++ b/app/lib/use_cases/generate_kea_config.rb
@@ -162,7 +162,7 @@ module UseCases
             test: "option[61].hex == '#{@client_class.client_id}'",
             "option-data": [
               {name: "domain-name", data: @client_class.domain_name},
-              {name: "domain-name-servers", data: @client_class.domain_name_servers}
+              {name: "domain-name-servers", data: @client_class.domain_name_servers.join(", ")}
             ]
           }
         ]

--- a/spec/use_cases/generate_kea_config_spec.rb
+++ b/spec/use_cases/generate_kea_config_spec.rb
@@ -309,7 +309,7 @@ describe UseCases::GenerateKeaConfig do
           test: "option[61].hex == '#{client_class.client_id}'",
           "option-data": [
             {name: "domain-name", data: client_class.domain_name},
-            {name: "domain-name-servers", data: client_class.domain_name_servers}
+            {name: "domain-name-servers", data: client_class.domain_name_servers.join(", ")}
           ]
         }
       ])


### PR DESCRIPTION
Previously we were sending an array that was then converted to JSON. KEA expects a comma separated string which resulted in invalid config errors when a client class was created