### PR TITLE
Use exceptions to exit transaction blocks

### DIFF
--- a/app/lib/use_cases/transactionally_update_dhcp_config.rb
+++ b/app/lib/use_cases/transactionally_update_dhcp_config.rb
@@ -13,16 +13,19 @@ module UseCases
           config_verification_result = verify_kea_config.call(kea_config)
           if config_verification_result.success?
             publish_kea_config.call(kea_config)
-            return true
           else
             raise KeaConfigInvalidError.new(config_verification_result.error.message)
           end
         else
-          return false
+          raise OperationFailedError.new
         end
       end
+
+      return true
     rescue KeaConfigInvalidError => error
       record.errors.add(:base, error.message)
+      false
+    rescue OperationFailedError
       false
     end
 
@@ -33,5 +36,6 @@ module UseCases
       :publish_kea_config
 
     class KeaConfigInvalidError < StandardError; end
+    class OperationFailedError < StandardError; end
   end
 end

--- a/app/lib/use_cases/transactionally_update_dhcp_config.rb
+++ b/app/lib/use_cases/transactionally_update_dhcp_config.rb
@@ -21,7 +21,7 @@ module UseCases
         end
       end
 
-      return true
+      true
     rescue KeaConfigInvalidError => error
       record.errors.add(:base, error.message)
       false
@@ -36,6 +36,7 @@ module UseCases
       :publish_kea_config
 
     class KeaConfigInvalidError < StandardError; end
+
     class OperationFailedError < StandardError; end
   end
 end

--- a/app/lib/use_cases/transactionally_update_dns_config.rb
+++ b/app/lib/use_cases/transactionally_update_dns_config.rb
@@ -23,7 +23,7 @@ module UseCases
         end
       end
 
-      return true
+      true
     rescue BindConfigInvalidError => error
       record.errors.add(:base, error.message)
       false
@@ -39,6 +39,7 @@ module UseCases
       :deploy_dns_service
 
     class BindConfigInvalidError < StandardError; end
+
     class OperationFailedError < StandardError; end
   end
 end

--- a/app/lib/use_cases/transactionally_update_dns_config.rb
+++ b/app/lib/use_cases/transactionally_update_dns_config.rb
@@ -15,16 +15,19 @@ module UseCases
           if config_verification_result.success?
             publish_bind_config.call(bind_config)
             deploy_dns_service.call
-            return true
           else
             raise BindConfigInvalidError.new(config_verification_result.error.message)
           end
         else
-          return false
+          raise OperationFailedError.new
         end
       end
+
+      return true
     rescue BindConfigInvalidError => error
       record.errors.add(:base, error.message)
+      false
+    rescue OperationFailedError
       false
     end
 
@@ -36,5 +39,6 @@ module UseCases
       :deploy_dns_service
 
     class BindConfigInvalidError < StandardError; end
+    class OperationFailedError < StandardError; end
   end
 end


### PR DESCRIPTION
Rails 6.1 deprecates the use of return to exit transaction blocks.
Use exceptions and return outside the block instead.
