### PR TITLE
Fix n+1 queries when generating the dhcp config

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -71,7 +71,11 @@ class ApplicationController < ActionController::Base
 
   def generate_kea_config
     UseCases::GenerateKeaConfig.new(
-      subnets: Subnet.all,
+      subnets: Subnet.includes(
+        :site,
+        :option,
+        reservations: [:reservation_option]
+      ).all,
       global_option: GlobalOption.first,
       client_classes: ClientClass.all
     )


### PR DESCRIPTION
# What
Uee includes to reduce the number of queries when fetching associations to generate the kea config.

# Why
When generating the Kea config, we have an n+1 query issue which as data sets increase, the queries will become significantly slower.

