### PR TITLE
Make subnet option routers mandatory

### DIFF
--- a/app/controllers/options_controller.rb
+++ b/app/controllers/options_controller.rb
@@ -61,7 +61,7 @@ class OptionsController < ApplicationController
   end
 
   def option_params
-    params.require(:option).permit(:routers, :domain_name_servers, :domain_name, :valid_lifetime)
+    params.require(:option).permit(:domain_name_servers, :domain_name, :valid_lifetime)
   end
 
   def confirmed?

--- a/app/controllers/subnets_controller.rb
+++ b/app/controllers/subnets_controller.rb
@@ -72,6 +72,6 @@ class SubnetsController < ApplicationController
   end
 
   def subnet_params
-    params.require(:subnet).permit(:cidr_block, :start_address, :end_address)
+    params.require(:subnet).permit(:cidr_block, :start_address, :end_address, :routers)
   end
 end

--- a/app/lib/use_cases/generate_kea_config.rb
+++ b/app/lib/use_cases/generate_kea_config.rb
@@ -33,17 +33,7 @@ module UseCases
         }
       }.merge(subnet_valid_lifetime_config(subnet.option))
         .merge(reservations_config(subnet.reservations))
-        .merge(require_client_class_config(subnet))
-    end
-
-    def include_subnet_options?(subnet)
-      subnet.option.present?
-    end
-
-    def require_client_class_config(subnet)
-      return {} unless include_subnet_options?(subnet)
-
-      {"require-client-classes": [subnet.client_class_name]}
+        .merge({"require-client-classes": [subnet.client_class_name]})
     end
 
     def reservations_config(reservations)
@@ -111,7 +101,6 @@ module UseCases
     def subnet_option_client_classes
       @subnet_option_client_classes ||= begin
         option_client_classes = @subnets.filter_map { |subnet|
-          next unless include_subnet_options?(subnet)
 
           options_config = UseCases::KeaConfig::GenerateOptionDataConfig.new.call(subnet)
           {

--- a/app/lib/use_cases/generate_kea_config.rb
+++ b/app/lib/use_cases/generate_kea_config.rb
@@ -101,7 +101,6 @@ module UseCases
     def subnet_option_client_classes
       @subnet_option_client_classes ||= begin
         option_client_classes = @subnets.filter_map { |subnet|
-
           options_config = UseCases::KeaConfig::GenerateOptionDataConfig.new.call(subnet)
           {
             name: subnet.client_class_name,

--- a/app/lib/use_cases/generate_kea_config.rb
+++ b/app/lib/use_cases/generate_kea_config.rb
@@ -113,7 +113,7 @@ module UseCases
         option_client_classes = @subnets.filter_map { |subnet|
           next unless include_subnet_options?(subnet)
 
-          options_config = UseCases::KeaConfig::GenerateOptionDataConfig.new.call(subnet.option)
+          options_config = UseCases::KeaConfig::GenerateOptionDataConfig.new.call(subnet)
           {
             name: subnet.client_class_name,
             test: "member('ALL')",

--- a/app/lib/use_cases/kea_config/generate_option_data_config.rb
+++ b/app/lib/use_cases/kea_config/generate_option_data_config.rb
@@ -15,7 +15,7 @@ module UseCases
           }
         end
 
-        if option.respond_to?(:domain_name_servers) && option.domain_name_servers.any?
+        if option.respond_to?(:domain_name_servers) && option.domain_name_servers.present?
           result[:"option-data"] << {
             "name": "domain-name-servers",
             "data": option.domain_name_servers.join(", ")

--- a/app/models/option.rb
+++ b/app/models/option.rb
@@ -1,6 +1,6 @@
 class Option < ApplicationRecord
   INVALID_IPV4_LIST_MESSAGE = "contains an invalid IPv4 address or is not separated using commas"
-  
+
   belongs_to :subnet
 
   validates :subnet, presence: true

--- a/app/models/option.rb
+++ b/app/models/option.rb
@@ -1,8 +1,9 @@
 class Option < ApplicationRecord
+  INVALID_IPV4_LIST_MESSAGE = "contains an invalid IPv4 address or is not separated using commas"
+  
   belongs_to :subnet
 
   validates :subnet, presence: true
-  INVALID_IPV4_LIST_MESSAGE = "contains an invalid IPv4 address or is not separated using commas"
   validates :domain_name_servers, ipv4_list: {message: INVALID_IPV4_LIST_MESSAGE}
   validates :valid_lifetime, numericality: {greater_than_or_equal_to: 0, only_integer: true},
                              allow_nil: true

--- a/app/models/option.rb
+++ b/app/models/option.rb
@@ -3,7 +3,6 @@ class Option < ApplicationRecord
 
   validates :subnet, presence: true
   INVALID_IPV4_LIST_MESSAGE = "contains an invalid IPv4 address or is not separated using commas"
-  validates :routers, ipv4_list: {message: INVALID_IPV4_LIST_MESSAGE}
   validates :domain_name_servers, ipv4_list: {message: INVALID_IPV4_LIST_MESSAGE}
   validates :valid_lifetime, numericality: {greater_than_or_equal_to: 0, only_integer: true},
                              allow_nil: true
@@ -15,11 +14,6 @@ class Option < ApplicationRecord
 
   audited
 
-  def routers
-    return [] unless self[:routers]
-    self[:routers].split(",")
-  end
-
   def domain_name_servers
     return [] unless self[:domain_name_servers]
     self[:domain_name_servers].split(",")
@@ -28,12 +22,11 @@ class Option < ApplicationRecord
   private
 
   def at_least_one_option
-    return if routers.any? || domain_name_servers.any? || domain_name.present? || valid_lifetime.present?
+    return if domain_name_servers.any? || domain_name.present? || valid_lifetime.present?
     errors.add(:base, "At least one option must be filled out")
   end
 
   def strip_whitespace
-    self[:routers] = self[:routers]&.strip&.delete(" ")
     self[:domain_name_servers] = self[:domain_name_servers]&.strip&.delete(" ")
   end
 end

--- a/app/models/subnet.rb
+++ b/app/models/subnet.rb
@@ -1,6 +1,7 @@
 class Subnet < ApplicationRecord
   KEA_SUBNET_ID_OFFSET = 1000
   CLIENT_CLASS_NAME_PREFIX = "subnet"
+  INVALID_IPV4_LIST_MESSAGE = "contains an invalid IPv4 address or is not separated using commas"
 
   belongs_to :site
   has_one :option, dependent: :destroy
@@ -10,7 +11,6 @@ class Subnet < ApplicationRecord
   validates :start_address, presence: true
   validates :end_address, presence: true
   validates :routers, presence: true
-  INVALID_IPV4_LIST_MESSAGE = "contains an invalid IPv4 address or is not separated using commas"
   validates :routers, ipv4_list: {message: INVALID_IPV4_LIST_MESSAGE}
 
   validate :cidr_block_is_a_valid_ipv4_subnet, :start_address_is_a_valid_ipv4_address,

--- a/app/views/options/_details.html.erb
+++ b/app/views/options/_details.html.erb
@@ -1,15 +1,6 @@
 <dl class="govuk-summary-list">
   <div class="govuk-summary-list__row">
     <dt class="govuk-summary-list__key">
-      Routers
-    </dt>
-    <dd class="govuk-summary-list__value">
-      <%= @subnet.routers.join(",") %>
-    </dd>
-  </div>
-
-  <div class="govuk-summary-list__row">
-    <dt class="govuk-summary-list__key">
       Domain name servers
     </dt>
     <dd class="govuk-summary-list__value">

--- a/app/views/options/_form.html.erb
+++ b/app/views/options/_form.html.erb
@@ -2,14 +2,6 @@
               url: subnet_options_path(option.subnet),
               method: option.new_record? ? :post : :put,
               local: true do |f| %>
-  <div class="govuk-form-group <%= field_error(f.object, :routers )%>">
-    <%= f.label :routers, class: "govuk-label" %>
-    <div id="options_routers-hint" class="govuk-hint">
-      Must be in the form: 127.0.0.1,127.0.0.2
-    </div>
-    <%= f.text_area :routers, value: f.object.routers.join(","), class: "govuk-input" %>
-  </div>
-
   <div class="govuk-form-group <%= field_error(f.object, :domain_name_servers) %>">
     <%= f.label :domain_name_servers, class: "govuk-label" %>
     <div id="options_domain_name_servers-hint" class="govuk-hint">

--- a/app/views/subnets/_form.html.erb
+++ b/app/views/subnets/_form.html.erb
@@ -13,6 +13,14 @@
     <%= f.label :end_address, class: "govuk-label" %>
     <%= f.text_field :end_address, class: "govuk-input" %>
   </div>
+  
+  <div class="govuk-form-group <%= field_error(f.object, :routers )%>">
+    <%= f.label :routers, class: "govuk-label" %>
+    <div id="options_routers-hint" class="govuk-hint">
+      Must be in the form: 127.0.0.1,127.0.0.2
+    </div>
+    <%= f.text_area :routers, value: f.object.routers.join(","), class: "govuk-input" %>
+  </div>
 
   <%= f.submit f.object.new_record? ? "Create" : "Update", {
     class: "govuk-button",

--- a/app/views/subnets/_list.html.erb
+++ b/app/views/subnets/_list.html.erb
@@ -7,6 +7,7 @@
       <th scope="col" class="govuk-table__header">CIDR block</th>
       <th scope="col" class="govuk-table__header">Start address</th>
       <th scope="col" class="govuk-table__header">End address</th>
+      <th scope="col" class="govuk-table__header">Routers</th>
       <% if !hide_actions %>
         <th scope="col" class="govuk-table__header">
           <span class="govuk-visually-hidden">Actions</span>
@@ -20,6 +21,7 @@
         <td class="govuk-table__cell"><%= subnet.cidr_block %></td>
         <td class="govuk-table__cell"><%= subnet.start_address %></td>
         <td class="govuk-table__cell"><%= subnet.end_address %></td>
+        <td class="govuk-table__cell"><%= subnet.routers.join(",") %></td>
         <% if !hide_actions %>
           <td class="govuk-table__cell">
             <%= link_to "View", subnet_path(subnet), class: "govuk-link" %>

--- a/app/views/subnets/show.html.erb
+++ b/app/views/subnets/show.html.erb
@@ -15,6 +15,11 @@
     <dt class="govuk-summary-list__key">End address</dt>
     <dd class="govuk-summary-list__value"><%= @subnet.end_address %></dd>
   </div>
+
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">Routers</dt>
+    <dd class="govuk-summary-list__value"><%= @subnet.routers.join(", ") %></dd>
+  </div>
 </dl>
 
 <%= link_to "View leases", subnet_leases_path(@subnet), class: "govuk-button govuk-button--secondary" %>

--- a/db/migrate/20210105115025_remove_routers_from_options.rb
+++ b/db/migrate/20210105115025_remove_routers_from_options.rb
@@ -1,0 +1,5 @@
+class RemoveRoutersFromOptions < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :options, :routers, :string
+  end
+end

--- a/db/migrate/20210105115151_add_routers_to_subnets.rb
+++ b/db/migrate/20210105115151_add_routers_to_subnets.rb
@@ -1,0 +1,5 @@
+class AddRoutersToSubnets < ActiveRecord::Migration[6.0]
+  def change
+    add_column :subnets, :routers, :string, null: false, default: "127.0.0.1"
+  end
+end

--- a/db/migrate/20210106162456_remove_default_routers_from_subnet.rb
+++ b/db/migrate/20210106162456_remove_default_routers_from_subnet.rb
@@ -1,4 +1,5 @@
 class RemoveDefaultRoutersFromSubnet < ActiveRecord::Migration[6.0]
   def change
+    change_column_default :subnets, :routers, from: "127.0.0.1", to: nil
   end
 end

--- a/db/migrate/20210106162456_remove_default_routers_from_subnet.rb
+++ b/db/migrate/20210106162456_remove_default_routers_from_subnet.rb
@@ -1,0 +1,4 @@
+class RemoveDefaultRoutersFromSubnet < ActiveRecord::Migration[6.0]
+  def change
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -96,7 +96,7 @@ ActiveRecord::Schema.define(version: 2021_01_06_162456) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.bigint "site_id", null: false
-    t.string "routers", default: "127.0.0.1", null: false
+    t.string "routers"
     t.index ["site_id"], name: "index_subnets_on_site_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_06_151356) do
+ActiveRecord::Schema.define(version: 2021_01_06_162456) do
   create_table "audits", options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
     t.integer "auditable_id"
     t.string "auditable_type"
@@ -53,7 +53,6 @@ ActiveRecord::Schema.define(version: 2021_01_06_151356) do
   end
 
   create_table "options", options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
-    t.string "routers"
     t.string "domain_name_servers"
     t.string "domain_name"
     t.datetime "created_at", precision: 6, null: false
@@ -97,6 +96,7 @@ ActiveRecord::Schema.define(version: 2021_01_06_151356) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.bigint "site_id", null: false
+    t.string "routers", default: "127.0.0.1", null: false
     t.index ["site_id"], name: "index_subnets_on_site_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,6 +11,7 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema.define(version: 2021_01_06_162456) do
+
   create_table "audits", options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
     t.integer "auditable_id"
     t.string "auditable_type"
@@ -96,7 +97,7 @@ ActiveRecord::Schema.define(version: 2021_01_06_162456) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.bigint "site_id", null: false
-    t.string "routers"
+    t.string "routers", null: false
     t.index ["site_id"], name: "index_subnets_on_site_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,6 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema.define(version: 2021_01_06_162456) do
-
   create_table "audits", options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
     t.integer "auditable_id"
     t.string "auditable_type"

--- a/spec/acceptance/create_options_spec.rb
+++ b/spec/acceptance/create_options_spec.rb
@@ -44,7 +44,6 @@ describe "create options", type: :feature do
       expect(page).not_to have_content("Edit options")
       click_on "Create options"
 
-      fill_in "Routers", with: "10.0.1.0,10.0.1.2"
       fill_in "Domain name servers", with: "10.0.2.1,10.0.2.2"
       fill_in "Domain name", with: "test.example.com"
       fill_in "Valid lifetime", with: "12345"
@@ -56,7 +55,6 @@ describe "create options", type: :feature do
       click_on "Create"
 
       expect(page).to have_content("Successfully created option")
-      expect(page).to have_content("10.0.1.0,10.0.1.2")
       expect(page).to have_content("10.0.2.1,10.0.2.2")
       expect(page).to have_content("test.example.com")
       expect(page).to have_content("12345")

--- a/spec/acceptance/create_subnets_spec.rb
+++ b/spec/acceptance/create_subnets_spec.rb
@@ -18,6 +18,7 @@ describe "create subnets", type: :feature do
     fill_in "CIDR block", with: "10.0.1.0/24"
     fill_in "Start address", with: "10.0.1.1"
     fill_in "End address", with: "10.0.1.255"
+    fill_in "Routers", with: "10.0.1.0,10.0.1.2"
 
     expect_config_to_be_verified
     expect_config_to_be_published
@@ -30,6 +31,7 @@ describe "create subnets", type: :feature do
     expect(page).to have_content("10.0.1.0/24")
     expect(page).to have_content("10.0.1.1")
     expect(page).to have_content("10.0.1.255")
+    expect(page).to have_content("10.0.1.0,10.0.1.2")
 
     expect_audit_log_entry_for(editor.email, "create", "Subnet")
   end
@@ -43,6 +45,7 @@ describe "create subnets", type: :feature do
     fill_in "CIDR block", with: "a"
     fill_in "Start address", with: "b"
     fill_in "End address", with: "c"
+    fill_in "Routers", with: "d"
 
     click_button "Create"
 

--- a/spec/acceptance/update_options_spec.rb
+++ b/spec/acceptance/update_options_spec.rb
@@ -46,11 +46,9 @@ describe "update options", type: :feature do
       expect(page).not_to have_content("Create options")
       click_on "Edit options"
 
-      expect(page).to have_field("Routers", with: option.routers.join(","))
       expect(page).to have_field("Domain name servers", with: option.domain_name_servers.join(","))
       expect(page).to have_field("Domain name", with: option.domain_name)
 
-      fill_in "Routers", with: "10.0.1.1,10.0.1.3"
       fill_in "Domain name servers", with: "10.0.2.2,10.0.2.3"
       fill_in "Domain name", with: "testier.example.com"
 
@@ -61,7 +59,6 @@ describe "update options", type: :feature do
       click_on "Update"
 
       expect(page).to have_content("Successfully updated options")
-      expect(page).to have_content("10.0.1.1,10.0.1.3")
       expect(page).to have_content("10.0.2.2,10.0.2.3")
       expect(page).to have_content("testier.example.com")
 
@@ -71,7 +68,6 @@ describe "update options", type: :feature do
     it "displays error if form cannot be submitted" do
       visit "/subnets/#{subnet.to_param}/options/edit"
 
-      fill_in "Routers", with: ""
       fill_in "Domain name servers", with: ""
       fill_in "Domain name", with: ""
 

--- a/spec/acceptance/update_subnets_spec.rb
+++ b/spec/acceptance/update_subnets_spec.rb
@@ -38,16 +38,4 @@ describe "update subnets", type: :feature do
 
     expect_audit_log_entry_for(editor.email, "update", "Subnet")
   end
-
-  # it "displays error if form cannot be submitted" do
-  #   visit "/subnets/#{subnet.to_param}/options/edit"
-
-  #   fill_in "Routers", with: ""
-  #   fill_in "Domain name servers", with: ""
-  #   fill_in "Domain name", with: ""
-
-  #   click_on "Update"
-
-  #   expect(page).to have_content "There is a problem"
-  # end
 end

--- a/spec/acceptance/update_subnets_spec.rb
+++ b/spec/acceptance/update_subnets_spec.rb
@@ -16,10 +16,12 @@ describe "update subnets", type: :feature do
     expect(page).to have_field("CIDR block", with: subnet.cidr_block)
     expect(page).to have_field("Start address", with: subnet.start_address)
     expect(page).to have_field("End address", with: subnet.end_address)
+    expect(page).to have_field("Routers", with: subnet.routers.join(","))
 
     fill_in "CIDR block", with: "10.1.1.0/24"
     fill_in "Start address", with: "10.1.1.1"
     fill_in "End address", with: "10.1.1.255"
+    fill_in "Routers", with: "10.0.1.1,10.0.1.3"
 
     expect_config_to_be_verified
     expect_config_to_be_published
@@ -32,7 +34,20 @@ describe "update subnets", type: :feature do
     expect(page).to have_content("10.1.1.0/24")
     expect(page).to have_content("10.1.1.1")
     expect(page).to have_content("10.1.1.255")
+    expect(page).to have_content("10.0.1.1,10.0.1.3")
 
     expect_audit_log_entry_for(editor.email, "update", "Subnet")
   end
+
+  # it "displays error if form cannot be submitted" do
+  #   visit "/subnets/#{subnet.to_param}/options/edit"
+
+  #   fill_in "Routers", with: ""
+  #   fill_in "Domain name servers", with: ""
+  #   fill_in "Domain name", with: ""
+
+  #   click_on "Update"
+
+  #   expect(page).to have_content "There is a problem"
+  # end
 end

--- a/spec/factories/options.rb
+++ b/spec/factories/options.rb
@@ -1,7 +1,6 @@
 FactoryBot.define do
   factory :option do
     subnet
-    routers { "10.0.4.0,10.0.4.2" }
     domain_name_servers { "12.0.4.1,12.0.4.5" }
     domain_name { "www.examgitple.com" }
   end

--- a/spec/factories/subnets.rb
+++ b/spec/factories/subnets.rb
@@ -7,6 +7,7 @@ FactoryBot.define do
     cidr_block { "10.#{index}.4.0/24" }
     start_address { "10.#{index}.4.1" }
     end_address { "10.#{index}.4.255" }
+    routers { "10.#{index}.4.0,10.#{index}.4.2" }
 
     site
 

--- a/spec/models/option_spec.rb
+++ b/spec/models/option_spec.rb
@@ -21,7 +21,6 @@ RSpec.describe Option, type: :model do
   it { should_not allow_value("me.example/.co").for(:domain_name) }
 
   it "is invalid if none of the options are completed" do
-    subject.routers = nil
     subject.domain_name_servers = nil
     subject.domain_name = nil
 
@@ -29,58 +28,10 @@ RSpec.describe Option, type: :model do
     expect(subject.errors[:base]).to include("At least one option must be filled out")
   end
 
-  it "rejects an incorrect routers" do
-    option = build :option, routers: "abcd,efg"
-    expect(option).not_to be_valid
-    expect(option.errors[:routers]).to eq(["contains an invalid IPv4 address or is not separated using commas"])
-  end
-
   it "rejects an incorrect domain_name_server" do
     option = build :option, domain_name_servers: "abcd,efg"
     expect(option).not_to be_valid
     expect(option.errors[:domain_name_servers]).to eq(["contains an invalid IPv4 address or is not separated using commas"])
-  end
-
-  describe "#routers" do
-    context "when routers is nil" do
-      before do
-        subject.routers = nil
-      end
-
-      it "returns an empty array" do
-        expect(subject.routers).to eq([])
-      end
-    end
-
-    context "when routers is not empty" do
-      before do
-        subject.routers = "192.168.0.2,192.168.0.3"
-      end
-
-      it "returns an empty array" do
-        expect(subject.routers).to eq(["192.168.0.2", "192.168.0.3"])
-      end
-    end
-  end
-
-  describe "#routers=" do
-    context "when the value is a string" do
-      before do
-        subject.routers = "192.168.0.2,192.168.0.3"
-      end
-
-      it "returns an empty array" do
-        expect(subject.routers).to eq(["192.168.0.2", "192.168.0.3"])
-      end
-    end
-
-    context "when the value is an string with whitespace" do
-      subject { create :option, routers: " 192.168.0.2, 192.168.0.3  " }
-
-      it "stores the routers correctly" do
-        expect(subject.routers).to eq(["192.168.0.2", "192.168.0.3"])
-      end
-    end
   end
 
   describe "#domain_name_servers" do

--- a/spec/use_cases/generate_kea_config_spec.rb
+++ b/spec/use_cases/generate_kea_config_spec.rb
@@ -20,8 +20,8 @@ describe UseCases::GenerateKeaConfig do
 
     it "appends subnets to the subnet4 list" do
       site = build_stubbed(:site, fits_id: "FITSID01", name: "SITENAME01")
-      subnet1 = build_stubbed(:subnet, cidr_block: "10.0.1.0/24", start_address: "10.0.1.1", end_address: "10.0.1.255", site: site)
-      subnet2 = build_stubbed(:subnet, cidr_block: "10.0.2.0/24", start_address: "10.0.2.1", end_address: "10.0.2.255", site: site)
+      subnet1 = build_stubbed(:subnet, cidr_block: "10.0.1.0/24", start_address: "10.0.1.1", end_address: "10.0.1.255", routers: "10.0.1.2,10.0.1.3", site: site)
+      subnet2 = build_stubbed(:subnet, cidr_block: "10.0.2.0/24", start_address: "10.0.2.1", end_address: "10.0.2.255", routers: "10.0.2.2,10.0.2.3", site: site)
 
       config = UseCases::GenerateKeaConfig.new(subnets: [subnet1, subnet2]).call
 
@@ -46,7 +46,10 @@ describe UseCases::GenerateKeaConfig do
           "user-context": {
             "site-id": subnet1.site.fits_id,
             "site-name": subnet1.site.name
-          }
+          },
+          "require-client-classes": [
+            "subnet-10.0.1.0-client"
+          ]
         },
         {
           pools: [
@@ -59,7 +62,10 @@ describe UseCases::GenerateKeaConfig do
           "user-context": {
             "site-id": subnet1.site.fits_id,
             "site-name": subnet1.site.name
-          }
+          },
+          "require-client-classes": [
+            "subnet-10.0.2.0-client"
+          ]
         }
       ])
     end


### PR DESCRIPTION
# What

- Moved routers from option model to the subnet model
- Updated UI to ensure subnet routers are mandatory
- Updated config generation to ensure router options are always generated for subnets fields

As part of the data migration step, a default router for all existing subnets will initially be set to 127.0.0.1. This default constraint will then be removed.

# Screenshots

![image](https://user-images.githubusercontent.com/64264510/103882521-d661fe80-50d3-11eb-9727-3870a9c137e0.png)


![image](https://user-images.githubusercontent.com/64264510/103881806-d8778d80-50d2-11eb-801a-dd6e658aabf3.png)
