### PR TITLE
Set the secure flag on cookies

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -28,8 +28,8 @@ module StaffDeviceDnsDhcpAdmin
     config.force_ssl = true
     config.ssl_options = {
       redirect: {
-        exclude: ->(request) { request.path =~ /healthcheck/ },
-      },
+        exclude: ->(request) { request.path =~ /healthcheck/ }
+      }
     }
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers

--- a/config/application.rb
+++ b/config/application.rb
@@ -24,6 +24,13 @@ module StaffDeviceDnsDhcpAdmin
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.0
 
+    # Force HTTPS for all requests except healthcheck endpoint
+    config.force_ssl = true
+    config.ssl_options = {
+      redirect: {
+        exclude: ->(request) { request.path =~ /healthcheck/ },
+      },
+    }
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -52,6 +52,7 @@ Rails.application.configure do
 
   # Suppress logger output for asset requests.
   config.assets.quiet = true
+  config.force_ssl = false
 
   # Raises error for missing translations.
   # config.action_view.raise_on_missing_translations = true

--- a/spec/request/cve_2015_9284_spec.rb
+++ b/spec/request/cve_2015_9284_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 RSpec.describe "CVE-2015-9284", type: :request do
   describe "GET /auth/:provider" do
     it do
-      get "/users/auth/cognito"
+      get "/users/auth/cognito", headers: { "HTTPS" => "on" }
       expect(response).not_to have_http_status(:redirect)
     end
   end
@@ -17,7 +17,7 @@ RSpec.describe "CVE-2015-9284", type: :request do
 
     it do
       expect {
-        post "/users/auth/cognito"
+        post "/users/auth/cognito", headers: { "HTTPS" => "on" }
       }.to raise_error(ActionController::InvalidAuthenticityToken)
     end
 

--- a/spec/request/cve_2015_9284_spec.rb
+++ b/spec/request/cve_2015_9284_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 RSpec.describe "CVE-2015-9284", type: :request do
   describe "GET /auth/:provider" do
     it do
-      get "/users/auth/cognito", headers: { "HTTPS" => "on" }
+      get "/users/auth/cognito", headers: {"HTTPS" => "on"}
       expect(response).not_to have_http_status(:redirect)
     end
   end
@@ -17,7 +17,7 @@ RSpec.describe "CVE-2015-9284", type: :request do
 
     it do
       expect {
-        post "/users/auth/cognito", headers: { "HTTPS" => "on" }
+        post "/users/auth/cognito", headers: {"HTTPS" => "on"}
       }.to raise_error(ActionController::InvalidAuthenticityToken)
     end
 


### PR DESCRIPTION
# What
Set secure flag on cookies
NLB Health checks need to go over HTTP or it will return a 301

# Why
prevent potential XSS and MITM attacks
