### PR TITLE
Add breadcrumb navigation

### DIFF
--- a/app/views/client_classes/index.html.erb
+++ b/app/views/client_classes/index.html.erb
@@ -1,3 +1,5 @@
+<%= render "layouts/breadcrumbs", crumbs: [["Home", root_path], ["DHCP", dhcp_path]] %>
+
 <div>
   <h2 class="govuk-heading-l">Client Classes</h2>
 

--- a/app/views/global_options/index.html.erb
+++ b/app/views/global_options/index.html.erb
@@ -1,3 +1,5 @@
+<%= render "layouts/breadcrumbs", crumbs: [["Home", root_path], ["DHCP", dhcp_path]] %>
+
 <div>
   <h2 class="govuk-heading-l">Global Options</h2>
 

--- a/app/views/layouts/_breadcrumbs.html.erb
+++ b/app/views/layouts/_breadcrumbs.html.erb
@@ -1,0 +1,9 @@
+<div class="govuk-breadcrumbs ">
+  <ol class="govuk-breadcrumbs__list">
+    <% crumbs.each do |name, path| %>
+      <li class="govuk-breadcrumbs__list-item">
+        <%= link_to name, path, class: "govuk-breadcrumbs__link" %>
+      </li>
+    <% end %>
+  </ol>
+</div>

--- a/app/views/leases/index.html.erb
+++ b/app/views/leases/index.html.erb
@@ -1,3 +1,5 @@
+<%= render "layouts/breadcrumbs", crumbs: [["Home", root_path], ["DHCP", dhcp_path], ["Site", @subnet.site], ["Subnet", @subnet]] %>
+
 <table class="govuk-table">
   <caption class="govuk-table__caption">Leases for <%= @subnet.cidr_block %></caption>
   <thead class="govuk-table__head">

--- a/app/views/reservations/_form.html.erb
+++ b/app/views/reservations/_form.html.erb
@@ -36,7 +36,7 @@
     "data-module" => "govuk-button"
   } %>
 
-  <%= link_to "Cancel", subnet_path(reservation.subnet),
+  <%= link_to "Cancel", f.object.new_record? ? subnet_path(reservation.subnet) : reservation,
   class: "govuk-button govuk-button--secondary",
   data: {
     module: "govuk-button"

--- a/app/views/reservations/show.html.erb
+++ b/app/views/reservations/show.html.erb
@@ -1,3 +1,5 @@
+<%= render "layouts/breadcrumbs", crumbs: [["Home", root_path], ["DHCP", dhcp_path], ["Site", @reservation.subnet.site], ["Subnet", @reservation.subnet]] %>
+
 <h2 class="govuk-heading-l">Reservation</h2>
 
 <dl class="govuk-summary-list">

--- a/app/views/sites/_form.html.erb
+++ b/app/views/sites/_form.html.erb
@@ -17,7 +17,7 @@
     "data-module" => "govuk-button"
   } %>
 
-  <%= link_to "Cancel", dhcp_path,
+  <%= link_to "Cancel", f.object.new_record? ? dhcp_path : @site,
   class: "govuk-button govuk-button--secondary",
   data: {
     module: "govuk-button"

--- a/app/views/sites/index.html.erb
+++ b/app/views/sites/index.html.erb
@@ -1,3 +1,5 @@
+<%= render "layouts/breadcrumbs", crumbs: [["Home", root_path]] %>
+
 <div>
   <h2 class="govuk-heading-l">DHCP</h2>
   <%= link_to "Global options", global_options_path, class: "govuk-button govuk-button--secondary govuk-!-margin-right-1" %>

--- a/app/views/sites/show.html.erb
+++ b/app/views/sites/show.html.erb
@@ -1,3 +1,5 @@
+<%= render "layouts/breadcrumbs", crumbs: [["Home", root_path], ["DHCP", dhcp_path]] %>
+
 <h2 class="govuk-heading-l">Site <%= @site.name %></h2>
 
 <dl class="govuk-summary-list">

--- a/app/views/subnets/_form.html.erb
+++ b/app/views/subnets/_form.html.erb
@@ -22,7 +22,7 @@
     </div>
     <%= f.text_field :end_address, class: "govuk-input" %>
   </div>
-  
+
   <div class="govuk-form-group <%= field_error(f.object, :routers )%>">
     <%= f.label :routers, class: "govuk-label" %>
     <div id="options_routers-hint" class="govuk-hint">
@@ -36,7 +36,7 @@
     "data-module" => "govuk-button"
   } %>
 
-  <%= link_to "Cancel", site_path(subnet.site),
+  <%= link_to "Cancel", f.object.new_record? ? site_path(subnet.site) : subnet,
   class: "govuk-button govuk-button--secondary",
   data: {
     module: "govuk-button"

--- a/app/views/subnets/show.html.erb
+++ b/app/views/subnets/show.html.erb
@@ -1,3 +1,5 @@
+<%= render "layouts/breadcrumbs", crumbs: [["Home", root_path], ["DHCP", dhcp_path], ["Site", @subnet.site]] %>
+
 <h2 class="govuk-heading-l">Subnet <%= @subnet.cidr_block %></h2>
 
 <dl class="govuk-summary-list">


### PR DESCRIPTION
# What
Added simple breadcrumb navigation to DHCP pages

# Why
To make it easier for the user to navigate back up the nested structure of the DHCP settings

# Screenshots
![ScreenShot 2021-01-29 at 11 59 43](https://user-images.githubusercontent.com/7527178/106272779-7faa9900-6229-11eb-835c-1f7838a94ed6.png)
