### PR TITLE
Set the KEA log level to WARN

### DIFF
--- a/app/lib/use_cases/generate_kea_config.rb
+++ b/app/lib/use_cases/generate_kea_config.rb
@@ -167,7 +167,7 @@ module UseCases
                   output: "stdout"
                 }
               ],
-              severity: "INFO",
+              severity: "WARN",
               debuglevel: 0
             }
           ],


### PR DESCRIPTION
# What
Set this now before doing the performance testing. Generating a large load will create too many logs to ship to OST.

# Why
This will be the production log level. 
