### PR TITLE
Pttp 1967 - Adding delete confirmation/previews to all deletion screens.

### DIFF
--- a/app/views/client_classes/destroy.html.erb
+++ b/app/views/client_classes/destroy.html.erb
@@ -1,6 +1,19 @@
 <h2 class="govuk-heading-l">Are you sure you want to delete the client class?</h2>
 
-<p class="govuk-body">Deleting the client class cannot be undone</p>
+<div class="govuk-inset-text">
+  <h4 class="govuk-heading-s">Class name:</h4>
+  <p class="govuk-body"><%= @client_class.name %></p>
+    <h4 class="govuk-heading-s">Domain name:</h4>
+  <p class="govuk-body"><%= @client_class.domain_name %></p>
+</div>
+
+<div class="govuk-warning-text">
+  <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+  <strong class="govuk-warning-text__text">
+    <span class="govuk-warning-text__assistive">Warning</span>
+      Deleting the client class options cannot be undone.
+  </strong>
+</div>
 
 <%= button_to "Delete client class", client_class_path(@client_class),
   method: :delete,

--- a/app/views/global_options/destroy.html.erb
+++ b/app/views/global_options/destroy.html.erb
@@ -1,6 +1,19 @@
 <h2 class="govuk-heading-l">Are you sure you want to delete the global options?</h2>
 
-<p class="govuk-body">Deleting the global options cannot be undone</p>
+<div class="govuk-inset-text">
+  <h4 class="govuk-heading-s">Domain name:</h4>
+  <p class="govuk-body"><%= @global_option.domain_name %></p>
+    <h4 class="govuk-heading-s">Domain name servers:</h4>
+  <p class="govuk-body"><%= @global_option.domain_name_servers.join(', ') %></p>
+</div>
+
+<div class="govuk-warning-text">
+  <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+  <strong class="govuk-warning-text__text">
+    <span class="govuk-warning-text__assistive">Warning</span>
+      Deleting the global options cannot be undone.
+  </strong>
+</div>
 
 <%= button_to "Delete global options", global_option_path(@global_option),
   method: :delete,

--- a/app/views/options/destroy.html.erb
+++ b/app/views/options/destroy.html.erb
@@ -1,6 +1,19 @@
 <h2 class="govuk-heading-l">Are you sure you want to delete these options?</h2>
 
-<p class="govuk-body">Deleting options cannot be undone</p>
+<div class="govuk-inset-text">
+  <h4 class="govuk-heading-s">Domain name:</h4>
+  <p class="govuk-body"><%= @option.domain_name %></p>
+  <h4 class="govuk-heading-s">Domain name servers:</h4>
+  <p class="govuk-body"><%= @option.domain_name_servers.join(", ") %></p>
+</div>
+
+<div class="govuk-warning-text">
+  <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+  <strong class="govuk-warning-text__text">
+    <span class="govuk-warning-text__assistive">Warning</span>
+      Deleting options cannot be undone.
+  </strong>
+</div>
 
 <%= button_to "Delete options", subnet_options_path(@option.subnet),
   method: :delete,

--- a/app/views/reservation_options/destroy.html.erb
+++ b/app/views/reservation_options/destroy.html.erb
@@ -1,6 +1,19 @@
 <h2 class="govuk-heading-l">Are you sure you want to delete these options?</h2>
 
-<p class="govuk-body">Deleting reservation options cannot be undone</p>
+<div class="govuk-inset-text">
+  <h4 class="govuk-heading-s">Routers:</h4>
+  <p class="govuk-body"><%= @reservation_option.routers %></p>
+  <h4 class="govuk-heading-s">Domain Name:</h4>
+  <p class="govuk-body"><%= @reservation_option.domain_name %></p>
+</div>
+
+<div class="govuk-warning-text">
+  <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+  <strong class="govuk-warning-text__text">
+    <span class="govuk-warning-text__assistive">Warning</span>
+      Deleting reservation options cannot be undone.
+  </strong>
+</div>
 
 <%= button_to "Delete reservation options", reservation_option_path(@reservation_option),
   method: :delete,

--- a/app/views/reservation_options/destroy.html.erb
+++ b/app/views/reservation_options/destroy.html.erb
@@ -2,7 +2,7 @@
 
 <div class="govuk-inset-text">
   <h4 class="govuk-heading-s">Routers:</h4>
-  <p class="govuk-body"><%= @reservation_option.routers %></p>
+  <p class="govuk-body"><%= @reservation_option.routers.join(", ") %></p>
   <h4 class="govuk-heading-s">Domain Name:</h4>
   <p class="govuk-body"><%= @reservation_option.domain_name %></p>
 </div>

--- a/app/views/reservations/destroy.html.erb
+++ b/app/views/reservations/destroy.html.erb
@@ -1,7 +1,11 @@
 <h2 class="govuk-heading-l">Are you sure you want to delete the below reservation?</h2>
 
-<p class="govuk-body">Hostname: <%= @reservation.hostname %></p>
-<p class="govuk-body">IP Address: <%= @reservation.ip_address %></p>
+<div class="govuk-inset-text">
+  <h4 class="govuk-heading-s">Hostname:</h4>
+  <p class="govuk-body"><%= @reservation.hostname %></p>
+  <h4 class="govuk-heading-s">IP Address:</h4>
+  <p class="govuk-body"><%= @reservation.ip_address %></p>
+</div>
 
 <div class="govuk-warning-text">
   <span class="govuk-warning-text__icon" aria-hidden="true">!</span>

--- a/app/views/reservations/destroy.html.erb
+++ b/app/views/reservations/destroy.html.erb
@@ -1,6 +1,15 @@
-<h2 class="govuk-heading-l">Are you sure you want to delete this reservation?</h2>
+<h2 class="govuk-heading-l">Are you sure you want to delete the below reservation?</h2>
 
-<p class="govuk-body">Deleting reservations cannot be undone</p>
+<p class="govuk-body">Hostname: <%= @reservation.hostname %></p>
+<p class="govuk-body">IP Address: <%= @reservation.ip_address %></p>
+
+<div class="govuk-warning-text">
+  <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+  <strong class="govuk-warning-text__text">
+    <span class="govuk-warning-text__assistive">Warning</span>
+      Deleting reservations cannot be undone.
+  </strong>
+</div>
 
 <%= button_to "Delete reservation", reservation_path(@reservation),
   method: :delete,

--- a/app/views/reservations/destroy.html.erb
+++ b/app/views/reservations/destroy.html.erb
@@ -1,4 +1,4 @@
-<h2 class="govuk-heading-l">Are you sure you want to delete the below reservation?</h2>
+<h2 class="govuk-heading-l">Are you sure you want to delete this reservation?</h2>
 
 <div class="govuk-inset-text">
   <h4 class="govuk-heading-s">Hostname:</h4>

--- a/app/views/sites/destroy.html.erb
+++ b/app/views/sites/destroy.html.erb
@@ -1,6 +1,19 @@
 <h2 class="govuk-heading-l">Are you sure you want to delete this site?</h2>
 
-<p class="govuk-body">Deleting a site cannot be undone</p>
+<div class="govuk-inset-text">
+  <h4 class="govuk-heading-s">Site name:</h4>
+  <p class="govuk-body"><%= @site.name %></p>
+  <h4 class="govuk-heading-s">FITS_ID:</h4>
+  <p class="govuk-body"><%= @site.fits_id %></p>
+</div>
+
+<div class="govuk-warning-text">
+  <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+  <strong class="govuk-warning-text__text">
+    <span class="govuk-warning-text__assistive">Warning</span>
+      Deleting a site cannot be undone.
+  </strong>
+</div>
 
 <% if @subnets.any? %>
   <p class="govuk-body">The following subnets will be destroyed</p>

--- a/app/views/subnets/destroy.html.erb
+++ b/app/views/subnets/destroy.html.erb
@@ -1,6 +1,18 @@
 <h2 class="govuk-heading-l">Are you sure you want to delete this subnet?</h2>
 
-<p class="govuk-body">Deleting a subnet cannot be undone</p>
+
+<div class="govuk-inset-text">
+  <h4 class="govuk-heading-s">CIDR block:</h4>
+  <p class="govuk-body"><%= @subnet.cidr_block %></p>
+</div>
+
+<div class="govuk-warning-text">
+  <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+  <strong class="govuk-warning-text__text">
+    <span class="govuk-warning-text__assistive">Warning</span>
+      Deleting a subnet cannot be undone.
+  </strong>
+</div>
 
 <% if @subnet.reservations.any? %>
   <p class="govuk-body">The following reservations will be destroyed</p>

--- a/app/views/zones/destroy.html.erb
+++ b/app/views/zones/destroy.html.erb
@@ -1,6 +1,19 @@
 <h2 class="govuk-heading-l">Are you sure you want to delete this zone?</h2>
 
-<p class="govuk-body">Deleting a zone cannot be undone</p>
+<div class="govuk-inset-text">
+  <h4 class="govuk-heading-s">Zone name:</h4>
+  <p class="govuk-body"><%= @zone.name %></p>
+  <h4 class="govuk-heading-s">Forwarders:</h4>
+  <p class="govuk-body"><%= @zone.forwarders.join(', ') %></p>
+</div>
+
+<div class="govuk-warning-text">
+  <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+  <strong class="govuk-warning-text__text">
+    <span class="govuk-warning-text__assistive">Warning</span>
+      Deleting a zone cannot be undone.
+  </strong>
+</div>
 
 <%= button_to "Delete zone", zone_path(@zone),
   method: :delete,

--- a/spec/acceptance/delete_client_classes_spec.rb
+++ b/spec/acceptance/delete_client_classes_spec.rb
@@ -14,6 +14,8 @@ describe "delete client class", type: :feature do
     click_on "Delete"
 
     expect(page).to have_content("Are you sure you want to delete the client class?")
+    expect(page).to have_content(client_class.domain_name)
+    expect(page).to have_content(client_class.name)
 
     expect_config_to_be_verified
     expect_config_to_be_published

--- a/spec/acceptance/delete_global_options_spec.rb
+++ b/spec/acceptance/delete_global_options_spec.rb
@@ -14,6 +14,8 @@ describe "delete global options", type: :feature do
     click_on "Delete global options"
 
     expect(page).to have_content("Are you sure you want to delete the global options?")
+    expect(page).to have_content(global_option.domain_name)
+    expect(page).to have_content(global_option.domain_name_servers.join(', '))
 
     expect_config_to_be_verified
     expect_config_to_be_published

--- a/spec/acceptance/delete_global_options_spec.rb
+++ b/spec/acceptance/delete_global_options_spec.rb
@@ -15,7 +15,7 @@ describe "delete global options", type: :feature do
 
     expect(page).to have_content("Are you sure you want to delete the global options?")
     expect(page).to have_content(global_option.domain_name)
-    expect(page).to have_content(global_option.domain_name_servers.join(', '))
+    expect(page).to have_content(global_option.domain_name_servers.join(", "))
 
     expect_config_to_be_verified
     expect_config_to_be_published

--- a/spec/acceptance/delete_options_spec.rb
+++ b/spec/acceptance/delete_options_spec.rb
@@ -20,6 +20,8 @@ describe "delete options", type: :feature do
     click_on "Delete options"
 
     expect(page).to have_content("Are you sure you want to delete these options?")
+    expect(page).to have_content(option.domain_name)
+    expect(page).to have_content(option.domain_name_servers.join(", "))
 
     expect_config_to_be_verified
     expect_config_to_be_published

--- a/spec/acceptance/delete_reservation_options_spec.rb
+++ b/spec/acceptance/delete_reservation_options_spec.rb
@@ -20,7 +20,7 @@ describe "delete reservation options", type: :feature do
     click_on "Delete"
 
     expect(page).to have_content("Are you sure you want to delete these options?")
-    expect(page).to have_content(reservation_option.routers)
+    expect(page).to have_content(reservation_option.routers.join(", "))
     expect(page).to have_content(reservation_option.domain_name)
 
     expect_config_to_be_verified

--- a/spec/acceptance/delete_reservation_options_spec.rb
+++ b/spec/acceptance/delete_reservation_options_spec.rb
@@ -20,6 +20,8 @@ describe "delete reservation options", type: :feature do
     click_on "Delete"
 
     expect(page).to have_content("Are you sure you want to delete these options?")
+    expect(page).to have_content(reservation_option.routers)
+    expect(page).to have_content(reservation_option.domain_name)
 
     expect_config_to_be_verified
     expect_config_to_be_published

--- a/spec/acceptance/delete_reservations_spec.rb
+++ b/spec/acceptance/delete_reservations_spec.rb
@@ -19,7 +19,9 @@ describe "delete reservations", type: :feature do
 
     click_on "Delete"
 
-    expect(page).to have_content("Are you sure you want to delete this reservation?")
+    expect(page).to have_content("Are you sure you want to delete the below reservation?")
+    expect(page).to have_content(reservation.hostname)
+    expect(page).to have_content(reservation.ip_address)
 
     expect_config_to_be_verified
     expect_config_to_be_published

--- a/spec/acceptance/delete_reservations_spec.rb
+++ b/spec/acceptance/delete_reservations_spec.rb
@@ -19,7 +19,7 @@ describe "delete reservations", type: :feature do
 
     click_on "Delete"
 
-    expect(page).to have_content("Are you sure you want to delete the below reservation?")
+    expect(page).to have_content("Are you sure you want to delete this reservation?")
     expect(page).to have_content(reservation.hostname)
     expect(page).to have_content(reservation.ip_address)
 

--- a/spec/acceptance/delete_sites_spec.rb
+++ b/spec/acceptance/delete_sites_spec.rb
@@ -32,6 +32,8 @@ describe "delete sites", type: :feature do
       click_on "Delete"
 
       expect(page).to have_content("Are you sure you want to delete this site?")
+      expect(page).to have_content(site.name)
+      expect(page).to have_content(site.fits_id)
 
       expect_config_to_be_verified
       expect_config_to_be_published

--- a/spec/acceptance/delete_subnets_spec.rb
+++ b/spec/acceptance/delete_subnets_spec.rb
@@ -19,6 +19,7 @@ describe "delete subnets", type: :feature do
     click_on "Delete"
 
     expect(page).to have_content("Are you sure you want to delete this subnet?")
+    expect(page).to have_content(subnet.cidr_block)
 
     expect_config_to_be_verified
     expect_config_to_be_published

--- a/spec/acceptance/delete_zones_spec.rb
+++ b/spec/acceptance/delete_zones_spec.rb
@@ -15,6 +15,8 @@ describe "delete zones", type: :feature do
     click_on "Delete"
 
     expect(page).to have_content("Are you sure you want to delete this zone?")
+    expect(page).to have_content(zone.name)
+    expect(page).to have_content(zone.forwarders.join(", "))
 
     click_on "Delete zone"
 


### PR DESCRIPTION
# What

Adding a delete preview to all delete screens, to allow the user to double check what is being deleted.

# Why

As an added precaution when deleting from the portal.

# Screenshots
![image](https://user-images.githubusercontent.com/68431297/108527512-43b7a080-72ca-11eb-9a52-980c9673f95a.png)

# Notes
