### PR TITLE
Add hint text for Site FITS ID

### DIFF
--- a/app/views/sites/_form.html.erb
+++ b/app/views/sites/_form.html.erb
@@ -1,6 +1,9 @@
 <%= form_with model: site, local: true do |f| %>
   <div class="govuk-form-group <%= field_error(f.object, :fits_id )%>">
     <%= f.label :fits_id, class: "govuk-label" %>
+    <div id="fits_id-hint" class="govuk-hint">
+      Unique reference of the Site. For example: FITS_1234
+    </div>
     <%= f.text_field :fits_id, class: "govuk-input" %>
   </div>
 


### PR DESCRIPTION
# What
Adds hint text to the Site FITS ID field

# Why
To prompt the user with an example format

# Screenshots
![ScreenShot 2021-01-27 at 15 31 43](https://user-images.githubusercontent.com/7527178/106014125-14d85100-60b5-11eb-81a3-a9890ac454ab.png)


# Notes
