### PR TITLE
add Subnet Range as an additional heading on "New Reservation" screen

### DIFF
--- a/app/views/reservations/edit.html.erb
+++ b/app/views/reservations/edit.html.erb
@@ -4,4 +4,6 @@
 
 <h3 class="govuk-heading-m">Subnet CIDR block: <%= @reservation.subnet.cidr_block %></h3>
 
+<h3 class="govuk-heading-s">Address pool: <%= @reservation.subnet.start_address %> to <%= @reservation.subnet.end_address %></h3>
+
 <%= render "reservations/form", reservation: @reservation %>

--- a/app/views/reservations/new.html.erb
+++ b/app/views/reservations/new.html.erb
@@ -4,6 +4,6 @@
 
 <h3 class="govuk-heading-m">Subnet CIDR block: <%= @reservation.subnet.cidr_block %></h3>
 
-<h3 class="govuk-heading-s">Address pool: <%= @reservation.subnet.start_address %> to <%= @reservation.subnet.end_address %></h3> %>
+<h3 class="govuk-heading-s">Address pool: <%= @reservation.subnet.start_address %> to <%= @reservation.subnet.end_address %></h3>
 
 <%= render "reservations/form", reservation: @reservation %>

--- a/app/views/reservations/new.html.erb
+++ b/app/views/reservations/new.html.erb
@@ -4,6 +4,6 @@
 
 <h3 class="govuk-heading-m">Subnet CIDR block: <%= @reservation.subnet.cidr_block %></h3>
 
-<h3 class="govuk-heading-s">Subnet range: <%= @reservation.subnet.start_address %> to <%= @reservation.subnet.end_address %></h3>
+<h3 class="govuk-heading-s">Address pool: <%= @reservation.subnet.start_address %> to <%= @reservation.subnet.end_address %></h3> %>
 
 <%= render "reservations/form", reservation: @reservation %>

--- a/app/views/reservations/new.html.erb
+++ b/app/views/reservations/new.html.erb
@@ -4,4 +4,6 @@
 
 <h3 class="govuk-heading-m">Subnet CIDR block: <%= @reservation.subnet.cidr_block %></h3>
 
+<h3 class="govuk-heading-s">Subnet range: <%= @reservation.subnet.start_address %> to <%= @reservation.subnet.end_address %></h3>
+
 <%= render "reservations/form", reservation: @reservation %>

--- a/spec/acceptance/create_reservations_spec.rb
+++ b/spec/acceptance/create_reservations_spec.rb
@@ -43,6 +43,8 @@ describe "create reservations", type: :feature do
 
       click_on "Create a new reservation"
 
+      expect(page).to have_content(reservation.subnet.start_address + " to " + reservation.subnet.end_address)
+
       fill_in "HW address", with: "01:bb:cc:dd:ee:fe"
       fill_in "IP address", with: "192.0.2.2"
       fill_in "Hostname", with: "test.example2.com"

--- a/spec/acceptance/update_reservations_spec.rb
+++ b/spec/acceptance/update_reservations_spec.rb
@@ -44,12 +44,11 @@ describe "update reservations", type: :feature do
       visit "/reservations/#{reservation.id}"
       first(:link, "Change").click
 
-expect(page).to have_content(reservation.subnet.start_address + " to " + reservation.subnet.end_address)
+      expect(page).to have_content(reservation.subnet.start_address + " to " + reservation.subnet.end_address)
       expect(page).to have_field("HW address", with: reservation.hw_address)
       expect(page).to have_field("IP address", with: reservation.ip_address)
       expect(page).to have_field("Hostname", with: reservation.hostname)
       expect(page).to have_field("Description", with: reservation.description)
-
 
       fill_in "HW address", with: "1a:1b:1c:1d:1e:1f"
       fill_in "IP address", with: "192.0.2.3"

--- a/spec/acceptance/update_reservations_spec.rb
+++ b/spec/acceptance/update_reservations_spec.rb
@@ -44,10 +44,12 @@ describe "update reservations", type: :feature do
       visit "/reservations/#{reservation.id}"
       first(:link, "Change").click
 
+expect(page).to have_content(reservation.subnet.start_address + " to " + reservation.subnet.end_address)
       expect(page).to have_field("HW address", with: reservation.hw_address)
       expect(page).to have_field("IP address", with: reservation.ip_address)
       expect(page).to have_field("Hostname", with: reservation.hostname)
       expect(page).to have_field("Description", with: reservation.description)
+
 
       fill_in "HW address", with: "1a:1b:1c:1d:1e:1f"
       fill_in "IP address", with: "192.0.2.3"


### PR DESCRIPTION
# What

Adding the subnet range at the top of the new reservation screen.

# Why

To inform users of the IP pool for which they are trying to add a reservation.

# Screenshots

![image](https://user-images.githubusercontent.com/68431297/108378772-37b1dd00-71fd-11eb-806e-82425e37c677.png)


# Notes
