### PR TITLE
Add KEA HA to generated config

### DIFF
--- a/app/lib/use_cases/generate_kea_config.rb
+++ b/app/lib/use_cases/generate_kea_config.rb
@@ -233,7 +233,34 @@ module UseCases
             },
             {
               "library": "/usr/lib/kea/hooks/libdhcp_stat_cmds.so"
+            },
+            {
+              "library": "/usr/lib/kea/hooks/libdhcp_ha.so",
+              "parameters": {
+                "high-availability": [
+                {
+                  "this-server-name": "<SERVER_NAME>",
+                  "mode": "hot-standby",
+                  "heartbeat-delay": 10000,
+                  "max-response-delay": 10000,
+                  "max-ack-delay": 5000,
+                  "max-unacked-clients": 5,
+                  "peers": [
+                    {
+                      "name": "primary",
+                      "url": "<PRIMARY_IP>",
+                      "role": "primary"
+                    },
+                    {
+                      "name": "standby",
+                      "url": "<STANDBY_IP>",
+                      "role": "standby"
+                    }
+                  ]
+                }
+              ]
             }
+          }
           ],
           "multi-threading": {
             "enable-multi-threading": true,

--- a/app/lib/use_cases/generate_kea_config.rb
+++ b/app/lib/use_cases/generate_kea_config.rb
@@ -238,29 +238,29 @@ module UseCases
               "library": "/usr/lib/kea/hooks/libdhcp_ha.so",
               "parameters": {
                 "high-availability": [
-                {
-                  "this-server-name": "<SERVER_NAME>",
-                  "mode": "hot-standby",
-                  "heartbeat-delay": 10000,
-                  "max-response-delay": 10000,
-                  "max-ack-delay": 5000,
-                  "max-unacked-clients": 5,
-                  "peers": [
-                    {
-                      "name": "primary",
-                      "url": "<PRIMARY_IP>",
-                      "role": "primary"
-                    },
-                    {
-                      "name": "standby",
-                      "url": "<STANDBY_IP>",
-                      "role": "standby"
-                    }
-                  ]
-                }
-              ]
+                  {
+                    "this-server-name": "<SERVER_NAME>",
+                    "mode": "hot-standby",
+                    "heartbeat-delay": 10000,
+                    "max-response-delay": 10000,
+                    "max-ack-delay": 5000,
+                    "max-unacked-clients": 5,
+                    "peers": [
+                      {
+                        "name": "primary",
+                        "url": "<PRIMARY_IP>",
+                        "role": "primary"
+                      },
+                      {
+                        "name": "standby",
+                        "url": "<STANDBY_IP>",
+                        "role": "standby"
+                      }
+                    ]
+                  }
+                ]
+              }
             }
-          }
           ],
           "multi-threading": {
             "enable-multi-threading": true,

--- a/spec/use_cases/generate_kea_config_spec.rb
+++ b/spec/use_cases/generate_kea_config_spec.rb
@@ -331,12 +331,12 @@ describe UseCases::GenerateKeaConfig do
            {
              "high-availability": [
                {
-                "heartbeat-delay": 10000,
-                "max-ack-delay": 5000,
-                "max-response-delay": 10000,
-                "max-unacked-clients": 5,
-                mode: "hot-standby",
-                peers:
+                 "heartbeat-delay": 10000,
+                 "max-ack-delay": 5000,
+                 "max-response-delay": 10000,
+                 "max-unacked-clients": 5,
+                 mode: "hot-standby",
+                 peers:
                   [
                     {
                       name: "primary",
@@ -349,12 +349,12 @@ describe UseCases::GenerateKeaConfig do
                       url: "<STANDBY_IP>"
                     }
                   ],
-                "this-server-name": "<SERVER_NAME>"
+                 "this-server-name": "<SERVER_NAME>"
                }
-              ]
-            }
-          }
-        )
+             ]
+           }
+        }
+      )
     end
   end
 end

--- a/spec/use_cases/generate_kea_config_spec.rb
+++ b/spec/use_cases/generate_kea_config_spec.rb
@@ -314,5 +314,47 @@ describe UseCases::GenerateKeaConfig do
         }
       ])
     end
+
+    it "adds the KEA hooks configuration" do
+      config = UseCases::GenerateKeaConfig.new.call
+
+      expect(config.dig(:Dhcp4, :"hooks-libraries")).to include(
+        {
+          library: "/usr/lib/kea/hooks/libdhcp_lease_cmds.so"
+        },
+        {
+          library: "/usr/lib/kea/hooks/libdhcp_stat_cmds.so"
+        },
+        {
+          library: "/usr/lib/kea/hooks/libdhcp_ha.so",
+          parameters:
+           {
+             "high-availability": [
+               {
+                "heartbeat-delay": 10000,
+                "max-ack-delay": 5000,
+                "max-response-delay": 10000,
+                "max-unacked-clients": 5,
+                mode: "hot-standby",
+                peers:
+                  [
+                    {
+                      name: "primary",
+                      role: "primary",
+                      url: "<PRIMARY_IP>"
+                    },
+                    {
+                      name: "standby",
+                      role: "standby",
+                      url: "<STANDBY_IP>"
+                    }
+                  ],
+                "this-server-name": "<SERVER_NAME>"
+               }
+              ]
+            }
+          }
+        )
+    end
   end
 end


### PR DESCRIPTION
# What

This will have placeholder values for the server name and peer IPs,
which will be injected at runtime when the KEA container starts.

# Why

To run in hot standby mode, we need the configuration to specify this
