### PR TITLE
Enforce SSL connection to DB

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,9 @@ migrate:
 migrate-dev: start-db
 	$(DOCKER_COMPOSE) run --rm app bundle exec rake db:migrate
 
+bootstrap:
+	./scripts/bootstrap.sh
+
 deploy:
 	./scripts/deploy.sh
 
@@ -64,4 +67,4 @@ lint:
 implode:
 	$(DOCKER_COMPOSE) rm
 
-.PHONY: build serve stop test deploy migrate migrate-dev build-dev push publish implode authenticate-docker check-container-registry-account-id start-db db-setup run shell lint
+.PHONY: build serve stop test deploy migrate migrate-dev build-dev push publish implode authenticate-docker check-container-registry-account-id start-db db-setup run shell lint bootstrap

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -28,4 +28,5 @@ phases:
       - make authenticate-docker
       - make publish
       - make migrate
+      - make bootstrap
       - make deploy

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+set -v -e -u -o pipefail
+
+source ./scripts/aws-helpers.sh
+
+function require_ssl() {
+  local require_ssl_command="mysql -u ${DB_USER} -p${DB_PASS} -n ${DB_NAME} -h ${DB_HOST} --ssl-ca=/usr/src/cert/rds-combined-ca-bundle.pem -e \"ALTER USER '${DB_USER}'@'%' REQUIRE SSL;\""
+  local docker_service_name="admin"
+  local cluster_name service_name task_definition docker_service_name
+
+  cluster_name="staff-device-${ENV}-dhcp-admin-cluster"
+  service_name="staff-device-${ENV}-dhcp-admin"
+  task_definition="staff-device-${ENV}-dhcp-admin-task"
+
+  echo "${cluster_name}"
+  echo "${service_name}"
+  aws sts get-caller-identity
+  echo "===================================================================================================="
+
+  run_task_with_command \
+    "${cluster_name}" \
+    "${service_name}" \
+    "${task_definition}" \
+    "${docker_service_name}" \
+    "${require_ssl_command}"
+}
+
+require_ssl


### PR DESCRIPTION
# What

Sets REQUIRE SSL for the db user to enforce an SSL connection

# Why

The mysql engine for RDS does not support forcing SSL requests using parameter groups (https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_MySQL.html). The require_secure_transport parameter is not modifiable which prevented us from going down that route.

We also cannot create a user using mysql_user (https://www.terraform.io/docs/providers/mysql/r/user.html) with terraform as we are using the admin user created by RDS which cannot be overridden with mysql_user (we can only create a new user which means we would still be left with an admin user that does not require SSL)
