### PR TITLE
Ensure queries are allowed from all clients

### DIFF
--- a/app/lib/use_cases/generate_bind_config.rb
+++ b/app/lib/use_cases/generate_bind_config.rb
@@ -19,6 +19,7 @@ options {
   pid-file "/var/run/named/named.pid";
 
   allow-transfer { none; };
+  allow-query { any; };
 };
 
 statistics-channels {
@@ -64,6 +65,7 @@ zone "." IN {
       %(
 zone "#{zone.name}" IN {
   type forward;
+  forward only;
   forwarders {#{format_zone_forwarders(zone.forwarders)}};
 };
 )

--- a/spec/use_cases/generate_bind_config_spec.rb
+++ b/spec/use_cases/generate_bind_config_spec.rb
@@ -21,6 +21,7 @@ options {
   pid-file "/var/run/named/named.pid";
 
   allow-transfer { none; };
+  allow-query { any; };
 };
 
 statistics-channels {
@@ -66,11 +67,13 @@ zone "." IN {
       expected_config = %(
 zone "example.test.com" IN {
   type forward;
+  forward only;
   forwarders {127.0.0.1;127.0.0.2;};
 };
 
 zone "example2.test.com" IN {
   type forward;
+  forward only;
   forwarders {10.0.0.1;10.0.0.255;};
 };
 )


### PR DESCRIPTION
We only allow known traffic from within the network, so unauthorised use
of the DNS servers won't be possible. Allow any query originating from
the internal network. This raised an error when not set.

Also add the forward only configuration to all zones, as we will never
be resolving queries ourselves.
