### PR TITLE
Benchmark config publishing steps

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -46,7 +46,8 @@ class ApplicationController < ActionController::Base
         key: "config.json",
         aws_config: Rails.application.config.s3_aws_config,
         content_type: "application/json"
-      )
+      ),
+      logger: Rails.logger
     )
   end
 
@@ -54,7 +55,8 @@ class ApplicationController < ActionController::Base
     UseCases::TransactionallyUpdateDhcpConfig.new(
       generate_kea_config: -> { generate_kea_config.call },
       verify_kea_config: verify_kea_config,
-      publish_kea_config: publish_kea_config
+      publish_kea_config: publish_kea_config,
+      logger: Rails.logger
     )
   end
 
@@ -66,7 +68,8 @@ class ApplicationController < ActionController::Base
         reservations: [:reservation_option]
       ).all,
       global_option: GlobalOption.first,
-      client_classes: ClientClass.all
+      client_classes: ClientClass.all,
+      logger: Rails.logger
     )
   end
 
@@ -79,7 +82,8 @@ class ApplicationController < ActionController::Base
 
   def verify_kea_config
     UseCases::VerifyKeaConfig.new(
-      kea_control_agent_gateway: kea_control_agent_gateway
+      kea_control_agent_gateway: kea_control_agent_gateway,
+      logger: Rails.logger
     )
   end
 end

--- a/app/lib/use_cases/generate_kea_config.rb
+++ b/app/lib/use_cases/generate_kea_config.rb
@@ -1,22 +1,29 @@
 module UseCases
   class GenerateKeaConfig
+    include ActiveSupport::Benchmarkable
+
     DEFAULT_VALID_LIFETIME_SECONDS = 4000
 
-    def initialize(subnets: [], global_option: nil, client_classes: [])
+    def initialize(subnets: [], global_option: nil, client_classes: [], logger: nil)
       @subnets = subnets
       @global_option = global_option
       @client_classes = client_classes
+      @logger = logger
     end
 
     def call
-      config = default_config
+      benchmark "Benchmark: UseCases::GenerateKeaConfig", level: :debug do
+        config = default_config
 
-      config[:Dhcp4][:subnet4] += @subnets.map { |subnet| subnet_config(subnet) }
+        config[:Dhcp4][:subnet4] += @subnets.map { |subnet| subnet_config(subnet) }
 
-      config
+        config
+      end
     end
 
     private
+
+    attr_reader :logger
 
     def subnet_config(subnet)
       {

--- a/app/lib/use_cases/publish_kea_config.rb
+++ b/app/lib/use_cases/publish_kea_config.rb
@@ -1,13 +1,19 @@
 class UseCases::PublishKeaConfig
-  def initialize(destination_gateway:)
+  include ActiveSupport::Benchmarkable
+
+  def initialize(destination_gateway:, logger: nil)
     @destination_gateway = destination_gateway
+    @logger = logger
   end
 
   def call(payload)
-    destination_gateway.write(data: JSON.generate(payload))
+    benchmark "Benchmark: UseCases::PublishKeaConfig", level: :debug do
+      destination_gateway.write(data: JSON.generate(payload))
+    end
   end
 
   private
 
-  attr_reader :destination_gateway
+  attr_reader :destination_gateway,
+    :logger
 end

--- a/app/lib/use_cases/transactionally_update_dhcp_config.rb
+++ b/app/lib/use_cases/transactionally_update_dhcp_config.rb
@@ -1,36 +1,42 @@
 module UseCases
   class TransactionallyUpdateDhcpConfig
-    def initialize(generate_kea_config:, verify_kea_config:, publish_kea_config:)
+    include ActiveSupport::Benchmarkable
+
+    def initialize(generate_kea_config:, verify_kea_config:, publish_kea_config:, logger: nil)
       @generate_kea_config = generate_kea_config
       @verify_kea_config = verify_kea_config
       @publish_kea_config = publish_kea_config
+      @logger = logger
     end
 
     def call(record, operation)
-      ApplicationRecord.transaction do
-        if operation.call
-          kea_config = generate_kea_config.call
-          config_verification_result = verify_kea_config.call(kea_config)
-          if config_verification_result.success?
-            publish_kea_config.call(kea_config)
-            return true
+      benchmark "Benchmark: UseCases::TransactionallyUpdateDhcpConfig", level: :debug do
+        ApplicationRecord.transaction do
+          if operation.call
+            kea_config = generate_kea_config.call
+            config_verification_result = verify_kea_config.call(kea_config)
+            if config_verification_result.success?
+              publish_kea_config.call(kea_config)
+              return true
+            else
+              raise KeaConfigInvalidError.new(config_verification_result.error.message)
+            end
           else
-            raise KeaConfigInvalidError.new(config_verification_result.error.message)
+            return false
           end
-        else
-          return false
         end
+      rescue KeaConfigInvalidError => error
+        record.errors.add(:base, error.message)
+        false
       end
-    rescue KeaConfigInvalidError => error
-      record.errors.add(:base, error.message)
-      false
     end
 
     private
 
     attr_reader :generate_kea_config,
       :verify_kea_config,
-      :publish_kea_config
+      :publish_kea_config,
+      :logger
 
     class KeaConfigInvalidError < StandardError; end
   end

--- a/app/lib/use_cases/verify_kea_config.rb
+++ b/app/lib/use_cases/verify_kea_config.rb
@@ -1,19 +1,25 @@
 module UseCases
   class VerifyKeaConfig
-    def initialize(kea_control_agent_gateway:)
+    include ActiveSupport::Benchmarkable
+
+    def initialize(kea_control_agent_gateway:, logger: nil)
       @kea_control_agent_gateway = kea_control_agent_gateway
+      @logger = logger
     end
 
     def call(config)
-      kea_control_agent_gateway.verify_config(config)
-      Result.new
-    rescue Gateways::KeaControlAgent::InternalError => error
-      Result.new(error)
+      benchmark "Benchmark: UseCases::VerifyKeaConfig", level: :debug do
+        kea_control_agent_gateway.verify_config(config)
+        Result.new
+      rescue Gateways::KeaControlAgent::InternalError => error
+        Result.new(error)
+      end
     end
 
     private
 
-    attr_reader :kea_control_agent_gateway
+    attr_reader :kea_control_agent_gateway,
+      :logger
 
     class Result
       attr_reader :error


### PR DESCRIPTION
# What
Make use of Rails benchmarking tools in order to measure bottlenecks in DHCP config generation / saving

# Why
Saving records relating to DHCP takes a long time and holds up requests. This causes timeouts. We want to find where the bottlenecks are in order to resolve them.

