### PR TITLE
Add valid lifetime units for options

### DIFF
--- a/app/controllers/global_options_controller.rb
+++ b/app/controllers/global_options_controller.rb
@@ -54,7 +54,7 @@ class GlobalOptionsController < ApplicationController
   end
 
   def global_option_params
-    params.require(:global_option).permit(:domain_name_servers, :domain_name, :valid_lifetime)
+    params.require(:global_option).permit(:domain_name_servers, :domain_name, :valid_lifetime, :valid_lifetime_unit)
   end
 
   def confirmed?

--- a/app/controllers/options_controller.rb
+++ b/app/controllers/options_controller.rb
@@ -61,7 +61,7 @@ class OptionsController < ApplicationController
   end
 
   def option_params
-    params.require(:option).permit(:domain_name_servers, :domain_name, :valid_lifetime)
+    params.require(:option).permit(:domain_name_servers, :domain_name, :valid_lifetime, :valid_lifetime_unit)
   end
 
   def confirmed?

--- a/app/lib/use_cases/generate_kea_config.rb
+++ b/app/lib/use_cases/generate_kea_config.rb
@@ -72,17 +72,17 @@ module UseCases
       return {} if @global_option.valid_lifetime.blank?
 
       {
-        "valid-lifetime": calculate_valid_lifetime(@global_option.valid_lifetime,@global_option.valid_lifetime_unit)
+        "valid-lifetime": calculate_valid_lifetime(@global_option.valid_lifetime, @global_option.valid_lifetime_unit)
       }
     end
 
     def subnet_valid_lifetime_config(option)
       return {} if option&.valid_lifetime.blank?
 
-      {"valid-lifetime": calculate_valid_lifetime(option.valid_lifetime,option.valid_lifetime_unit)}
+      {"valid-lifetime": calculate_valid_lifetime(option.valid_lifetime, option.valid_lifetime_unit)}
     end
 
-    def calculate_valid_lifetime(valid_lifetime,unit)
+    def calculate_valid_lifetime(valid_lifetime, unit)
       case unit
       when "Days"
         valid_lifetime * SECONDS_IN_A_DAY

--- a/app/lib/use_cases/generate_kea_config.rb
+++ b/app/lib/use_cases/generate_kea_config.rb
@@ -1,6 +1,9 @@
 module UseCases
   class GenerateKeaConfig
     DEFAULT_VALID_LIFETIME_SECONDS = 4000
+    SECONDS_IN_A_DAY = 86400
+    SECONDS_IN_AN_HOUR = 3600
+    SECONDS_IN_A_MINUTE = 60
 
     def initialize(subnets: [], global_option: nil, client_classes: [])
       @subnets = subnets
@@ -69,14 +72,27 @@ module UseCases
       return {} if @global_option.valid_lifetime.blank?
 
       {
-        "valid-lifetime": @global_option.valid_lifetime
+        "valid-lifetime": calculate_valid_lifetime(@global_option.valid_lifetime,@global_option.valid_lifetime_unit)
       }
     end
 
     def subnet_valid_lifetime_config(option)
       return {} if option&.valid_lifetime.blank?
 
-      {"valid-lifetime": option.valid_lifetime}
+      {"valid-lifetime": calculate_valid_lifetime(option.valid_lifetime,option.valid_lifetime_unit)}
+    end
+
+    def calculate_valid_lifetime(valid_lifetime,unit)
+      case unit
+      when "Days"
+        valid_lifetime * SECONDS_IN_A_DAY
+      when "Hours"
+        valid_lifetime * SECONDS_IN_AN_HOUR
+      when "Minutes"
+        valid_lifetime * SECONDS_IN_A_MINUTE
+      else
+        valid_lifetime
+      end
     end
 
     def client_class_config

--- a/app/models/global_option.rb
+++ b/app/models/global_option.rb
@@ -4,9 +4,12 @@ class GlobalOption < ApplicationRecord
     presence: {message: "must contain at least one IPv4 address separated using commas"},
     ipv4_list: {message: "contains an invalid IPv4 address or is not separated using commas"}
   validates :domain_name, presence: true, domain_name: true
-  validates :valid_lifetime, numericality: {greater_than_or_equal_to: 0, only_integer: true},
-                             allow_nil: true
-  validates :valid_lifetime_unit, inclusion: {in: VALID_LIFETIME_UNIT_OPTIONS, message: "%{value} is not valid", allow_blank: true}
+  validates :valid_lifetime,
+    numericality: {greater_than_or_equal_to: 0, only_integer: true},
+    allow_nil: true
+  validates :valid_lifetime_unit,
+    presence: {if: :valid_lifetime?},
+    inclusion: {in: VALID_LIFETIME_UNIT_OPTIONS, message: "%{value} is not valid"}
 
   validate :only_one_record
 
@@ -17,10 +20,6 @@ class GlobalOption < ApplicationRecord
   def domain_name_servers
     return [] unless self[:domain_name_servers]
     self[:domain_name_servers].split(",")
-  end
-
-  def valid_lifetime_unit_options
-    VALID_LIFETIME_UNIT_OPTIONS
   end
 
   private

--- a/app/models/global_option.rb
+++ b/app/models/global_option.rb
@@ -1,10 +1,12 @@
 class GlobalOption < ApplicationRecord
+  VALID_LIFETIME_UNIT_OPTIONS = ['Seconds','Minutes','Hours','Days']
   validates :domain_name_servers,
     presence: {message: "must contain at least one IPv4 address separated using commas"},
     ipv4_list: {message: "contains an invalid IPv4 address or is not separated using commas"}
   validates :domain_name, presence: true, domain_name: true
   validates :valid_lifetime, numericality: {greater_than_or_equal_to: 0, only_integer: true},
                              allow_nil: true
+  validates :valid_lifetime_unit, inclusion: { in: VALID_LIFETIME_UNIT_OPTIONS, message: "%{value} is not valid", allow_blank: true }
 
   validate :only_one_record
 
@@ -15,6 +17,10 @@ class GlobalOption < ApplicationRecord
   def domain_name_servers
     return [] unless self[:domain_name_servers]
     self[:domain_name_servers].split(",")
+  end
+
+  def valid_lifetime_unit_options
+    return VALID_LIFETIME_UNIT_OPTIONS
   end
 
   private

--- a/app/models/global_option.rb
+++ b/app/models/global_option.rb
@@ -1,12 +1,12 @@
 class GlobalOption < ApplicationRecord
-  VALID_LIFETIME_UNIT_OPTIONS = ['Seconds','Minutes','Hours','Days']
+  VALID_LIFETIME_UNIT_OPTIONS = ["Seconds", "Minutes", "Hours", "Days"]
   validates :domain_name_servers,
     presence: {message: "must contain at least one IPv4 address separated using commas"},
     ipv4_list: {message: "contains an invalid IPv4 address or is not separated using commas"}
   validates :domain_name, presence: true, domain_name: true
   validates :valid_lifetime, numericality: {greater_than_or_equal_to: 0, only_integer: true},
                              allow_nil: true
-  validates :valid_lifetime_unit, inclusion: { in: VALID_LIFETIME_UNIT_OPTIONS, message: "%{value} is not valid", allow_blank: true }
+  validates :valid_lifetime_unit, inclusion: {in: VALID_LIFETIME_UNIT_OPTIONS, message: "%{value} is not valid", allow_blank: true}
 
   validate :only_one_record
 
@@ -20,7 +20,7 @@ class GlobalOption < ApplicationRecord
   end
 
   def valid_lifetime_unit_options
-    return VALID_LIFETIME_UNIT_OPTIONS
+    VALID_LIFETIME_UNIT_OPTIONS
   end
 
   private

--- a/app/models/option.rb
+++ b/app/models/option.rb
@@ -1,5 +1,6 @@
 class Option < ApplicationRecord
   INVALID_IPV4_LIST_MESSAGE = "contains an invalid IPv4 address or is not separated using commas"
+  VALID_LIFETIME_UNIT_OPTIONS = ['Seconds','Minutes','Hours','Days']
 
   belongs_to :subnet
 
@@ -8,6 +9,7 @@ class Option < ApplicationRecord
   validates :valid_lifetime, numericality: {greater_than_or_equal_to: 0, only_integer: true},
                              allow_nil: true
   validates :domain_name, domain_name: true
+  validates :valid_lifetime_unit, inclusion: { in: VALID_LIFETIME_UNIT_OPTIONS, message: "%{value} is not valid", allow_blank: true }
 
   validate :at_least_one_option
 
@@ -18,6 +20,10 @@ class Option < ApplicationRecord
   def domain_name_servers
     return [] unless self[:domain_name_servers]
     self[:domain_name_servers].split(",")
+  end
+
+  def valid_lifetime_unit_options
+    return VALID_LIFETIME_UNIT_OPTIONS
   end
 
   private

--- a/app/models/option.rb
+++ b/app/models/option.rb
@@ -6,10 +6,13 @@ class Option < ApplicationRecord
 
   validates :subnet, presence: true
   validates :domain_name_servers, ipv4_list: {message: INVALID_IPV4_LIST_MESSAGE}
-  validates :valid_lifetime, numericality: {greater_than_or_equal_to: 0, only_integer: true},
-                             allow_nil: true
+  validates :valid_lifetime,
+    numericality: {greater_than_or_equal_to: 0, only_integer: true},
+    allow_nil: true
   validates :domain_name, domain_name: true
-  validates :valid_lifetime_unit, inclusion: {in: VALID_LIFETIME_UNIT_OPTIONS, message: "%{value} is not valid", allow_blank: true}
+  validates :valid_lifetime_unit,
+    presence: {if: :valid_lifetime?},
+    inclusion: {in: VALID_LIFETIME_UNIT_OPTIONS, message: "%{value} is not valid"}
 
   validate :at_least_one_option
 
@@ -20,10 +23,6 @@ class Option < ApplicationRecord
   def domain_name_servers
     return [] unless self[:domain_name_servers]
     self[:domain_name_servers].split(",")
-  end
-
-  def valid_lifetime_unit_options
-    VALID_LIFETIME_UNIT_OPTIONS
   end
 
   private

--- a/app/models/option.rb
+++ b/app/models/option.rb
@@ -1,6 +1,6 @@
 class Option < ApplicationRecord
   INVALID_IPV4_LIST_MESSAGE = "contains an invalid IPv4 address or is not separated using commas"
-  VALID_LIFETIME_UNIT_OPTIONS = ['Seconds','Minutes','Hours','Days']
+  VALID_LIFETIME_UNIT_OPTIONS = ["Seconds", "Minutes", "Hours", "Days"]
 
   belongs_to :subnet
 
@@ -9,7 +9,7 @@ class Option < ApplicationRecord
   validates :valid_lifetime, numericality: {greater_than_or_equal_to: 0, only_integer: true},
                              allow_nil: true
   validates :domain_name, domain_name: true
-  validates :valid_lifetime_unit, inclusion: { in: VALID_LIFETIME_UNIT_OPTIONS, message: "%{value} is not valid", allow_blank: true }
+  validates :valid_lifetime_unit, inclusion: {in: VALID_LIFETIME_UNIT_OPTIONS, message: "%{value} is not valid", allow_blank: true}
 
   validate :at_least_one_option
 
@@ -23,7 +23,7 @@ class Option < ApplicationRecord
   end
 
   def valid_lifetime_unit_options
-    return VALID_LIFETIME_UNIT_OPTIONS
+    VALID_LIFETIME_UNIT_OPTIONS
   end
 
   private

--- a/app/models/subnet.rb
+++ b/app/models/subnet.rb
@@ -24,6 +24,7 @@ class Subnet < ApplicationRecord
   delegate :domain_name_servers,
     :domain_name,
     :valid_lifetime,
+    :valid_lifetime_unit,
     to: :option,
     allow_nil: true
 

--- a/app/presenters/global_option_presenter.rb
+++ b/app/presenters/global_option_presenter.rb
@@ -6,6 +6,10 @@ class GlobalOptionPresenter < BasePresenter
   def display_valid_lifetime
     return if record.valid_lifetime.blank?
 
-    record.valid_lifetime > 1 ? record.valid_lifetime_unit&.downcase : record.valid_lifetime_unit&.downcase&.delete_suffix("s")
+    if record.valid_lifetime > 1
+      "#{record.valid_lifetime} #{record.valid_lifetime_unit&.downcase}"
+    else
+      "#{record.valid_lifetime} #{record.valid_lifetime_unit&.downcase&.delete_suffix("s")}"
+    end
   end
 end

--- a/app/presenters/global_option_presenter.rb
+++ b/app/presenters/global_option_presenter.rb
@@ -2,4 +2,10 @@ class GlobalOptionPresenter < BasePresenter
   def display_name
     nil
   end
+
+  def display_valid_lifetime
+    return if record.valid_lifetime.blank?
+
+    record.valid_lifetime > 1 ? record.valid_lifetime_unit&.downcase : record.valid_lifetime_unit&.downcase&.delete_suffix("s")
+  end
 end

--- a/app/presenters/subnet_presenter.rb
+++ b/app/presenters/subnet_presenter.rb
@@ -6,6 +6,10 @@ class SubnetPresenter < BasePresenter
   def display_valid_lifetime
     return if record.valid_lifetime.blank?
 
-    record.valid_lifetime > 1 ? record.valid_lifetime_unit&.downcase : record.valid_lifetime_unit&.downcase&.delete_suffix("s")
+    if record.valid_lifetime > 1
+      "#{record.valid_lifetime} #{record.valid_lifetime_unit&.downcase}"
+    else
+      "#{record.valid_lifetime} #{record.valid_lifetime_unit&.downcase&.delete_suffix("s")}"
+    end
   end
 end

--- a/app/presenters/subnet_presenter.rb
+++ b/app/presenters/subnet_presenter.rb
@@ -2,4 +2,10 @@ class SubnetPresenter < BasePresenter
   def display_name
     record.cidr_block
   end
+
+  def display_valid_lifetime
+    return if record.valid_lifetime.blank?
+
+    record.valid_lifetime > 1 ? record.valid_lifetime_unit&.downcase : record.valid_lifetime_unit&.downcase&.delete_suffix("s")
+  end
 end

--- a/app/views/global_options/_form.html.erb
+++ b/app/views/global_options/_form.html.erb
@@ -21,9 +21,12 @@
   <div class="govuk-form-group <%= field_error(f.object, :valid_lifetime) %>">
     <%= f.label :valid_lifetime, class: "govuk-label" %>
     <div id="global_option_valid_lifetime-hint" class="govuk-hint">
-      How long the addresses (leases) given out by the server are valid for in seconds. Defaults to 4000 seconds
+      How long the addresses (leases) given out by the server are valid for. Defaults to 4000 seconds
     </div>
-    <%= f.text_field :valid_lifetime, class: "govuk-input" %>
+    <div>
+    <%= f.text_field :valid_lifetime, class: "govuk-input govuk-!-width-one-third" %>
+    <%= f.select( :valid_lifetime_unit, global_option.valid_lifetime_unit_options, {}, {class: "govuk-select govuk-!-width-one-third"}) %>
+    </div>
   </div>
 
   <%= f.submit f.object.new_record? ? "Create" : "Update", {

--- a/app/views/global_options/_form.html.erb
+++ b/app/views/global_options/_form.html.erb
@@ -23,9 +23,15 @@
     <div id="global_option_valid_lifetime-hint" class="govuk-hint">
       How long the addresses (leases) given out by the server are valid for. Defaults to 4000 seconds
     </div>
-    <div>
-    <%= f.text_field :valid_lifetime, class: "govuk-input govuk-!-width-one-third" %>
-    <%= f.select( :valid_lifetime_unit, global_option.valid_lifetime_unit_options, {}, {class: "govuk-select govuk-!-width-one-third"}) %>
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-full">
+        <div class="govuk-grid-column-one-half govuk-!-padding-0">
+          <%= f.text_field :valid_lifetime, class: "govuk-input" %>
+        </div>
+        <div class="govuk-grid-column-one-half">
+          <%= f.select( :valid_lifetime_unit, GlobalOption::VALID_LIFETIME_UNIT_OPTIONS, {}, {class: "govuk-select govuk-!-width-full"}) %>
+        </div>
+      </div>
     </div>
   </div>
 

--- a/app/views/global_options/index.html.erb
+++ b/app/views/global_options/index.html.erb
@@ -2,6 +2,8 @@
   <h2 class="govuk-heading-l">Global Options</h2>
 
   <% if @global_option %>
+    <% presenter = present(@global_option) %>
+
     <dl class="govuk-summary-list">
 
       <div class="govuk-summary-list__row">
@@ -28,9 +30,7 @@
         </dt>
         <dd class="govuk-summary-list__value">
           <%= @global_option.valid_lifetime %>
-          <% if @global_option.valid_lifetime.present? %>
-          <%= @global_option.valid_lifetime > 1 ? @global_option.valid_lifetime_unit.downcase : @global_option.valid_lifetime_unit&.downcase.delete_suffix('s') %>
-          <% end %>
+          <%= presenter.display_valid_lifetime %>
         </dd>
       </div>
     </dl>

--- a/app/views/global_options/index.html.erb
+++ b/app/views/global_options/index.html.erb
@@ -28,6 +28,9 @@
         </dt>
         <dd class="govuk-summary-list__value">
           <%= @global_option.valid_lifetime %>
+          <% if @global_option.valid_lifetime.present? %>
+          <%= @global_option.valid_lifetime > 1 ? @global_option.valid_lifetime_unit.downcase : @global_option.valid_lifetime_unit&.downcase.delete_suffix('s') %>
+          <% end %>
         </dd>
       </div>
     </dl>

--- a/app/views/global_options/index.html.erb
+++ b/app/views/global_options/index.html.erb
@@ -29,7 +29,6 @@
           Valid lifetime
         </dt>
         <dd class="govuk-summary-list__value">
-          <%= @global_option.valid_lifetime %>
           <%= presenter.display_valid_lifetime %>
         </dd>
       </div>

--- a/app/views/options/_details.html.erb
+++ b/app/views/options/_details.html.erb
@@ -1,3 +1,5 @@
+<% presenter = present(@subnet) %>
+
 <dl class="govuk-summary-list">
   <div class="govuk-summary-list__row">
     <dt class="govuk-summary-list__key">
@@ -23,9 +25,7 @@
     </dt>
     <dd class="govuk-summary-list__value">
       <%= @subnet.valid_lifetime %>
-      <% if @subnet.valid_lifetime.present? %>
-      <%= @subnet.valid_lifetime > 1 ? @subnet.valid_lifetime_unit.downcase : @subnet.valid_lifetime_unit&.downcase.delete_suffix('s') %>
-      <% end %>
+      <%= presenter.display_valid_lifetime %>
     </dd>
   </div>
 </dl>

--- a/app/views/options/_details.html.erb
+++ b/app/views/options/_details.html.erb
@@ -24,7 +24,6 @@
       Valid lifetime
     </dt>
     <dd class="govuk-summary-list__value">
-      <%= @subnet.valid_lifetime %>
       <%= presenter.display_valid_lifetime %>
     </dd>
   </div>

--- a/app/views/options/_details.html.erb
+++ b/app/views/options/_details.html.erb
@@ -23,6 +23,9 @@
     </dt>
     <dd class="govuk-summary-list__value">
       <%= @subnet.valid_lifetime %>
+      <% if @subnet.valid_lifetime.present? %>
+      <%= @subnet.valid_lifetime > 1 ? @subnet.valid_lifetime_unit.downcase : @subnet.valid_lifetime_unit&.downcase.delete_suffix('s') %>
+      <% end %>
     </dd>
   </div>
 </dl>

--- a/app/views/options/_form.html.erb
+++ b/app/views/options/_form.html.erb
@@ -21,9 +21,10 @@
   <div class="govuk-form-group <%= field_error(f.object, :valid_lifetime) %>">
     <%= f.label :valid_lifetime, class: "govuk-label" %>
     <div id="options_valid_lifetime-hint" class="govuk-hint">
-      How long the addresses (leases) given out by the server for this subnet are valid for in seconds
+      How long the addresses (leases) given out by the server for this subnet are valid for
     </div>
-    <%= f.text_field :valid_lifetime, class: "govuk-input" %>
+    <%= f.text_field :valid_lifetime, class: "govuk-input govuk-!-width-one-half" %>
+    <%= f.select( :valid_lifetime_unit, option.valid_lifetime_unit_options, {}, {class: "govuk-select govuk-!-width-one-third"}) %>
   </div>
 
   <%= f.submit f.object.new_record? ? "Create" : "Update", {

--- a/app/views/options/_form.html.erb
+++ b/app/views/options/_form.html.erb
@@ -23,8 +23,16 @@
     <div id="options_valid_lifetime-hint" class="govuk-hint">
       How long the addresses (leases) given out by the server for this subnet are valid for
     </div>
-    <%= f.text_field :valid_lifetime, class: "govuk-input govuk-!-width-one-half" %>
-    <%= f.select( :valid_lifetime_unit, option.valid_lifetime_unit_options, {}, {class: "govuk-select govuk-!-width-one-third"}) %>
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-full">
+        <div class="govuk-grid-column-one-half govuk-!-padding-0">
+          <%= f.text_field :valid_lifetime, class: "govuk-input" %>
+        </div>
+        <div class="govuk-grid-column-one-half">
+          <%= f.select( :valid_lifetime_unit, Option::VALID_LIFETIME_UNIT_OPTIONS, {}, {class: "govuk-select govuk-!-width-full"}) %>
+        </div>
+      </div>
+    </div>
   </div>
 
   <%= f.submit f.object.new_record? ? "Create" : "Update", {

--- a/db/migrate/20210126114119_add_valid_lifetime_unit_to_global_options.rb
+++ b/db/migrate/20210126114119_add_valid_lifetime_unit_to_global_options.rb
@@ -1,0 +1,5 @@
+class AddValidLifetimeUnitToGlobalOptions < ActiveRecord::Migration[6.0]
+  def change
+    add_column :global_options, :valid_lifetime_unit, :string, default: "Seconds"
+  end
+end

--- a/db/migrate/20210126114246_add_valid_lifetime_unit_to_options.rb
+++ b/db/migrate/20210126114246_add_valid_lifetime_unit_to_options.rb
@@ -1,0 +1,5 @@
+class AddValidLifetimeUnitToOptions < ActiveRecord::Migration[6.0]
+  def change
+    add_column :options, :valid_lifetime_unit, :string, default: "Seconds"
+  end
+end

--- a/db/migrate/20210127150048_remove_default_from_global_options_valid_lifetime_unit.rb
+++ b/db/migrate/20210127150048_remove_default_from_global_options_valid_lifetime_unit.rb
@@ -1,0 +1,5 @@
+class RemoveDefaultFromGlobalOptionsValidLifetimeUnit < ActiveRecord::Migration[6.0]
+  def change
+    change_column_default :global_options, :valid_lifetime_unit, from: "Seconds", to: nil
+  end
+end

--- a/db/migrate/20210127150536_remove_default_from_options_valid_lifetime_unit.rb
+++ b/db/migrate/20210127150536_remove_default_from_options_valid_lifetime_unit.rb
@@ -1,0 +1,5 @@
+class RemoveDefaultFromOptionsValidLifetimeUnit < ActiveRecord::Migration[6.0]
+  def change
+    change_column_default :options, :valid_lifetime_unit, from: "Seconds", to: nil
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,6 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema.define(version: 2021_01_27_150536) do
-
   create_table "audits", options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
     t.integer "auditable_id"
     t.string "auditable_type"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,8 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_06_162456) do
+ActiveRecord::Schema.define(version: 2021_01_27_150536) do
+
   create_table "audits", options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
     t.integer "auditable_id"
     t.string "auditable_type"
@@ -50,6 +51,7 @@ ActiveRecord::Schema.define(version: 2021_01_06_162456) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.integer "valid_lifetime", unsigned: true
+    t.string "valid_lifetime_unit"
   end
 
   create_table "options", options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
@@ -59,6 +61,7 @@ ActiveRecord::Schema.define(version: 2021_01_06_162456) do
     t.datetime "updated_at", precision: 6, null: false
     t.bigint "subnet_id", null: false
     t.integer "valid_lifetime", unsigned: true
+    t.string "valid_lifetime_unit"
     t.index ["subnet_id"], name: "index_options_on_subnet_id"
   end
 

--- a/spec/acceptance/create_global_options_spec.rb
+++ b/spec/acceptance/create_global_options_spec.rb
@@ -40,7 +40,8 @@ describe "create global options", type: :feature do
       fill_in "Domain name servers", with: "10.0.2.1,10.0.2.2"
       fill_in "Domain name", with: "test.example.com"
       fill_in "Valid lifetime", with: 12345
-
+      select "Minutes", from: "global_option[valid_lifetime_unit]"
+      
       expect_config_to_be_verified
       expect_config_to_be_published
 
@@ -50,7 +51,27 @@ describe "create global options", type: :feature do
       expect(page).to have_content("This could take up to 10 minutes to apply.")
       expect(page).to have_content("10.0.2.1,10.0.2.2")
       expect(page).to have_content("test.example.com")
-      expect(page).to have_content("12345")
+      expect(page).to have_content("12345 minutes")
+
+      expect_audit_log_entry_for(editor.email, "create", "Global option")
+    end
+
+    it "Edit global options to have a valid lifetime of 1 hour" do
+      visit "/global-options"
+
+      click_on "Create global options"
+
+      fill_in "Domain name servers", with: "10.0.2.10,10.0.2.20"
+      fill_in "Domain name", with: "test2.example.com"
+      fill_in "Valid lifetime", with: 1
+      select "Hours", from: "global_option[valid_lifetime_unit]"
+
+      expect_config_to_be_verified
+      expect_config_to_be_published
+
+      click_on "Create"
+
+      expect(page).to have_content("1 hour")
 
       expect_audit_log_entry_for(editor.email, "create", "Global option")
     end

--- a/spec/acceptance/create_global_options_spec.rb
+++ b/spec/acceptance/create_global_options_spec.rb
@@ -41,7 +41,7 @@ describe "create global options", type: :feature do
       fill_in "Domain name", with: "test.example.com"
       fill_in "Valid lifetime", with: 12345
       select "Minutes", from: "global_option[valid_lifetime_unit]"
-      
+
       expect_config_to_be_verified
       expect_config_to_be_published
 

--- a/spec/acceptance/create_options_spec.rb
+++ b/spec/acceptance/create_options_spec.rb
@@ -47,6 +47,7 @@ describe "create options", type: :feature do
       fill_in "Domain name servers", with: "10.0.2.1,10.0.2.2"
       fill_in "Domain name", with: "test.example.com"
       fill_in "Valid lifetime", with: "12345"
+      select "Seconds", from: "option[valid_lifetime_unit]"
 
       expect_config_to_be_verified
       expect_config_to_be_published
@@ -57,7 +58,28 @@ describe "create options", type: :feature do
       expect(page).to have_content("This could take up to 10 minutes to apply.")
       expect(page).to have_content("10.0.2.1,10.0.2.2")
       expect(page).to have_content("test.example.com")
-      expect(page).to have_content("12345")
+      expect(page).to have_content("12345 seconds")
+
+      expect_audit_log_entry_for(editor.email, "create", "Option")
+    end
+
+    it "edit subnet option to have a valid lifetime of 1 day" do
+      visit "/subnets/#{subnet.to_param}"
+
+      expect(page).not_to have_content("Edit options")
+      click_on "Create options"
+
+      fill_in "Domain name servers", with: "10.0.2.1,10.0.2.2"
+      fill_in "Domain name", with: "test.example.com"
+      fill_in "Valid lifetime", with: "1"
+      select "Days", from: "option[valid_lifetime_unit]"
+
+      expect_config_to_be_verified
+      expect_config_to_be_published
+
+      click_on "Create"
+
+      expect(page).to have_content("1 day")
 
       expect_audit_log_entry_for(editor.email, "create", "Option")
     end

--- a/spec/acceptance/delete_global_options_spec.rb
+++ b/spec/acceptance/delete_global_options_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe "delete gobal options", type: :feature do
+describe "delete global options", type: :feature do
   let(:editor) { create(:user, :editor) }
 
   before do

--- a/spec/factories/global_options.rb
+++ b/spec/factories/global_options.rb
@@ -2,5 +2,6 @@ FactoryBot.define do
   factory :global_option do
     domain_name_servers { "12.0.4.1,12.0.4.5" }
     domain_name { "www.example.com" }
+    valid_lifetime_unit { "Seconds" }
   end
 end

--- a/spec/factories/options.rb
+++ b/spec/factories/options.rb
@@ -3,5 +3,6 @@ FactoryBot.define do
     subnet
     domain_name_servers { "12.0.4.1,12.0.4.5" }
     domain_name { "www.examgitple.com" }
+    valid_lifetime_unit { "Seconds" }
   end
 end

--- a/spec/presenters/global_option_presenter_spec.rb
+++ b/spec/presenters/global_option_presenter_spec.rb
@@ -1,0 +1,33 @@
+require "rails_helper"
+
+describe GlobalOptionPresenter do
+  describe "#display_valid_lifetime" do
+    it "returns a user-friendly valid lifetime unit of 320 second'" do
+      global_option = build_stubbed(:global_option, valid_lifetime: 320, valid_lifetime_unit: "Seconds")
+      presenter = GlobalOptionPresenter.new(global_option)
+
+      expect(presenter.display_valid_lifetime).to eq("320 seconds")
+    end
+
+    it "returns a user-friendly valid lifetime unit of 1 minute" do
+      global_option = build_stubbed(:global_option, valid_lifetime: 1, valid_lifetime_unit: "Minutes")
+      presenter = GlobalOptionPresenter.new(global_option)
+
+      expect(presenter.display_valid_lifetime).to eq("1 minute")
+    end
+
+    it "returns a user-friendly valid lifetime unit of 26 hours" do
+      global_option = build_stubbed(:global_option, valid_lifetime: 26, valid_lifetime_unit: "Hours")
+      presenter = GlobalOptionPresenter.new(global_option)
+
+      expect(presenter.display_valid_lifetime).to eq("26 hours")
+    end
+
+    it "returns a user-friendly valid lifetime unit of 3 days" do
+      global_option = build_stubbed(:global_option, valid_lifetime: 3, valid_lifetime_unit: "Days")
+      presenter = GlobalOptionPresenter.new(global_option)
+
+      expect(presenter.display_valid_lifetime).to eq("3 days")
+    end
+  end
+end

--- a/spec/presenters/subnet_presenter_spec.rb
+++ b/spec/presenters/subnet_presenter_spec.rb
@@ -1,0 +1,41 @@
+require "rails_helper"
+
+describe SubnetPresenter do
+  describe "#display_valid_lifetime" do
+    it "returns a user-friendly valid lifetime unit of 320 seconds" do
+      option = build_stubbed(:option, valid_lifetime: 320, valid_lifetime_unit: "Seconds")
+      subnet = build_stubbed(:subnet, option: option)
+
+      presenter = SubnetPresenter.new(subnet)
+
+      expect(presenter.display_valid_lifetime).to eq("320 seconds")
+    end
+
+    it "returns a user-friendly valid lifetime unit of 1 minute" do
+      option = build_stubbed(:option, valid_lifetime: 1, valid_lifetime_unit: "Minutes")
+      subnet = build_stubbed(:subnet, option: option)
+
+      presenter = SubnetPresenter.new(subnet)
+
+      expect(presenter.display_valid_lifetime).to eq("1 minute")
+    end
+
+    it "returns a user-friendly valid lifetime unit of 26 hours" do
+      option = build_stubbed(:option, valid_lifetime: 26, valid_lifetime_unit: "Hours")
+      subnet = build_stubbed(:subnet, option: option)
+
+      presenter = SubnetPresenter.new(subnet)
+
+      expect(presenter.display_valid_lifetime).to eq("26 hours")
+    end
+
+    it "returns a user-friendly valid lifetime unit of 3 days" do
+      option = build_stubbed(:option, valid_lifetime: 3, valid_lifetime_unit: "Days")
+      subnet = build_stubbed(:subnet, option: option)
+
+      presenter = SubnetPresenter.new(subnet)
+
+      expect(presenter.display_valid_lifetime).to eq("3 days")
+    end
+  end
+end

--- a/spec/use_cases/generate_kea_config_spec.rb
+++ b/spec/use_cases/generate_kea_config_spec.rb
@@ -128,11 +128,32 @@ describe UseCases::GenerateKeaConfig do
       expect(config.dig(:Dhcp4, :"valid-lifetime")).to eq 4000
     end
 
-    it "sets the valid-lifetime using the global option valid lifetime" do
+    it "sets the valid-lifetime using the global option valid lifetime and valid lifetime unit defaults to seconds" do
       global_option = build_stubbed(:global_option, valid_lifetime: 600)
       config = UseCases::GenerateKeaConfig.new(subnets: [], global_option: global_option).call
 
       expect(config.dig(:Dhcp4, :"valid-lifetime")).to eq 600
+    end
+
+    it "sets the valid-lifetime of 1 day using the global option valid lifetime" do
+      global_option = build_stubbed(:global_option, valid_lifetime: 1, valid_lifetime_unit: "Days")
+      config = UseCases::GenerateKeaConfig.new(subnets: [], global_option: global_option).call
+
+      expect(config.dig(:Dhcp4, :"valid-lifetime")).to eq 86400
+    end
+
+    it "sets the valid-lifetime of 3 hours using the global option valid lifetime" do
+      global_option = build_stubbed(:global_option, valid_lifetime: 3, valid_lifetime_unit: "Hours")
+      config = UseCases::GenerateKeaConfig.new(subnets: [], global_option: global_option).call
+
+      expect(config.dig(:Dhcp4, :"valid-lifetime")).to eq 10800
+    end
+
+    it "sets the valid-lifetime of 5 minutes using the global option valid lifetime" do
+      global_option = build_stubbed(:global_option, valid_lifetime: 5, valid_lifetime_unit: "Minutes")
+      config = UseCases::GenerateKeaConfig.new(subnets: [], global_option: global_option).call
+
+      expect(config.dig(:Dhcp4, :"valid-lifetime")).to eq 300
     end
 
     it "does not set the valid lifetime for a subnet if the subnet option is not set" do

--- a/spec/use_cases/generate_kea_config_spec.rb
+++ b/spec/use_cases/generate_kea_config_spec.rb
@@ -156,6 +156,13 @@ describe UseCases::GenerateKeaConfig do
       expect(config.dig(:Dhcp4, :"valid-lifetime")).to eq 300
     end
 
+    it "sets the valid-lifetime of 250 seconds using the global option valid lifetime" do
+      global_option = build_stubbed(:global_option, valid_lifetime: 250, valid_lifetime_unit: "Seconds")
+      config = UseCases::GenerateKeaConfig.new(subnets: [], global_option: global_option).call
+
+      expect(config.dig(:Dhcp4, :"valid-lifetime")).to eq 250
+    end
+
     it "does not set the valid lifetime for a subnet if the subnet option is not set" do
       subnet = build_stubbed(:subnet, option: nil)
       config = UseCases::GenerateKeaConfig.new(subnets: [subnet]).call


### PR DESCRIPTION
# What
Add valid lifetime units for global options and subnet options

# Why
Allow users to select from a list of time units when setting the valid lifetime option

# Screenshots

<img width="675" alt="Screenshot 2021-01-27 at 15 26 49" src="https://user-images.githubusercontent.com/64264510/106013298-371d9f00-60b4-11eb-9e59-5c47064eaa65.png">

<img width="866" alt="Screenshot 2021-01-27 at 15 28 50" src="https://user-images.githubusercontent.com/64264510/106013493-69c79780-60b4-11eb-83f1-1fa59abda86c.png">
