### PR TITLE
Add pagination to Audit log

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,7 @@ gem "aws-sdk-ecs", "~> 1.73"
 gem "cancancan", "~> 3.2"
 gem "sentry-raven"
 gem "audited"
+gem "kaminari"
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -134,6 +134,18 @@ GEM
       activesupport (>= 5.0.0)
     jmespath (1.4.0)
     jwt (2.2.2)
+    kaminari (1.2.1)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.2.1)
+      kaminari-activerecord (= 1.2.1)
+      kaminari-core (= 1.2.1)
+    kaminari-actionview (1.2.1)
+      actionview
+      kaminari-core (= 1.2.1)
+    kaminari-activerecord (1.2.1)
+      activerecord
+      kaminari-core (= 1.2.1)
+    kaminari-core (1.2.1)
     listen (3.4.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -347,6 +359,7 @@ DEPENDENCIES
   ipaddress_2
   jbuilder (~> 2.10)
   jwt
+  kaminari
   listen (~> 3.4)
   mysql2 (~> 0.5.3)
   omniauth-oauth2

--- a/app/controllers/audits_controller.rb
+++ b/app/controllers/audits_controller.rb
@@ -1,6 +1,6 @@
 class AuditsController < ApplicationController
   def index
-    @audits = Audit.order(created_at: "DESC").all
+    @audits = Audit.order(created_at: "DESC").page params[:page]
   end
 
   def show

--- a/app/models/audit.rb
+++ b/app/models/audit.rb
@@ -1,4 +1,5 @@
 # Always interact with our own Audit model rather than
 # using Audited's internal model
 class Audit < Audited::Audit
+  paginates_per 50
 end

--- a/app/views/audits/index.html.erb
+++ b/app/views/audits/index.html.erb
@@ -24,3 +24,5 @@
     <% end %>
   </tbody>
 </table>
+
+<%= paginate @audits %>

--- a/app/views/kaminari/_first_page.html.erb
+++ b/app/views/kaminari/_first_page.html.erb
@@ -1,0 +1,11 @@
+<%# Link to the "First" page
+  - available local variables
+    url:           url to the first page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<span class="first govuk-!-padding-1">
+  <%= link_to_unless current_page.first?, t('views.pagination.first').html_safe, url, remote: remote, class: "govuk-link govuk-link--no-visited-state" %>
+</span>

--- a/app/views/kaminari/_gap.html.erb
+++ b/app/views/kaminari/_gap.html.erb
@@ -1,0 +1,8 @@
+<%# Non-link tag that stands for skipped pages...
+  - available local variables
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<span class="page gap govuk-body govuk-!-padding-1"><%= t('views.pagination.truncate').html_safe %></span>

--- a/app/views/kaminari/_last_page.html.erb
+++ b/app/views/kaminari/_last_page.html.erb
@@ -1,0 +1,11 @@
+<%# Link to the "Last" page
+  - available local variables
+    url:           url to the last page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<span class="last govuk-!-padding-1">
+  <%= link_to_unless current_page.last?, t('views.pagination.last').html_safe, url, remote: remote, class: "govuk-link govuk-link--no-visited-state" %>
+</span>

--- a/app/views/kaminari/_next_page.html.erb
+++ b/app/views/kaminari/_next_page.html.erb
@@ -1,0 +1,11 @@
+<%# Link to the "Next" page
+  - available local variables
+    url:           url to the next page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<span class="next govuk-!-padding-1">
+  <%= link_to_unless current_page.last?, t('views.pagination.next').html_safe, url, rel: 'next', remote: remote, class: "govuk-link govuk-link--no-visited-state" %>
+</span>

--- a/app/views/kaminari/_page.html.erb
+++ b/app/views/kaminari/_page.html.erb
@@ -1,0 +1,12 @@
+<%# Link showing page number
+  - available local variables
+    page:          a page object for "this" page
+    url:           url to this page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<span class="page govuk-!-padding-1<%= ' current govuk-link' if page.current? %>">
+  <%= link_to_unless page.current?, page, url, {remote: remote, rel: page.rel, class: "govuk-link govuk-link--no-visited-state"} %>
+</span>

--- a/app/views/kaminari/_paginator.html.erb
+++ b/app/views/kaminari/_paginator.html.erb
@@ -1,0 +1,25 @@
+<%# The container tag
+  - available local variables
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+    paginator:     the paginator that renders the pagination tags inside
+-%>
+<%= paginator.render do -%>
+  <nav class="pagination govuk-!-font-size-19" role="navigation" aria-label="pager">
+    <%= first_page_tag unless current_page.first? %>
+    <%= prev_page_tag unless current_page.first? %>
+    <% each_page do |page| -%>
+      <% if page.display_tag? -%>
+        <%= page_tag page %>
+      <% elsif !page.was_truncated? -%>
+        <%= gap_tag %>
+      <% end -%>
+    <% end -%>
+    <% unless current_page.out_of_range? %>
+      <%= next_page_tag unless current_page.last? %>
+      <%= last_page_tag unless current_page.last? %>
+    <% end %>
+  </nav>
+<% end -%>

--- a/app/views/kaminari/_prev_page.html.erb
+++ b/app/views/kaminari/_prev_page.html.erb
@@ -1,0 +1,11 @@
+<%# Link to the "Previous" page
+  - available local variables
+    url:           url to the previous page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<span class="prev govuk-!-padding-1">
+  <%= link_to_unless current_page.first?, t('views.pagination.previous').html_safe, url, rel: 'prev', remote: remote, class: "govuk-link govuk-link--no-visited-state" %>
+</span>


### PR DESCRIPTION
# What
Adds pagination (using [Kaminari](https://github.com/kaminari/kaminari)) to the Audit log

# Why
The audit log will grow endlessly as changes are made. At some point this page will become unusable without pagination.

# Screenshots
![ScreenShot 2021-01-25 at 14 26 03](https://user-images.githubusercontent.com/7527178/105718985-b6c33680-5f19-11eb-8c85-66d563eb05a6.png)
![ScreenShot 2021-01-25 at 14 25 50](https://user-images.githubusercontent.com/7527178/105718987-b75bcd00-5f19-11eb-98a0-bc310ea1e46c.png)
![ScreenShot 2021-01-25 at 14 25 40](https://user-images.githubusercontent.com/7527178/105718996-b88cfa00-5f19-11eb-8229-38c25fa94d38.png)

# Notes
Takes inspiration from the home office design system (https://design.homeoffice.gov.uk/components/pagination)