### PR TITLE
Filter out nil values from the client class array when subnets have no options

### DIFF
--- a/app/lib/use_cases/generate_kea_config.rb
+++ b/app/lib/use_cases/generate_kea_config.rb
@@ -110,7 +110,7 @@ module UseCases
 
     def subnet_option_client_classes
       @subnet_option_client_classes ||= begin
-        option_client_classes = @subnets.map { |subnet|
+        option_client_classes = @subnets.filter_map { |subnet|
           next unless include_subnet_options?(subnet)
 
           options_config = UseCases::KeaConfig::GenerateOptionDataConfig.new.call(subnet.option)

--- a/spec/use_cases/generate_kea_config_spec.rb
+++ b/spec/use_cases/generate_kea_config_spec.rb
@@ -376,5 +376,13 @@ describe UseCases::GenerateKeaConfig do
         ["DOM1 device", "subnet-10.0.4.0-client"]
       )
     end
+
+    it "filters out nils from the client class array when subnets have no options" do
+      subnet = create(:subnet, index: 0)
+      subnet2 = create(:subnet, :with_option, index: 1)
+
+      config = UseCases::GenerateKeaConfig.new(subnets: [subnet, subnet2]).call
+      expect(config.dig(:Dhcp4, :"client-classes")).to_not include nil
+    end
   end
 end


### PR DESCRIPTION
In the @subnets.map block, we call next if the subnet has no options. Calling next in a map block will return nil when the block ends. The nil values were  resulting in invalid KEA config. This change uses Enumerable#filter_map to filter out all nil values (same as doing a map followed by compact).
