### PR TITLE
Merge view and edit links to be 'Manage'

### DIFF
--- a/app/controllers/sites_controller.rb
+++ b/app/controllers/sites_controller.rb
@@ -19,7 +19,7 @@ class SitesController < ApplicationController
     authorize! :create, @site
 
     if update_dhcp_config.call(@site, -> { @site.save })
-      redirect_to dhcp_path, notice: "Successfully created site. " + CONFIG_UPDATE_DELAY_NOTICE
+      redirect_to site_path(@site), notice: "Successfully created site. " + CONFIG_UPDATE_DELAY_NOTICE
     else
       render :new
     end
@@ -34,7 +34,7 @@ class SitesController < ApplicationController
     @site.assign_attributes(site_params)
 
     if update_dhcp_config.call(@site, -> { @site.save })
-      redirect_to dhcp_path, notice: "Successfully updated site. " + CONFIG_UPDATE_DELAY_NOTICE
+      redirect_to site_path(@site), notice: "Successfully updated site. " + CONFIG_UPDATE_DELAY_NOTICE
     else
       render :edit
     end

--- a/app/controllers/subnets_controller.rb
+++ b/app/controllers/subnets_controller.rb
@@ -12,7 +12,7 @@ class SubnetsController < ApplicationController
     authorize! :create, @subnet
 
     if update_dhcp_config.call(@subnet, -> { @subnet.save })
-      redirect_to @site, notice: "Successfully created subnet." + CONFIG_UPDATE_DELAY_NOTICE
+      redirect_to @subnet, notice: "Successfully created subnet." + CONFIG_UPDATE_DELAY_NOTICE
     else
       render :new
     end
@@ -30,7 +30,7 @@ class SubnetsController < ApplicationController
     @subnet.assign_attributes(subnet_params)
 
     if update_dhcp_config.call(@subnet, -> { @subnet.save })
-      redirect_to @subnet.site, notice: "Successfully updated subnet." + CONFIG_UPDATE_DELAY_NOTICE
+      redirect_to @subnet, notice: "Successfully updated subnet." + CONFIG_UPDATE_DELAY_NOTICE
     else
       render :edit
     end

--- a/app/views/reservations/_list.html.erb
+++ b/app/views/reservations/_list.html.erb
@@ -24,10 +24,11 @@
         <td class="govuk-table__cell"><%= reservation.description %></td>
         <% if !hide_actions %>
           <td class="govuk-table__cell">
-              <%= link_to "View", reservation_path(reservation), class: "govuk-link" %>
             <% if can?(:manage, Reservation) %>
-              <%= link_to "Edit", edit_reservation_path(reservation), class: "govuk-link" %>
+              <%= link_to "Manage", reservation_path(reservation), class: "govuk-link" %>
               <%= link_to "Delete", reservation_path(reservation), class: "govuk-link", method: :delete %>
+            <% else %>
+              <%= link_to "View", reservation_path(reservation), class: "govuk-link" %>
             <% end %>
           </td>
       <% end %>

--- a/app/views/reservations/show.html.erb
+++ b/app/views/reservations/show.html.erb
@@ -4,16 +4,31 @@
   <div class="govuk-summary-list__row">
     <dt class="govuk-summary-list__key">HW address</dt>
     <dd class="govuk-summary-list__value"><%= @reservation.hw_address %></dd>
+    <dd class="govuk-summary-list__actions">
+      <%= link_to edit_reservation_path(@reservation), class: "govuk-link" do %>
+        Change<span class="govuk-visually-hidden"> hardware address</span>
+      <% end %>
+    </dd>
   </div>
 
   <div class="govuk-summary-list__row">
     <dt class="govuk-summary-list__key">IP address</dt>
     <dd class="govuk-summary-list__value"><%= @reservation.ip_address %></dd>
+    <dd class="govuk-summary-list__actions">
+      <%= link_to edit_reservation_path(@reservation), class: "govuk-link" do %>
+        Change<span class="govuk-visually-hidden"> IP address</span>
+      <% end %>
+    </dd>
   </div>
 
   <div class="govuk-summary-list__row">
     <dt class="govuk-summary-list__key">Hostname</dt>
     <dd class="govuk-summary-list__value"><%= @reservation.hostname %></dd>
+    <dd class="govuk-summary-list__actions">
+      <%= link_to edit_reservation_path(@reservation), class: "govuk-link" do %>
+        Change<span class="govuk-visually-hidden"> hostname</span>
+      <% end %>
+    </dd>
   </div>
 </dl>
     <h3 class="govuk-heading-m">Options</h3>
@@ -33,12 +48,11 @@
       <td class="govuk-table__cell"><%= @reservation.reservation_option.routers.join(",") %></td>
       <td class="govuk-table__cell"><%= @reservation.reservation_option.domain_name %></td>
       <td class="govuk-table__cell">
-            <% if can?(:manage, ReservationOption) %>
-              <%= link_to "Edit", edit_reservation_option_path(@reservation.reservation_option), class: "govuk-link" %>
-              <%= link_to "Delete", reservation_option_path(@reservation.reservation_option), class: "govuk-link", method: :delete %>
-            <% end %>
-          </td>
+        <% if can?(:manage, ReservationOption) %>
+          <%= link_to "Manage", edit_reservation_option_path(@reservation.reservation_option), class: "govuk-link" %>
+          <%= link_to "Delete", reservation_option_path(@reservation.reservation_option), class: "govuk-link", method: :delete %>
+        <% end %>
+      </td>
     </tr>
     <% end %>
     </table>
-

--- a/app/views/sites/index.html.erb
+++ b/app/views/sites/index.html.erb
@@ -27,10 +27,11 @@
           <td class="govuk-table__cell"><%= site.fits_id %></td>
           <td class="govuk-table__cell"><%= site.name %></td>
           <td class="govuk-table__cell">
-            <%= link_to "View", site_path(site), class: "govuk-link" %>
             <% if can? :manage, Site %>
-              <%= link_to "Edit", edit_site_path(site), class: "govuk-link" %>
+              <%= link_to "Manage", site_path(site), class: "govuk-link" %>
               <%= link_to "Delete", site_path(site), class:"govuk-link", method: :delete %>
+            <% else %>
+              <%= link_to "View", site_path(site), class: "govuk-link" %>
             <% end %>
           </td>
         </tr>

--- a/app/views/sites/show.html.erb
+++ b/app/views/sites/show.html.erb
@@ -4,11 +4,21 @@
   <div class="govuk-summary-list__row">
     <dt class="govuk-summary-list__key">FITS id</dt>
     <dd class="govuk-summary-list__value"><%= @site.fits_id %></dd>
+    <dd class="govuk-summary-list__actions">
+      <%= link_to edit_site_path(@site), class: "govuk-link" do %>
+        Change<span class="govuk-visually-hidden"> FITS id</span>
+      <% end %>
+    </dd>
   </div>
 
   <div class="govuk-summary-list__row">
     <dt class="govuk-summary-list__key">Name</dt>
     <dd class="govuk-summary-list__value"><%= @site.name %></dd>
+    <dd class="govuk-summary-list__actions">
+      <%= link_to edit_site_path(@site), class: "govuk-link" do %>
+        Change<span class="govuk-visually-hidden"> name</span>
+      <% end %>
+    </dd>
   </div>
 </dl>
 

--- a/app/views/subnets/_list.html.erb
+++ b/app/views/subnets/_list.html.erb
@@ -24,10 +24,11 @@
         <td class="govuk-table__cell"><%= subnet.routers.join(",") %></td>
         <% if !hide_actions %>
           <td class="govuk-table__cell">
-            <%= link_to "View", subnet_path(subnet), class: "govuk-link" %>
             <% if can?(:manage, Subnet) %>
-              <%= link_to "Edit", edit_subnet_path(subnet), class: "govuk-link" %>
+              <%= link_to "Manage", subnet_path(subnet), class: "govuk-link" %>
               <%= link_to "Delete", subnet_path(subnet), class: "govuk-link", method: :delete %>
+            <% else %>
+              <%= link_to "View", subnet_path(subnet), class: "govuk-link" %>
             <% end %>
           </td>
         <% end %>

--- a/app/views/subnets/show.html.erb
+++ b/app/views/subnets/show.html.erb
@@ -4,21 +4,41 @@
   <div class="govuk-summary-list__row">
     <dt class="govuk-summary-list__key">CIDR block</dt>
     <dd class="govuk-summary-list__value"><%= @subnet.cidr_block %></dd>
+    <dd class="govuk-summary-list__actions">
+      <%= link_to edit_subnet_path(@subnet), class: "govuk-link" do %>
+        Change<span class="govuk-visually-hidden"> CIDR block</span>
+      <% end %>
+    </dd>
   </div>
 
   <div class="govuk-summary-list__row">
     <dt class="govuk-summary-list__key">Start address</dt>
     <dd class="govuk-summary-list__value"><%= @subnet.start_address %></dd>
+    <dd class="govuk-summary-list__actions">
+      <%= link_to edit_subnet_path(@subnet), class: "govuk-link" do %>
+        Change<span class="govuk-visually-hidden"> start address</span>
+      <% end %>
+    </dd>
   </div>
 
   <div class="govuk-summary-list__row">
     <dt class="govuk-summary-list__key">End address</dt>
     <dd class="govuk-summary-list__value"><%= @subnet.end_address %></dd>
+    <dd class="govuk-summary-list__actions">
+      <%= link_to edit_subnet_path(@subnet), class: "govuk-link" do %>
+        Change<span class="govuk-visually-hidden"> end address</span>
+      <% end %>
+    </dd>
   </div>
 
   <div class="govuk-summary-list__row">
     <dt class="govuk-summary-list__key">Routers</dt>
     <dd class="govuk-summary-list__value"><%= @subnet.routers.join(", ") %></dd>
+    <dd class="govuk-summary-list__actions">
+      <%= link_to edit_subnet_path(@subnet), class: "govuk-link" do %>
+        Change<span class="govuk-visually-hidden"> routers</span>
+      <% end %>
+    </dd>
   </div>
 </dl>
 

--- a/app/views/zones/index.html.erb
+++ b/app/views/zones/index.html.erb
@@ -28,7 +28,7 @@
           <td class="govuk-table__cell"><%= zone.purpose %></td>
           <% if can? :manage, Subnet %>
             <td class="govuk-table__cell">
-              <%= link_to "Edit", edit_zone_path(zone), class: "govuk-link" %>
+              <%= link_to "Manage", edit_zone_path(zone), class: "govuk-link" %>
               <%= link_to "Delete", zone_path(zone), class:"govuk-link", method: :delete %>
             </td>
           <% end %>

--- a/spec/acceptance/create_subnets_spec.rb
+++ b/spec/acceptance/create_subnets_spec.rb
@@ -25,12 +25,12 @@ describe "create subnets", type: :feature do
 
     click_button "Create"
 
-    expect(current_path).to eq("/sites/#{site.to_param}")
+    expect(current_path).to eq("/subnets/#{site.subnets.first.to_param}")
 
     expect(page).to have_content("10.0.1.0/24")
     expect(page).to have_content("10.0.1.1")
     expect(page).to have_content("10.0.1.255")
-    expect(page).to have_content("10.0.1.0,10.0.1.2")
+    expect(page).to have_content("10.0.1.0, 10.0.1.2")
 
     expect_audit_log_entry_for(editor.email, "create", "Subnet")
   end

--- a/spec/acceptance/update_reservation_options_spec.rb
+++ b/spec/acceptance/update_reservation_options_spec.rb
@@ -44,7 +44,7 @@ describe "update reservation options", type: :feature do
       visit "/reservations/#{reservation.to_param}"
 
       expect(page).not_to have_content("Create reservation options")
-      click_on "Edit"
+      click_on "Manage"
 
       expect(page).to have_field("Routers", with: reservation_option.routers.join(","))
       expect(page).to have_field("Domain name", with: reservation_option.domain_name)

--- a/spec/acceptance/update_reservations_spec.rb
+++ b/spec/acceptance/update_reservations_spec.rb
@@ -41,9 +41,8 @@ describe "update reservations", type: :feature do
     end
 
     it "edits an existing reservation" do
-      visit "/subnets/#{subnet.to_param}"
-
-      click_on "Edit"
+      visit "/reservations/#{reservation.id}"
+      first(:link, "Change").click
 
       expect(page).to have_field("HW address", with: reservation.hw_address)
       expect(page).to have_field("IP address", with: reservation.ip_address)

--- a/spec/acceptance/update_sites_spec.rb
+++ b/spec/acceptance/update_sites_spec.rb
@@ -40,9 +40,9 @@ describe "update sites", type: :feature do
     end
 
     it "update an existing site" do
-      visit "/dhcp"
+      visit "/sites/#{site.id}"
 
-      click_on "Edit"
+      first(:link, "Change").click
 
       expect(page).to have_field("FITS id", with: site.fits_id)
       expect(page).to have_field("Name", with: site.name)
@@ -55,7 +55,7 @@ describe "update sites", type: :feature do
 
       click_on "Update"
 
-      expect(current_path).to eq("/dhcp")
+      expect(current_path).to eq("/sites/#{site.id}")
 
       expect(page).to have_content("MYFITS202")
       expect(page).to have_content("My Manchester Site")

--- a/spec/acceptance/update_subnets_spec.rb
+++ b/spec/acceptance/update_subnets_spec.rb
@@ -9,9 +9,11 @@ describe "update subnets", type: :feature do
 
   it "update an existing subnet" do
     subnet = Audited.audit_class.as_user(User.first) { create(:subnet) }
-    visit "/sites/#{subnet.site.to_param}"
+    visit "/subnets/#{subnet.id}"
 
-    click_on "Edit"
+    expect(current_path).to eq("/subnets/#{subnet.id}")
+
+    first(:link, "Change").click
 
     expect(page).to have_field("CIDR block", with: subnet.cidr_block)
     expect(page).to have_field("Start address", with: subnet.start_address)
@@ -21,7 +23,7 @@ describe "update subnets", type: :feature do
     fill_in "CIDR block", with: "10.1.1.0/24"
     fill_in "Start address", with: "10.1.1.1"
     fill_in "End address", with: "10.1.1.255"
-    fill_in "Routers", with: "10.0.1.1,10.0.1.3"
+    fill_in "Routers", with: "10.0.1.1, 10.0.1.3"
 
     expect_config_to_be_verified
     expect_config_to_be_published
@@ -33,7 +35,7 @@ describe "update subnets", type: :feature do
     expect(page).to have_content("10.1.1.0/24")
     expect(page).to have_content("10.1.1.1")
     expect(page).to have_content("10.1.1.255")
-    expect(page).to have_content("10.0.1.1,10.0.1.3")
+    expect(page).to have_content("10.0.1.1, 10.0.1.3")
 
     expect_audit_log_entry_for(editor.email, "update", "Subnet")
   end

--- a/spec/acceptance/update_zones_spec.rb
+++ b/spec/acceptance/update_zones_spec.rb
@@ -16,7 +16,7 @@ describe "update zones", type: :feature do
   it "update an existing zone" do
     visit "/dns"
 
-    click_on "Edit"
+    click_on "Manage"
 
     expect(page).to have_field("Domain name", with: zone.name)
     expect(page).to have_field("Forwarders", with: zone.forwarders.join(","))

--- a/spec/acceptance/zones_spec.rb
+++ b/spec/acceptance/zones_spec.rb
@@ -37,7 +37,7 @@ describe "GET /zones", type: :feature do
       visit "/dns"
 
       expect(page).to have_content "Create a new zone"
-      expect(page).to have_content "Edit"
+      expect(page).to have_content "Manage"
       expect(page).to have_content "Delete"
     end
   end


### PR DESCRIPTION
# What
Replaces the separate View and Edit links in to a singular "Manage" link. The Manage link has the same behaviour as the View link, and the Edit functionality has been replaced by "Change" links next to the values in the show page.

# Why
During user feedback sessions, we have found in nearly every single case, when the user is asked to add a new Subnet to a Site, they click the “Edit” link next to the Site instead of the View link.

Users are assuming that the “Edit” link will take them to a page to make changes to the Site, and adding a Subnet is a change to the Site. The “View” link gives off the impression that changes cannot be made via that link, and you can only read / view information.

# Screenshots
![ScreenShot 2021-01-26 at 14 20 08](https://user-images.githubusercontent.com/7527178/105857091-daea4a80-5fe1-11eb-9f62-6316702198c8.png)

# Notes
