### PR TITLE
Add a missing space between the two sentences in notifications.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -83,5 +83,5 @@ class ApplicationController < ActionController::Base
     )
   end
 
-  CONFIG_UPDATE_DELAY_NOTICE = "This could take up to 10 minutes to apply."
+  CONFIG_UPDATE_DELAY_NOTICE = " This could take up to 10 minutes to apply."
 end


### PR DESCRIPTION
Applied to update, create and delete notifications.

# What
When adding the second half of the notification, a space was missed in between sentences in some case. 

# Screenshots
BEFORE: 
<img width="719" alt="Screenshot 2021-01-15 at 11 24 38" src="https://user-images.githubusercontent.com/38878719/104719375-47349680-5724-11eb-8713-d5ccb31882b6.png">
AFTER: 
<img width="727" alt="Screenshot 2021-01-15 at 11 19 59" src="https://user-images.githubusercontent.com/38878719/104719063-cd9ca880-5723-11eb-889f-52f1830733bb.png">

