### PR TITLE
Replace View and Edit link with 'Manage' for Client Classes

### DIFF
--- a/app/views/client_classes/index.html.erb
+++ b/app/views/client_classes/index.html.erb
@@ -26,10 +26,11 @@
           <td class="govuk-table__cell"><%= client_class.domain_name_servers.join(",") %></td>
           <td class="govuk-table__cell"><%= client_class.domain_name %></td>
           <td class="govuk-table__cell">
-            <%= link_to "View", client_class_path(client_class), class: "govuk-link" %>
             <% if can?(:manage, client_class) %>
-              <%= link_to "Edit", edit_client_class_path(client_class), class: "govuk-link" %>
+              <%= link_to "Manage", edit_client_class_path(client_class), class: "govuk-link" %>
               <%= link_to "Delete", client_class_path(client_class), class: "govuk-link", method: :delete %>
+            <% else %>
+              <%= link_to "View", client_class_path(client_class), class: "govuk-link" %>
             <% end %>
           </td>
         </tr>

--- a/spec/acceptance/update_client_classes_spec.rb
+++ b/spec/acceptance/update_client_classes_spec.rb
@@ -42,7 +42,7 @@ describe "update client class", type: :feature do
     it "edits an existing client class" do
       visit "/client-classes"
 
-      click_on "Edit"
+      click_on "Manage"
 
       expect(page).to have_field("Name", with: client_class.name)
       expect(page).to have_field("Client id", with: client_class.client_id)


### PR DESCRIPTION
ClientClasses were missed in #242

# Screenshots

![ScreenShot 2021-01-27 at 10 25 09](https://user-images.githubusercontent.com/7527178/105977998-f4df6800-6089-11eb-8d70-5551183bdd52.png)
