### PR TITLE
Update HA configuration values

### DIFF
--- a/app/lib/use_cases/generate_kea_config.rb
+++ b/app/lib/use_cases/generate_kea_config.rb
@@ -224,7 +224,7 @@ module UseCases
                 }
               ],
               severity: "DEBUG",
-              debuglevel: 99
+              debuglevel: 0
             }
           ],
           "hooks-libraries": [
@@ -241,11 +241,10 @@ module UseCases
                   {
                     "this-server-name": "<SERVER_NAME>",
                     "mode": "hot-standby",
-                    "heartbeat-interval": 10,
-                    "heartbeat-delay": 20,
-                    "max-response-delay": 60,
-                    "max-ack-delay": 10,
-                    "max-unacked-clients": 10,
+                    "heartbeat-delay": 5000,
+                    "max-response-delay": 5000,
+                    "max-ack-delay": 5000,
+                    "max-unacked-clients": 0,
                     "peers": [
                       {
                         "name": "primary",

--- a/spec/use_cases/generate_kea_config_spec.rb
+++ b/spec/use_cases/generate_kea_config_spec.rb
@@ -331,12 +331,12 @@ describe UseCases::GenerateKeaConfig do
            {
              "high-availability": [
                {
-                "this-server-name": "<SERVER_NAME>",
-                mode: "hot-standby",
-                "heartbeat-delay": 5000,
-                "max-response-delay": 5000,
-                "max-ack-delay": 5000,
-                "max-unacked-clients": 0,
+                 "this-server-name": "<SERVER_NAME>",
+                 mode: "hot-standby",
+                 "heartbeat-delay": 5000,
+                 "max-response-delay": 5000,
+                 "max-ack-delay": 5000,
+                 "max-unacked-clients": 0,
                  peers:
                   [
                     {

--- a/spec/use_cases/generate_kea_config_spec.rb
+++ b/spec/use_cases/generate_kea_config_spec.rb
@@ -331,13 +331,12 @@ describe UseCases::GenerateKeaConfig do
            {
              "high-availability": [
                {
-                 "this-server-name": "<SERVER_NAME>",
-                 mode: "hot-standby",
-                 "heartbeat-interval": 10,
-                 "heartbeat-delay": 20,
-                 "max-response-delay": 60,
-                 "max-ack-delay": 10,
-                 "max-unacked-clients": 10,
+                "this-server-name": "<SERVER_NAME>",
+                mode: "hot-standby",
+                "heartbeat-delay": 5000,
+                "max-response-delay": 5000,
+                "max-ack-delay": 5000,
+                "max-unacked-clients": 0,
                  peers:
                   [
                     {


### PR DESCRIPTION
# What

Update HA configuration values in the dynamically generated KEA config file

# Why

These are represented as milliseconds not seconds.

Also set debug level to 0, we don't need these verbose logs for testing
anymore.
