### PR TITLE
Create static subnet for heatbeat instance

### DIFF
--- a/app/lib/use_cases/generate_kea_config.rb
+++ b/app/lib/use_cases/generate_kea_config.rb
@@ -173,6 +173,15 @@ module UseCases
               ],
               subnet: "127.0.0.1/24",
               id: 1 # This is the subnet used for smoke testing
+            },
+            {
+              pools: [
+                {
+                  pool: "10.180.82.5 - 10.180.82.254"
+                }
+              ],
+              subnet: "10.180.82.0/24",
+              id: 2 # This is the heartbeat subnet
             }
           ],
           loggers: [

--- a/spec/use_cases/generate_kea_config_spec.rb
+++ b/spec/use_cases/generate_kea_config_spec.rb
@@ -2,9 +2,9 @@ require "rails_helper"
 
 describe UseCases::GenerateKeaConfig do
   describe "#call" do
-    it "returns a default subnet used for smoke testing" do
-      config = UseCases::GenerateKeaConfig.new.call
+    let(:config) { UseCases::GenerateKeaConfig.new.call }
 
+    it "generates a subnet for local testing" do
       expect(config.dig(:Dhcp4, :subnet4)).to match_array([
         {
           pools: [
@@ -14,6 +14,15 @@ describe UseCases::GenerateKeaConfig do
           ],
           subnet: "127.0.0.1/24",
           id: 1
+        },
+        {
+          pools: [
+            {
+              pool: "10.180.82.5 - 10.180.82.254"
+            }
+          ],
+          subnet: "10.180.82.0/24",
+          id: 2
         }
       ])
     end
@@ -34,6 +43,15 @@ describe UseCases::GenerateKeaConfig do
           ],
           subnet: "127.0.0.1/24",
           id: 1
+        },
+        {
+          pools: [
+            {
+              pool: "10.180.82.5 - 10.180.82.254"
+            }
+          ],
+          subnet: "10.180.82.0/24",
+          id: 2
         },
         {
           pools: [
@@ -88,6 +106,7 @@ describe UseCases::GenerateKeaConfig do
 
       expect(config.dig(:Dhcp4, :subnet4)).to match_array([
         hash_including(subnet: "127.0.0.1/24", id: 1),
+        hash_including(subnet: "10.180.82.0/24", id: 2),
         hash_including(subnet: "10.0.1.0/24", id: 1001),
         hash_including(subnet: "10.0.2.0/24", id: 1002)
       ])


### PR DESCRIPTION
# What
Create static subnet for heatbeat instance. This will have a known subnet ID of 2.

# Why
This subnet is used to automate checking the
health of the system via a heartbeat EC2 instance.

# Notes
This subnet is not managed through the UI and needs to always be
present.