### PR TITLE
Update packet-queue-size for Kea config file generation

### DIFF
--- a/app/lib/use_cases/generate_kea_config.rb
+++ b/app/lib/use_cases/generate_kea_config.rb
@@ -211,7 +211,7 @@ module UseCases
           "multi-threading": {
             "enable-multi-threading": true,
             "thread-pool-size": 12,
-            "packet-queue-size": 792
+            "packet-queue-size": 65
           }
         }.merge(UseCases::KeaConfig::GenerateOptionDataConfig.new.call(@global_option))
           .merge(valid_lifetime_config)


### PR DESCRIPTION


# What
For packet-queue-size 65 is optimised for Mysql, see more here: https://kea.readthedocs.io/en/kea-1.8.1/arm/dhcp4-srv.html

# Why
This will distribute the packets more evenly between the threads.

