### PR TITLE
Validate that ClientClass#name does not start with the preserved subnet prefix

### DIFF
--- a/app/models/client_class.rb
+++ b/app/models/client_class.rb
@@ -34,7 +34,7 @@ class ClientClass < ApplicationRecord
     return if name.blank?
 
     if name.start_with?(Subnet::CLIENT_CLASS_NAME_PREFIX)
-      # subnet prefix is preserved for Subnet#client_class_name
+      # subnet prefix is reserved for Subnet#client_class_name
       errors.add(:name, "cannot begin with the word '#{Subnet::CLIENT_CLASS_NAME_PREFIX}'")
     end
   end

--- a/app/models/client_class.rb
+++ b/app/models/client_class.rb
@@ -11,6 +11,7 @@ class ClientClass < ApplicationRecord
   validates :domain_name, domain_name: true
 
   validate :only_one_record
+  validate :name_cannot_start_with_subnet
 
   before_validation :strip_whitespace
 
@@ -26,6 +27,15 @@ class ClientClass < ApplicationRecord
   def only_one_record
     if ClientClass.where.not(id: id).exists?
       errors.add(:base, "A client class already exists")
+    end
+  end
+
+  def name_cannot_start_with_subnet
+    return if name.blank?
+
+    if name.start_with?(Subnet::CLIENT_CLASS_NAME_PREFIX)
+      # subnet prefix is preserved for Subnet#client_class_name
+      errors.add(:name, "cannot begin with the word '#{Subnet::CLIENT_CLASS_NAME_PREFIX}'")
     end
   end
 

--- a/app/models/subnet.rb
+++ b/app/models/subnet.rb
@@ -1,5 +1,6 @@
 class Subnet < ApplicationRecord
   KEA_SUBNET_ID_OFFSET = 1000
+  CLIENT_CLASS_NAME_PREFIX = "subnet"
 
   belongs_to :site
   has_one :option, dependent: :destroy
@@ -50,7 +51,7 @@ class Subnet < ApplicationRecord
   end
 
   def client_class_name
-    "subnet-#{ip_addr}-client"
+    "#{CLIENT_CLASS_NAME_PREFIX}-#{ip_addr}-client"
   end
 
   private

--- a/spec/models/client_class_spec.rb
+++ b/spec/models/client_class_spec.rb
@@ -103,4 +103,10 @@ RSpec.describe ClientClass, type: :model do
     expect(new_client_class).to_not be_valid
     expect(new_client_class.errors[:base]).to include "A client class already exists"
   end
+
+  it "name cannot be prefixed with the word 'subnet'" do
+    client_class = build(:client_class, name: "subnet-1234")
+    expect(client_class).to_not be_valid
+    expect(client_class.errors[:name]).to include("cannot begin with the word 'subnet'")
+  end
 end


### PR DESCRIPTION
The "subnet" prefix is preserved for use by subnet client classes (which are used to alter the precedence of options in the kea config)
