### PR TITLE
Make client class options take precedence over subnet options

### DIFF
--- a/app/lib/use_cases/generate_kea_config.rb
+++ b/app/lib/use_cases/generate_kea_config.rb
@@ -43,7 +43,7 @@ module UseCases
     def require_client_class_config(subnet)
       return {} unless include_subnet_options?(subnet)
 
-      {"require-client-classes": [subnet_client_class_name(subnet)]}
+      {"require-client-classes": [subnet.client_class_name]}
     end
 
     def reservations_config(reservations)
@@ -115,7 +115,7 @@ module UseCases
 
           options_config = UseCases::KeaConfig::GenerateOptionDataConfig.new.call(subnet.option)
           {
-            name: subnet_client_class_name(subnet),
+            name: subnet.client_class_name,
             test: "member('ALL')",
             "only-if-required": true
           }.merge(options_config)
@@ -123,10 +123,6 @@ module UseCases
 
         option_client_classes
       end
-    end
-
-    def subnet_client_class_name(subnet)
-      "subnet-#{subnet.ip_addr}-client"
     end
 
     def default_config

--- a/app/lib/use_cases/kea_config/generate_option_data_config.rb
+++ b/app/lib/use_cases/kea_config/generate_option_data_config.rb
@@ -1,0 +1,36 @@
+module UseCases
+  module KeaConfig
+    class GenerateOptionDataConfig
+      def call(option)
+        return {} unless option.present?
+
+        result = {
+          "option-data": []
+        }
+
+        if option.respond_to?(:domain_name) && option.domain_name.present?
+          result[:"option-data"] << {
+            "name": "domain-name",
+            "data": option.domain_name
+          }
+        end
+
+        if option.respond_to?(:domain_name_servers) && option.domain_name_servers.any?
+          result[:"option-data"] << {
+            "name": "domain-name-servers",
+            "data": option.domain_name_servers.join(", ")
+          }
+        end
+
+        if option.respond_to?(:routers) && option.routers.any?
+          result[:"option-data"] << {
+            "name": "routers",
+            "data": option.routers.join(", ")
+          }
+        end
+
+        result
+      end
+    end
+  end
+end

--- a/app/models/subnet.rb
+++ b/app/models/subnet.rb
@@ -49,6 +49,10 @@ class Subnet < ApplicationRecord
     self[:end_address] = val.try(:strip)
   end
 
+  def client_class_name
+    "subnet-#{ip_addr}-client"
+  end
+
   private
 
   def cidr_block_is_a_valid_ipv4_subnet

--- a/spec/use_cases/generate_kea_config_spec.rb
+++ b/spec/use_cases/generate_kea_config_spec.rb
@@ -181,7 +181,7 @@ describe UseCases::GenerateKeaConfig do
             "hw-address": reservation.hw_address,
             "ip-address": reservation.ip_address,
             "hostname": reservation.hostname,
-            "option-data": [
+            "option-data": match_array([
               {
                 "name": "routers",
                 "data": reservation_option.routers.join(", ")
@@ -190,7 +190,7 @@ describe UseCases::GenerateKeaConfig do
                 "name": "domain-name",
                 "data": reservation_option.domain_name
               }
-            ],
+            ]),
             "user-context": {
               "description": reservation.description
             }
@@ -280,22 +280,22 @@ describe UseCases::GenerateKeaConfig do
       client_class2 = build(:client_class)
       config = UseCases::GenerateKeaConfig.new(client_classes: [client_class, client_class2]).call
 
-      expect(config.dig(:Dhcp4, :"client-classes")).to eq([
+      expect(config.dig(:Dhcp4, :"client-classes")).to match_array([
         {
           name: client_class.name,
           test: "option[77].hex == '#{client_class.client_id}'",
-          "option-data": [
+          "option-data": match_array([
             {name: "domain-name", data: client_class.domain_name},
             {name: "domain-name-servers", data: client_class.domain_name_servers.join(", ")}
-          ]
+          ])
         },
         {
           name: client_class2.name,
           test: "option[77].hex == '#{client_class2.client_id}'",
-          "option-data": [
+          "option-data": match_array([
             {name: "domain-name", data: client_class2.domain_name},
             {name: "domain-name-servers", data: client_class2.domain_name_servers.join(", ")}
-          ]
+          ])
         }
       ])
     end
@@ -352,16 +352,16 @@ describe UseCases::GenerateKeaConfig do
         hash_including("require-client-classes": ["subnet-10.0.4.0-client"])
       )
 
-      expect(config.dig(:Dhcp4, :"client-classes")).to eq([
+      expect(config.dig(:Dhcp4, :"client-classes")).to match([
         {
           name: "subnet-10.0.4.0-client",
           test: "member('ALL')",
           "only-if-required": true,
-          "option-data": [
+          "option-data": match_array([
             {"name": "domain-name-servers", "data": subnet.domain_name_servers.join(", ")},
             {"name": "routers", "data": subnet.routers.join(", ")},
             {"name": "domain-name", "data": subnet.domain_name}
-          ]
+          ])
         }
       ])
     end


### PR DESCRIPTION
# What

Make client class options take precedence over subnet options

# Why
We want options set at the client level to take precedence over subnet options. To achieve this we need to change how we define subnet options in the config by creating client classes containing options for a subnet. This way the client will get selected first before the subnet and the correct options will be applied.

See https://kb.isc.org/docs/en/understanding-client-classificationin the "Influencing Options Precedence" section