### PR TITLE
Flush MySQL blocked hosts

### DIFF
--- a/scripts/migrate.sh
+++ b/scripts/migrate.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 source ./scripts/aws_helpers.sh
 
 migrate() {
-  local migration_command="./bin/rails db:migrate"
+  local migration_command="mysqladmin -h$DB_HOST -u$DB_USER -p$DB_PASS flush-hosts && ./bin/rails db:migrate"
   local docker_service_name="admin"
   local cluster_name service_name task_definition docker_service_name
 


### PR DESCRIPTION
When a host makes too many connection errors to MySQL it is blocked.
When AWS recycles these IP addresses, new hosts which are not broken
fail to connect causing a server to 500. The original error which
caused this is now fixed. We will flush the hosts then revert this
change.

We may want to consider turning off this protection given the
security grouos only allow admin containers to speak to the database.
