### PR TITLE
Remove unused DHCP leases db env vars

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,10 +16,6 @@ ARG SECRET_KEY_BASE="fakekeybase"
 ARG DB_NAME=root
 ARG BUNDLE_WITHOUT=""
 ARG BUNDLE_INSTALL_FLAGS=""
-ARG DHCP_DB_USER=""
-ARG DHCP_DB_PASS=""
-ARG DHCP_DB_HOST=""
-ARG DHCP_DB_NAME=""
 ARG RUN_PRECOMPILATION=true
 
 # required for certain linting tools that read files, such as erb-lint

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ check-container-registry-account-id:
 	./scripts/check_container_registry_account_id.sh
 
 build: check-container-registry-account-id
-	docker build -t docker_admin . --build-arg RACK_ENV --build-arg DB_HOST --build-arg DB_USER --build-arg DB_PASS --build-arg SECRET_KEY_BASE --build-arg DB_NAME --build-arg BUNDLE_WITHOUT --build-arg DHCP_DB_NAME --build-arg DHCP_DB_HOST --build-arg DHCP_DB_USER --build-arg DHCP_DB_PASS --build-arg SHARED_SERVICES_ACCOUNT_ID
+	docker build -t docker_admin . --build-arg RACK_ENV --build-arg DB_HOST --build-arg DB_USER --build-arg DB_PASS --build-arg SECRET_KEY_BASE --build-arg DB_NAME --build-arg BUNDLE_WITHOUT --build-arg SHARED_SERVICES_ACCOUNT_ID
 
 build-dev:
 	$(DOCKER_COMPOSE) build


### PR DESCRIPTION
# What

Delete env variables for the leases db

# Why

No longer accessed. These are not used and "orphans"

# Notes

Related [infra PR](https://github.com/ministryofjustice/staff-device-dns-dhcp-infrastructure/pull/118)