### PR TITLE
Run the app as an "app" user rather than "root"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,11 @@
 ARG SHARED_SERVICES_ACCOUNT_ID
 FROM ${SHARED_SERVICES_ACCOUNT_ID}.dkr.ecr.eu-west-2.amazonaws.com/admin:latest
 
+ARG GROUP=app
+ARG USER=app
+ARG HOME=/home/$USER
+ARG APPDIR=$HOME/staff-device-dns-dhcp-admin
+
 ARG RACK_ENV=development
 ARG DB_HOST=db
 ARG DB_USER=root
@@ -27,12 +32,18 @@ ENV LANG='C.UTF-8' \
   AWS_DEFAULT_REGION='eu-west-2' \
   DB_NAME=${DB_NAME}
 
-WORKDIR /usr/src/app
-
 ADD https://s3.amazonaws.com/rds-downloads/rds-combined-ca-bundle.pem /usr/src/cert/
 
 RUN apk add --no-cache --virtual .build-deps build-base && \
   apk add --no-cache nodejs yarn mysql-dev mysql-client bash make
+
+RUN addgroup $GROUP && \
+  adduser --home $HOME --ingroup $GROUP --disabled-password $USER && \
+  mkdir -p $APPDIR && \
+  chown -R $USER:$GROUP $HOME
+
+USER $USER
+WORKDIR $APPDIR
 
 COPY Gemfile Gemfile.lock .ruby-version ./
 RUN bundle config set no-cache 'true' && \
@@ -41,9 +52,11 @@ RUN bundle config set no-cache 'true' && \
 COPY package.json yarn.lock ./
 RUN yarn && yarn cache clean
 
-RUN apk del .build-deps
+COPY --chown=$USER:$GROUP . $APPDIR
 
-COPY . .
+USER root
+RUN apk del .build-deps
+USER $USER
 
 RUN if [ ${RUN_PRECOMPILATION} = 'true' ]; then \
   ASSET_PRECOMPILATION_ONLY=true RAILS_ENV=production bundle exec rails assets:precompile; \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,8 +19,8 @@ services:
         SHARED_SERVICES_ACCOUNT_ID: "${SHARED_SERVICES_ACCOUNT_ID}"
     command: bash -c "rm -f tmp/pids/server.pid && bundle exec rails s -p 3000 -b '0.0.0.0'"
     volumes:
-      - ".:/usr/src/app"
-      - "node_modules:/usr/src/app/node_modules"
+      - .:/home/app/staff-device-dns-dhcp-admin
+      - node_modules:/home/app/staff-device-dns-dhcp-admin/node_modules
       - /app/tmp
     links:
       - db


### PR DESCRIPTION
We shouldnt need to run our application as the root user. Instead
install ruby and js dependencies as the app user and run the app
as "app". Linux binaries are installed as "root".
