### PR TITLE
Add auto-failover to HA configuration

### DIFF
--- a/app/lib/use_cases/generate_kea_config.rb
+++ b/app/lib/use_cases/generate_kea_config.rb
@@ -241,20 +241,23 @@ module UseCases
                   {
                     "this-server-name": "<SERVER_NAME>",
                     "mode": "hot-standby",
-                    "heartbeat-delay": 10000,
-                    "max-response-delay": 10000,
-                    "max-ack-delay": 5000,
-                    "max-unacked-clients": 5,
+                    "heartbeat-interval": 10,
+                    "heartbeat-delay": 20,
+                    "max-response-delay": 60,
+                    "max-ack-delay": 10,
+                    "max-unacked-clients": 10,
                     "peers": [
                       {
                         "name": "primary",
                         "url": "http://<PRIMARY_IP>:8000",
-                        "role": "primary"
+                        "role": "primary",
+                        "auto-failover": true
                       },
                       {
                         "name": "standby",
                         "url": "http://<STANDBY_IP>:8000",
-                        "role": "standby"
+                        "role": "standby",
+                        "auto-failover": true
                       }
                     ]
                   }

--- a/spec/use_cases/generate_kea_config_spec.rb
+++ b/spec/use_cases/generate_kea_config_spec.rb
@@ -331,25 +331,28 @@ describe UseCases::GenerateKeaConfig do
            {
              "high-availability": [
                {
-                 "heartbeat-delay": 10000,
-                 "max-ack-delay": 5000,
-                 "max-response-delay": 10000,
-                 "max-unacked-clients": 5,
+                 "this-server-name": "<SERVER_NAME>",
                  mode: "hot-standby",
+                 "heartbeat-interval": 10,
+                 "heartbeat-delay": 20,
+                 "max-response-delay": 60,
+                 "max-ack-delay": 10,
+                 "max-unacked-clients": 10,
                  peers:
                   [
                     {
                       name: "primary",
                       role: "primary",
-                      url: "http://<PRIMARY_IP>:8000"
+                      url: "http://<PRIMARY_IP>:8000",
+                      "auto-failover": true
                     },
                     {
                       name: "standby",
                       role: "standby",
-                      url: "http://<STANDBY_IP>:8000"
+                      url: "http://<STANDBY_IP>:8000",
+                      "auto-failover": true
                     }
-                  ],
-                 "this-server-name": "<SERVER_NAME>"
+                  ]
                }
              ]
            }


### PR DESCRIPTION
When a peer is down, traffic should be redirected to the remaining peer

# What
Reduce the heartbeat configuration settings as per documentation
here: https://gitlab.isc.org/isc-projects/kea/-/wikis/designs/High-Availability-Design
