### PR TITLE
Disable dnssec-validation for BIND

### DIFF
--- a/app/lib/use_cases/generate_bind_config.rb
+++ b/app/lib/use_cases/generate_bind_config.rb
@@ -18,6 +18,9 @@ options {
 
   pid-file "/var/run/named/named.pid";
 
+  dnssec-enable no;
+  dnssec-validation no;
+
   allow-transfer { none; };
   allow-query { any; };
 };

--- a/spec/use_cases/generate_bind_config_spec.rb
+++ b/spec/use_cases/generate_bind_config_spec.rb
@@ -20,6 +20,9 @@ options {
 
   pid-file "/var/run/named/named.pid";
 
+  dnssec-enable no;
+  dnssec-validation no;
+
   allow-transfer { none; };
   allow-query { any; };
 };


### PR DESCRIPTION


# What
Disable dnssec-validation for BIND

# Why
This setting defaults to true.
Forwarding to internal DNS servers does not work with this turned on.

