### PR TITLE
Revert "Add a lease stats endpoint to debug lease metrics"

### DIFF
--- a/app/controllers/monitoring_controller.rb
+++ b/app/controllers/monitoring_controller.rb
@@ -4,8 +4,4 @@ class MonitoringController < ApplicationController
   def healthcheck
     render body: "Healthy"
   end
-
-  def lease_stats
-    render body: kea_control_agent_gateway.fetch_lease_stats
-  end
 end

--- a/app/lib/gateways/kea_control_agent.rb
+++ b/app/lib/gateways/kea_control_agent.rb
@@ -30,16 +30,6 @@ module Gateways
       handle_response(http.request(req).body)
     end
 
-    def fetch_lease_stats
-      req = Net::HTTP::Post.new(uri.path, headers)
-      req.body = {
-        command: "stat-lease4-get",
-        service: ["dhcp4"]
-      }.to_json
-
-      handle_response(http.request(req).body).dig("arguments")
-    end
-
     private
 
     attr_reader :uri, :logger

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,7 +30,6 @@ Rails.application.routes.draw do
   resources :audits, only: [:index, :show]
 
   get "/healthcheck", to: "monitoring#healthcheck"
-  get "/lease_stats", to: "monitoring#lease_stats"
 
   root "home#index"
 end


### PR DESCRIPTION
Reverts ministryofjustice/staff-device-dns-dhcp-admin#201

This debugging code is no longer required and unused.