### PR TITLE
Set the Expect-CT header

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,6 @@
 class ApplicationController < ActionController::Base
   before_action :authenticate_user!
+  after_action :set_expect_ct_header
 
   def new_session_path(scope)
     new_user_session_path
@@ -18,6 +19,10 @@ class ApplicationController < ActionController::Base
   end
 
   private
+
+  def set_expect_ct_header
+    response.headers['Expect-CT'] = "max-age=86400, enforce"
+  end
 
   # Overwriting the sign_out redirect path method
   def after_sign_out_path_for(resource_or_scope)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -21,7 +21,7 @@ class ApplicationController < ActionController::Base
   private
 
   def set_expect_ct_header
-    response.headers['Expect-CT'] = "max-age=86400, enforce"
+    response.headers["Expect-CT"] = "max-age=86400, enforce"
   end
 
   # Overwriting the sign_out redirect path method


### PR DESCRIPTION
# What

Add new header to improve SSL of the application.

More details can be found here:
https://wiki.owasp.org/index.php/OWASP_Secure_Headers_Project#ect

# Why
This improves the security posture of the application

# Notes

https://github.com/github/secure_headers was considered but comes with additional headers by default that are not required.
