### PR TITLE
Remove leftover stats controller for testing

### DIFF
--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -1,5 +1,0 @@
-class StatsController < ApplicationController
-  def dhcp
-    render json: Gateways::KeaControlAgent.new.fetch_stats
-  end
-end

--- a/app/lib/gateways/kea_control_agent.rb
+++ b/app/lib/gateways/kea_control_agent.rb
@@ -19,16 +19,6 @@ module Gateways
       handle_response(http.request(req).body).dig("arguments").fetch("leases")
     end
 
-    def fetch_stats
-      req = Net::HTTP::Post.new(uri.path, headers)
-      req.body = {
-        command: "statistic-get-all",
-        service: ["dhcp4"]
-      }.to_json
-
-      handle_response(http.request(req).body)
-    end
-
     def verify_config(config)
       req = Net::HTTP::Post.new(uri.path, headers)
       req.body = {

--- a/app/lib/gateways/kea_control_agent.rb
+++ b/app/lib/gateways/kea_control_agent.rb
@@ -64,6 +64,7 @@ module Gateways
     end
 
     class InternalError < StandardError; end
+
     class InvalidCommand < StandardError; end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,6 @@ Rails.application.routes.draw do
   resources :zones, except: [:index]
 
   get "/dhcp", to: "sites#index", as: :dhcp
-  get "/dhcp/stats", to: "stats#dhcp", as: :dhcp_stats
 
   resources :sites, except: [:index] do
     resources :subnets, only: [:new, :create]


### PR DESCRIPTION
We created this to test kea stats. Stats are no longer consumer or viewed via the admin app.
