### PR TITLE
Fix production log level to warn

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -48,7 +48,7 @@ Rails.application.configure do
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.
-  config.log_level = ENV["log_level"] || :debug
+  config.log_level = ENV["log_level"] || :warn
 
   # Prepend all log lines with the following tags.
   config.log_tags = [:request_id]


### PR DESCRIPTION
There is no longer a need for debug level logs in production environments. Set them to warn to provide less noisy logging