### PR TITLE
Move breadcrumbs partial out of the main div in the application layout

### DIFF
--- a/app/controllers/client_classes_controller.rb
+++ b/app/controllers/client_classes_controller.rb
@@ -3,6 +3,7 @@ class ClientClassesController < ApplicationController
 
   def index
     @client_classes = ClientClass.order(:name).all
+    @navigation_crumbs = [["Home", root_path], ["DHCP", dhcp_path]]
   end
 
   def show

--- a/app/controllers/global_options_controller.rb
+++ b/app/controllers/global_options_controller.rb
@@ -3,6 +3,7 @@ class GlobalOptionsController < ApplicationController
 
   def index
     @global_option = GlobalOption.first
+    @navigation_crumbs = [["Home", root_path], ["DHCP", dhcp_path]]
   end
 
   def new

--- a/app/controllers/leases_controller.rb
+++ b/app/controllers/leases_controller.rb
@@ -5,5 +5,6 @@ class LeasesController < ApplicationController
       gateway: kea_control_agent_gateway,
       subnet_kea_id: @subnet.kea_id
     ).call
+    @navigation_crumbs = [["Home", root_path], ["DHCP", dhcp_path], ["Site", @subnet.site], ["Subnet", @subnet]]
   end
 end

--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -19,6 +19,7 @@ class ReservationsController < ApplicationController
   end
 
   def show
+    @navigation_crumbs = [["Home", root_path], ["DHCP", dhcp_path], ["Site", @reservation.subnet.site], ["Subnet", @reservation.subnet]]
   end
 
   def edit

--- a/app/controllers/sites_controller.rb
+++ b/app/controllers/sites_controller.rb
@@ -3,10 +3,12 @@ class SitesController < ApplicationController
 
   def index
     @sites = Site.order(:fits_id).all
+    @navigation_crumbs = [["Home", root_path]]
   end
 
   def show
     @subnets = @site.subnets.sort_by(&:ip_addr)
+    @navigation_crumbs = [["Home", root_path], ["DHCP", dhcp_path]]
   end
 
   def new

--- a/app/controllers/subnets_controller.rb
+++ b/app/controllers/subnets_controller.rb
@@ -19,6 +19,7 @@ class SubnetsController < ApplicationController
   end
 
   def show
+    @navigation_crumbs = [["Home", root_path], ["DHCP", dhcp_path], ["Site", @subnet.site]]
   end
 
   def edit

--- a/app/controllers/zones_controller.rb
+++ b/app/controllers/zones_controller.rb
@@ -3,6 +3,7 @@ class ZonesController < ApplicationController
 
   def index
     @zones = Zone.select(:id, :name, :forwarders, :purpose).all
+    @navigation_crumbs = [["Home", root_path]]
   end
 
   def new

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -13,4 +13,8 @@ module ApplicationHelper
     presenter = "#{model.class}Presenter".constantize
     presenter.new(model)
   end
+
+  def navigation_crumbs
+    @navigation_crumbs ||= []
+  end
 end

--- a/app/views/client_classes/index.html.erb
+++ b/app/views/client_classes/index.html.erb
@@ -1,5 +1,3 @@
-<%= render "layouts/breadcrumbs", crumbs: [["Home", root_path], ["DHCP", dhcp_path]] %>
-
 <div>
   <h2 class="govuk-heading-l">Client Classes</h2>
 

--- a/app/views/global_options/index.html.erb
+++ b/app/views/global_options/index.html.erb
@@ -1,5 +1,3 @@
-<%= render "layouts/breadcrumbs", crumbs: [["Home", root_path], ["DHCP", dhcp_path]] %>
-
 <div>
   <h2 class="govuk-heading-l">Global Options</h2>
 

--- a/app/views/layouts/_breadcrumbs.html.erb
+++ b/app/views/layouts/_breadcrumbs.html.erb
@@ -1,9 +1,11 @@
-<div class="govuk-breadcrumbs ">
-  <ol class="govuk-breadcrumbs__list">
-    <% crumbs.each do |name, path| %>
-      <li class="govuk-breadcrumbs__list-item">
-        <%= link_to name, path, class: "govuk-breadcrumbs__link" %>
-      </li>
-    <% end %>
-  </ol>
-</div>
+<% if crumbs.present? %>
+  <div class="govuk-breadcrumbs ">
+    <ol class="govuk-breadcrumbs__list">
+      <% crumbs.each do |name, path| %>
+        <li class="govuk-breadcrumbs__list-item">
+          <%= link_to name, path, class: "govuk-breadcrumbs__link" %>
+        </li>
+      <% end %>
+    </ol>
+  </div>
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -59,9 +59,11 @@
 
       <% if user_signed_in? %>
         <hr class="govuk-section-break govuk-section-break--xs govuk-section-break--visible">
+        <%= render "layouts/breadcrumbs", crumbs: navigation_crumbs %>
+
         <div class="govuk-grid-row">
           <div class="govuk-grid-column-three-quarters">
-            <main class="govuk-main-wrapper govuk-!-padding-top-4" id="main-content" role="main">
+            <main class="govuk-main-wrapper govuk-!-padding-top-3" id="main-content" role="main">
               <%= render "layouts/flash_notices" %>
               <%= yield %>
             </main>

--- a/app/views/leases/index.html.erb
+++ b/app/views/leases/index.html.erb
@@ -1,5 +1,3 @@
-<%= render "layouts/breadcrumbs", crumbs: [["Home", root_path], ["DHCP", dhcp_path], ["Site", @subnet.site], ["Subnet", @subnet]] %>
-
 <table class="govuk-table">
   <caption class="govuk-table__caption">Leases for <%= @subnet.cidr_block %></caption>
   <thead class="govuk-table__head">

--- a/app/views/reservations/show.html.erb
+++ b/app/views/reservations/show.html.erb
@@ -1,5 +1,3 @@
-<%= render "layouts/breadcrumbs", crumbs: [["Home", root_path], ["DHCP", dhcp_path], ["Site", @reservation.subnet.site], ["Subnet", @reservation.subnet]] %>
-
 <h2 class="govuk-heading-l">Reservation</h2>
 
 <dl class="govuk-summary-list">

--- a/app/views/sites/index.html.erb
+++ b/app/views/sites/index.html.erb
@@ -1,5 +1,3 @@
-<%= render "layouts/breadcrumbs", crumbs: [["Home", root_path]] %>
-
 <div>
   <h2 class="govuk-heading-l">DHCP</h2>
   <%= link_to "Global options", global_options_path, class: "govuk-button govuk-button--secondary govuk-!-margin-right-1" %>

--- a/app/views/sites/show.html.erb
+++ b/app/views/sites/show.html.erb
@@ -1,5 +1,3 @@
-<%= render "layouts/breadcrumbs", crumbs: [["Home", root_path], ["DHCP", dhcp_path]] %>
-
 <h2 class="govuk-heading-l">Site <%= @site.name %></h2>
 
 <dl class="govuk-summary-list">

--- a/app/views/subnets/show.html.erb
+++ b/app/views/subnets/show.html.erb
@@ -1,5 +1,3 @@
-<%= render "layouts/breadcrumbs", crumbs: [["Home", root_path], ["DHCP", dhcp_path], ["Site", @subnet.site]] %>
-
 <h2 class="govuk-heading-l">Subnet <%= @subnet.cidr_block %></h2>
 
 <dl class="govuk-summary-list">


### PR DESCRIPTION
# What

Extracted breadcrumbs partial out of the main element

# Why

Follows guidance for the back link around navigation elements and the `<main>` element

https://design-system.service.gov.uk/components/back-link/

> Always place back links at the top of a page, before the `<main>` element.
> Placing them here means that the “Skip to main content” link allows the user
> to skip all navigation links, including the back link.

This also fixes the spacing above the previous breadcrumbs as they were inheriting the padding from the `<main>` element

The padding in the main element has also been changed to match the margin for the breadcrumbs (so that pages without breadcrumbs maintain the same distance from the navbar)

# Screenshots

### Before
![ScreenShot 2021-02-01 at 11 49 12](https://user-images.githubusercontent.com/7527178/106455248-d6131400-6483-11eb-9ddc-f72caee82634.png)

### After
![ScreenShot 2021-02-01 at 11 48 50](https://user-images.githubusercontent.com/7527178/106455257-d9a69b00-6483-11eb-9700-4d2006fef54e.png)


# Notes
