### PR TITLE
Resurface Kea invalid config errors to the frontend

### DIFF
--- a/app/lib/use_cases/verify_kea_config.rb
+++ b/app/lib/use_cases/verify_kea_config.rb
@@ -6,13 +6,25 @@ module UseCases
 
     def call(config)
       kea_control_agent_gateway.verify_config(config)
-      true
-    rescue Gateways::KeaControlAgent::InternalError
-      false
+      Result.new
+    rescue Gateways::KeaControlAgent::InternalError => error
+      Result.new(error)
     end
 
     private
 
     attr_reader :kea_control_agent_gateway
+
+    class Result
+      attr_reader :error
+
+      def initialize(error = nil)
+        @error = error
+      end
+
+      def success?
+        error.nil?
+      end
+    end
   end
 end

--- a/spec/gateways/kea_control_agent_spec.rb
+++ b/spec/gateways/kea_control_agent_spec.rb
@@ -1,0 +1,35 @@
+require "rails_helper"
+
+describe Gateways::KeaControlAgent do
+  let(:uri) { "http://example.com/" }
+  subject { described_class.new(uri: uri) }
+
+  describe "#verify_config" do
+    context "when the kea api returns an error" do
+      let(:config) { { Dhcp4: {} } }
+      let(:kea_response) do
+        [{
+          "result": 1,
+          "text": "thats invalid"
+        }].to_json
+      end
+
+      before do
+        stub_request(:post, uri)
+        .with(body: {
+          command: "config-test",
+          service: ["dhcp4"],
+          arguments: config
+        }, headers: {
+          "Content-Type": "application/json"
+        })
+        .to_return(body: kea_response)
+      end
+
+      it "raises a InternalError" do
+        expect { subject.verify_config(config) }
+          .to raise_error(described_class::InternalError, "thats invalid")
+      end
+    end
+  end
+end

--- a/spec/gateways/kea_control_agent_spec.rb
+++ b/spec/gateways/kea_control_agent_spec.rb
@@ -6,7 +6,7 @@ describe Gateways::KeaControlAgent do
 
   describe "#verify_config" do
     context "when the kea api returns an error" do
-      let(:config) { { Dhcp4: {} } }
+      let(:config) { {Dhcp4: {}} }
       let(:kea_response) do
         [{
           "result": 1,
@@ -16,14 +16,14 @@ describe Gateways::KeaControlAgent do
 
       before do
         stub_request(:post, uri)
-        .with(body: {
-          command: "config-test",
-          service: ["dhcp4"],
-          arguments: config
-        }, headers: {
-          "Content-Type": "application/json"
-        })
-        .to_return(body: kea_response)
+          .with(body: {
+            command: "config-test",
+            service: ["dhcp4"],
+            arguments: config
+          }, headers: {
+            "Content-Type": "application/json"
+          })
+          .to_return(body: kea_response)
       end
 
       it "raises a InternalError" do

--- a/spec/use_cases/transactionally_update_dhcp_config_spec.rb
+++ b/spec/use_cases/transactionally_update_dhcp_config_spec.rb
@@ -62,8 +62,10 @@ RSpec.describe UseCases::TransactionallyUpdateDhcpConfig do
     end
 
     context "when the kea config is invalid" do
+      let(:result) { double(:result, success?: false, error: StandardError.new("im borked")) }
+
       before do
-        allow(verify_kea_config).to receive(:call).and_return(false)
+        allow(verify_kea_config).to receive(:call).and_return(result)
       end
 
       it "does not save the record" do
@@ -73,7 +75,7 @@ RSpec.describe UseCases::TransactionallyUpdateDhcpConfig do
 
       it "adds errors to the record" do
         use_case.call(record, operation)
-        expect(record.errors[:base]).not_to be_empty
+        expect(record.errors[:base]).to include(result.error.message)
       end
     end
   end

--- a/spec/use_cases/verify_kea_config_spec.rb
+++ b/spec/use_cases/verify_kea_config_spec.rb
@@ -14,18 +14,24 @@ RSpec.describe UseCases::VerifyKeaConfig do
         allow(kea_control_agent_gateway).to receive(:verify_config)
       end
 
-      it "returns true" do
-        expect(use_case.call(config)).to eql(true)
+      it "returns a successful result" do
+        expect(use_case.call(config).success?).to eql(true)
       end
     end
 
     context "when the config is invalid" do
+      let(:error) { Gateways::KeaControlAgent::InternalError.new("oh noes!") }
+
       before do
-        allow(kea_control_agent_gateway).to receive(:verify_config).and_raise(Gateways::KeaControlAgent::InternalError)
+        allow(kea_control_agent_gateway).to receive(:verify_config).and_raise(error)
       end
 
-      it "returns false" do
-        expect(use_case.call(config)).to eql(false)
+      it "returns an unsuccessful result" do
+        expect(use_case.call(config).success?).to eql(false)
+      end
+
+      it "returns the result error" do
+        expect(use_case.call(config).error).to eql(error)
       end
     end
   end


### PR DESCRIPTION
# What
Resurface errors from kea config validation to the user

# Why
Si the user can understand why a config may be invalid

# Screenshots

<img width="794" alt="Screenshot 2020-11-26 at 10 59 27" src="https://user-images.githubusercontent.com/326561/100342836-778a6f00-2fd6-11eb-8b96-8ae63dc512b9.png">

# Notes
I am unsure of the best way to remove the odd bracketed error codes from kea. We could regex, but this seems flakey. Given it provides little or no issue. Potentially we just ignore it.