### PR TITLE
Make admin networking easier

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -7,4 +7,4 @@ DHCP_CLUSTER_NAME=some-cluster
 DNS_SERVICE_NAME=some-dns-service
 DNS_CLUSTER_NAME=some-dns-cluster
 PDNS_IPS="1.2.3.4,7.7.7.7"
-KEA_CONTROL_AGENT_URI=http://172.1.0.3:8000/
+KEA_CONTROL_AGENT_URI=http://dhcp-primary:8000/

--- a/README.md
+++ b/README.md
@@ -18,6 +18,13 @@ aws-vault exec SHARED_SERVICES_VAULT_PROFILE_NAME -- aws ecr get-login-password 
 
 Replace ```SHARED_SERVICES_VAULT_PROFILE_NAME``` and ```SHARED_SERVICES_ACCOUNT_ID``` in the command above with the profile name and ID of the shared services account configured in aws-vault.
 
+### Prerequisite to starting the App
+
+This repo is dependant on a locally running dhcp network. This is so that the admin app can query the dhcp api without timing out.
+1. Clone the repository [here](https://github.com/ministryofjustice/staff-device-dhcp-server)
+1. Follow the insturctions in the cloned repository to run the dhcp server
+1. Navigate back to this repo
+
 ### Starting the App
 
 1. Clone the repository

--- a/buildspec.test.yml
+++ b/buildspec.test.yml
@@ -17,5 +17,6 @@ phases:
   build:
     commands:
       - make authenticate-docker
+      - docker network create staff-device-dhcp-server_default
       - ENV=test make db-setup
       - make test

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,16 @@ services:
     ports:
       - "3000:3000"
     env_file: .env.${ENV}
+    networks:
+      - default
+      - dhcp
 
 volumes:
   node_modules:
   datavolume:
+
+networks:
+  dhcp:
+    external:
+      name: "staff-device-dhcp-server_default"
+


### PR DESCRIPTION
# What
Changed admin networking so that we don't get timeouts locally
# Why
We were getting timeouts
# Screenshots
N/A
# Notes
This change requires local users to have a running version of the dhcp repo. 