### PR TITLE
Increase HA  config values to defaults

### DIFF
--- a/app/lib/use_cases/generate_kea_config.rb
+++ b/app/lib/use_cases/generate_kea_config.rb
@@ -185,8 +185,8 @@ module UseCases
                   {
                     "this-server-name": "<SERVER_NAME>",
                     "mode": "hot-standby",
-                    "heartbeat-delay": 5000,
-                    "max-response-delay": 5000,
+                    "heartbeat-delay": 10000,
+                    "max-response-delay": 60000,
                     "max-ack-delay": 5000,
                     "max-unacked-clients": 0,
                     "peers": [

--- a/app/lib/use_cases/generate_kea_config.rb
+++ b/app/lib/use_cases/generate_kea_config.rb
@@ -187,7 +187,7 @@ module UseCases
                     "mode": "hot-standby",
                     "heartbeat-delay": 10000,
                     "max-response-delay": 60000,
-                    "max-ack-delay": 5000,
+                    "max-ack-delay": 10000,
                     "max-unacked-clients": 0,
                     "peers": [
                       {

--- a/spec/use_cases/generate_kea_config_spec.rb
+++ b/spec/use_cases/generate_kea_config_spec.rb
@@ -326,7 +326,7 @@ describe UseCases::GenerateKeaConfig do
                  mode: "hot-standby",
                  "heartbeat-delay": 10000,
                  "max-response-delay": 60000,
-                 "max-ack-delay": 5000,
+                 "max-ack-delay": 10000,
                  "max-unacked-clients": 0,
                  peers:
                   [

--- a/spec/use_cases/generate_kea_config_spec.rb
+++ b/spec/use_cases/generate_kea_config_spec.rb
@@ -324,8 +324,8 @@ describe UseCases::GenerateKeaConfig do
                {
                  "this-server-name": "<SERVER_NAME>",
                  mode: "hot-standby",
-                 "heartbeat-delay": 5000,
-                 "max-response-delay": 5000,
+                 "heartbeat-delay": 10000,
+                 "max-response-delay": 60000,
                  "max-ack-delay": 5000,
                  "max-unacked-clients": 0,
                  peers:


### PR DESCRIPTION
# What

Increase the following HA config values to defaults specified in the current [Kea Docs](https://kea.readthedocs.io/en/kea-1.8.2/arm/hooks.html#load-balancing-configuration)
- `heartbeat-delay`
- `max-response-delay`
- `max-ack-delay`

# Why

See if this can be updated to be less frequent to alleviate pressure on the servers