### PR TITLE
Add multi threading support to the kea config

### DIFF
--- a/app/lib/use_cases/generate_kea_config.rb
+++ b/app/lib/use_cases/generate_kea_config.rb
@@ -234,7 +234,12 @@ module UseCases
             {
               "library": "/usr/lib/kea/hooks/libdhcp_stat_cmds.so"
             }
-          ]
+          ],
+          "multi-threading": {
+            "enable-multi-threading": true,
+            "thread-pool-size": 12,
+            "packet-queue-size": 792
+          }
         }.merge(global_options_config).merge(valid_lifetime_config).merge(client_class_config)
       }
     end

--- a/spec/use_cases/generate_kea_config_spec.rb
+++ b/spec/use_cases/generate_kea_config_spec.rb
@@ -70,7 +70,7 @@ describe UseCases::GenerateKeaConfig do
       expect(config[:Dhcp4].keys).to match_array([
         :"host-reservation-identifiers", :"hosts-database", :"interfaces-config",
         :"lease-database", :"valid-lifetime", :loggers, :subnet4,
-        :"control-socket", :"hooks-libraries"
+        :"control-socket", :"hooks-libraries", :"multi-threading"
       ])
     end
 


### PR DESCRIPTION
Values set based on testing by KEA for our backend (mysql)

https://kea.readthedocs.io/en/kea-1.8.0/arm/dhcp4-srv.html#multi-threading-settings-in-different-backends

Performance results for kea 1.7 found here:
https://jenkins.isc.org/job/kea-1.7/job/performance/KeaPerformanceReport/