### PR TITLE
Revert wildcard syntax for zones

### DIFF
--- a/app/models/zone.rb
+++ b/app/models/zone.rb
@@ -1,8 +1,5 @@
 class Zone < ApplicationRecord
-  VALID_ZONE_REGEX = /\A[a-z0-9*]+([\-.]{1}[a-z0-9]+)*\.[a-z]{2,5}(:[0-9]{1,5})?(\/.*)?\z/ix
-
-  validates :name, presence: true, uniqueness: {case_sensitive: false}
-  validates_format_of :name, with: VALID_ZONE_REGEX
+  validates :name, presence: true, uniqueness: {case_sensitive: false}, domain_name: true
 
   validates :forwarders,
     presence: {message: "must contain at least one IPv4 address separated using commas"},

--- a/spec/models/zone_spec.rb
+++ b/spec/models/zone_spec.rb
@@ -15,10 +15,8 @@ RSpec.describe Zone, type: :model do
   it { should allow_value("foo.example.com").for(:name) }
   it { should allow_value("foo-bar-1.abc.123.example.com").for(:name) }
   it { should allow_value("foo-BAR-1.ABC.123.example.com").for(:name) }
-  it { should allow_value("*.test.com").for(:name) }
   it { should_not allow_value("i_contain_an_at_sign@gov.uk").for(:name) }
   it { should_not allow_value("测试.com").for(:name) }
-  it { should_not allow_value("test.*.com").for(:name) }
 
   context "forwarders validation" do
     it "must be a valid IPv4 address" do


### PR DESCRIPTION
This doesn't work and just defining the TLD will match the incoming
request.

