### PR TITLE
Display forwarding IPs in a list

### DIFF
--- a/app/views/zones/index.html.erb
+++ b/app/views/zones/index.html.erb
@@ -24,7 +24,11 @@
       <% @zones.each do |zone| %>
         <tr class="govuk-table__row">
           <td class="govuk-table__cell"><%= zone.name %></td>
-          <td class="govuk-table__cell"><%= zone.forwarders.join(',') %></td>
+          <td class="govuk-table__cell">
+          <% zone.forwarders.each do |forwarder| %>
+            <%= forwarder %><br />
+          <% end%>
+          </td>
           <td class="govuk-table__cell"><%= zone.purpose %></td>
           <% if can? :manage, Subnet %>
             <td class="govuk-table__cell">

--- a/spec/acceptance/update_zones_spec.rb
+++ b/spec/acceptance/update_zones_spec.rb
@@ -31,7 +31,7 @@ describe "update zones", type: :feature do
     expect(page).to have_content("Successfully updated zone")
 
     expect(page).to have_content("test.example.com")
-    expect(page).to have_content("127.0.0.2,127.0.0.1")
+    expect(page).to have_content("127.0.0.2 127.0.0.1")
     expect(page).to have_content("UI Testing for Updating")
 
     expect_audit_log_entry_for(editor.email, "update", "Zone")

--- a/spec/acceptance/zones_spec.rb
+++ b/spec/acceptance/zones_spec.rb
@@ -12,7 +12,7 @@ describe "GET /zones", type: :feature do
 
       visit "/dns"
       expect(page).to have_content zone.name
-      expect(page).to have_content zone.forwarders.join(",")
+      expect(page).to have_content zone.forwarders.join(" ")
       expect(page).to have_content zone.purpose
 
       expect(page).to have_content zone2.name


### PR DESCRIPTION
Most zones will have many forwarding IPs, this never goes onto a new
line and creates a horizontal scrollbar.

Display the list of IPs vertically so this doesn't happen.

Can't take a screenshot of this as it contains real IP addresses.

# Screenshots

Before
<img width="1272" alt="Screenshot 2021-02-03 at 16 47 48" src="https://user-images.githubusercontent.com/1215147/106780146-9e50cb80-663f-11eb-99c2-a64fea55a44b.png">

After
<img width="936" alt="Screenshot 2021-02-03 at 16 48 45" src="https://user-images.githubusercontent.com/1215147/106780244-b3c5f580-663f-11eb-8020-f24af67ae881.png">


