### PR TITLE
Revert "Benchmark config publishing steps"

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -46,8 +46,7 @@ class ApplicationController < ActionController::Base
         key: "config.json",
         aws_config: Rails.application.config.s3_aws_config,
         content_type: "application/json"
-      ),
-      logger: Rails.logger
+      )
     )
   end
 
@@ -55,8 +54,7 @@ class ApplicationController < ActionController::Base
     UseCases::TransactionallyUpdateDhcpConfig.new(
       generate_kea_config: -> { generate_kea_config.call },
       verify_kea_config: verify_kea_config,
-      publish_kea_config: publish_kea_config,
-      logger: Rails.logger
+      publish_kea_config: publish_kea_config
     )
   end
 
@@ -68,8 +66,7 @@ class ApplicationController < ActionController::Base
         reservations: [:reservation_option]
       ).all,
       global_option: GlobalOption.first,
-      client_classes: ClientClass.all,
-      logger: Rails.logger
+      client_classes: ClientClass.all
     )
   end
 
@@ -82,8 +79,7 @@ class ApplicationController < ActionController::Base
 
   def verify_kea_config
     UseCases::VerifyKeaConfig.new(
-      kea_control_agent_gateway: kea_control_agent_gateway,
-      logger: Rails.logger
+      kea_control_agent_gateway: kea_control_agent_gateway
     )
   end
 end

--- a/app/lib/use_cases/generate_kea_config.rb
+++ b/app/lib/use_cases/generate_kea_config.rb
@@ -1,29 +1,22 @@
 module UseCases
   class GenerateKeaConfig
-    include ActiveSupport::Benchmarkable
-
     DEFAULT_VALID_LIFETIME_SECONDS = 4000
 
-    def initialize(subnets: [], global_option: nil, client_classes: [], logger: nil)
+    def initialize(subnets: [], global_option: nil, client_classes: [])
       @subnets = subnets
       @global_option = global_option
       @client_classes = client_classes
-      @logger = logger
     end
 
     def call
-      benchmark "Benchmark: UseCases::GenerateKeaConfig", level: :debug do
-        config = default_config
+      config = default_config
 
-        config[:Dhcp4][:subnet4] += @subnets.map { |subnet| subnet_config(subnet) }
+      config[:Dhcp4][:subnet4] += @subnets.map { |subnet| subnet_config(subnet) }
 
-        config
-      end
+      config
     end
 
     private
-
-    attr_reader :logger
 
     def subnet_config(subnet)
       {

--- a/app/lib/use_cases/publish_kea_config.rb
+++ b/app/lib/use_cases/publish_kea_config.rb
@@ -1,19 +1,13 @@
 class UseCases::PublishKeaConfig
-  include ActiveSupport::Benchmarkable
-
-  def initialize(destination_gateway:, logger: nil)
+  def initialize(destination_gateway:)
     @destination_gateway = destination_gateway
-    @logger = logger
   end
 
   def call(payload)
-    benchmark "Benchmark: UseCases::PublishKeaConfig", level: :debug do
-      destination_gateway.write(data: JSON.generate(payload))
-    end
+    destination_gateway.write(data: JSON.generate(payload))
   end
 
   private
 
-  attr_reader :destination_gateway,
-    :logger
+  attr_reader :destination_gateway
 end

--- a/app/lib/use_cases/verify_kea_config.rb
+++ b/app/lib/use_cases/verify_kea_config.rb
@@ -1,25 +1,19 @@
 module UseCases
   class VerifyKeaConfig
-    include ActiveSupport::Benchmarkable
-
-    def initialize(kea_control_agent_gateway:, logger: nil)
+    def initialize(kea_control_agent_gateway:)
       @kea_control_agent_gateway = kea_control_agent_gateway
-      @logger = logger
     end
 
     def call(config)
-      benchmark "Benchmark: UseCases::VerifyKeaConfig", level: :debug do
-        kea_control_agent_gateway.verify_config(config)
-        Result.new
-      rescue Gateways::KeaControlAgent::InternalError => error
-        Result.new(error)
-      end
+      kea_control_agent_gateway.verify_config(config)
+      Result.new
+    rescue Gateways::KeaControlAgent::InternalError => error
+      Result.new(error)
     end
 
     private
 
-    attr_reader :kea_control_agent_gateway,
-      :logger
+    attr_reader :kea_control_agent_gateway
 
     class Result
       attr_reader :error


### PR DESCRIPTION
Benchmarking code is no longer required in production like environments

Results of a benchmark test for config generatiopn are below

<img width="1109" alt="screenshot_2021-01-11_at_14 16 18" src="https://user-images.githubusercontent.com/326561/104195027-0124bd80-541a-11eb-850a-d8f7a968335c.png">

Reverts ministryofjustice/staff-device-dns-dhcp-admin#209