### PR TITLE
Make log_level configurable in production like environments

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -48,7 +48,7 @@ Rails.application.configure do
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.
-  config.log_level = ENV['log_level'] || :debug
+  config.log_level = ENV["log_level"] || :debug
 
   # Prepend all log lines with the following tags.
   config.log_tags = [:request_id]

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -48,7 +48,7 @@ Rails.application.configure do
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.
-  config.log_level = :debug
+  config.log_level = ENV['log_level'] || :debug
 
   # Prepend all log lines with the following tags.
   config.log_tags = [:request_id]


### PR DESCRIPTION
Pass an `ENV` variable to the docker container in production like environments in order to change the log level
