### PR TITLE
Display lease state in the leases table

### DIFF
--- a/app/lib/gateways/kea_control_agent.rb
+++ b/app/lib/gateways/kea_control_agent.rb
@@ -49,7 +49,7 @@ module Gateways
     end
 
     def handle_response(response_body)
-      logger.info("Kea response: #{response_body}") if logger
+      logger&.info("Kea response: #{response_body}")
 
       body = parse_response(response_body)
 

--- a/app/lib/use_cases/fetch_leases.rb
+++ b/app/lib/use_cases/fetch_leases.rb
@@ -11,7 +11,8 @@ class UseCases::FetchLeases
       Lease.new(
         hw_address: lease_data["hw-address"],
         ip_address: lease_data["ip-address"],
-        hostname: lease_data["hostname"]
+        hostname: lease_data["hostname"],
+        state: lease_data["state"]
       )
     end
   end

--- a/app/models/lease.rb
+++ b/app/models/lease.rb
@@ -1,11 +1,21 @@
 class Lease
   attr_reader :hw_address,
     :ip_address,
-    :hostname
+    :hostname,
+    :state
 
-  def initialize(hw_address:, ip_address:, hostname:)
+  def initialize(hw_address:, ip_address:, hostname:, state:)
     @hw_address = hw_address
     @ip_address = ip_address
     @hostname = hostname
+    @state = state
+  end
+
+  def pretty_state
+    return "Leased" if state == 0
+    return "Declined" if state == 1
+    return "Expired / Reclaimed" if state == 2
+
+    "Unknown"
   end
 end

--- a/app/views/leases/index.html.erb
+++ b/app/views/leases/index.html.erb
@@ -5,6 +5,7 @@
       <th scope="col" class="govuk-table__header">HW address</th>
       <th scope="col" class="govuk-table__header">IP address</th>
       <th scope="col" class="govuk-table__header">Hostname</th>
+      <th scope="col" class="govuk-table__header">State</th>
     </tr>
   </thead>
   <tbody class="govuk-table__body">
@@ -13,6 +14,7 @@
         <td class="govuk-table__cell"><%= lease.hw_address %></td>
         <td class="govuk-table__cell"><%= lease.ip_address %></td>
         <td class="govuk-table__cell"><%= lease.hostname %></td>
+        <td class="govuk-table__cell"><%= lease.pretty_state %></td>
       </tr>
     <% end %>
   </tbody>

--- a/spec/acceptance/list_leases_spec.rb
+++ b/spec/acceptance/list_leases_spec.rb
@@ -16,7 +16,8 @@ RSpec.describe "Listing leases", type: :feature do
             {
               "hw-address": hw_address,
               "ip-address": ip_address,
-              "hostname": hostname
+              "hostname": hostname,
+              "state": 0
             }
           ]
         },
@@ -46,5 +47,6 @@ RSpec.describe "Listing leases", type: :feature do
     expect(page).to have_content hw_address
     expect(page).to have_content ip_address
     expect(page).to have_content hostname
+    expect(page).to have_content "Leased"
   end
 end

--- a/spec/use_cases/fetch_leases_spec.rb
+++ b/spec/use_cases/fetch_leases_spec.rb
@@ -18,7 +18,8 @@ RSpec.describe UseCases::FetchLeases do
       {
         "hw-address" => hw_address,
         "ip-address" => ip_address,
-        "hostname" => hostname
+        "hostname" => hostname,
+        "state" => 1
       }
     ]
   end
@@ -33,7 +34,8 @@ RSpec.describe UseCases::FetchLeases do
         class: Lease,
         hw_address: hw_address,
         ip_address: ip_address,
-        hostname: hostname
+        hostname: hostname,
+        state: 1
       )
     ])
   end


### PR DESCRIPTION
# What
Display the state (Leased, Declined, Expired / Reclaimed) so that it's clear what state a Lease is in

# Why
This is important because a lease that has expired / is being reclaimed will be included in the response until it has been released / re-assigned.

# Screenshots

# Notes
States are defined here https://kea.readthedocs.io/en/kea-1.8.0/arm/hooks.html#the-lease4-add-lease6-add-commands