### PR TITLE
Add reverse lookup zone to BIND config

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -6,3 +6,4 @@ DNS_SERVICE_NAME=some-dns-service
 DNS_CLUSTER_NAME=some-dns-cluster
 PDNS_IPS="1.2.3.4,7.7.7.7"
 KEA_CONTROL_AGENT_URI=http://dhcp-primary:8000/
+PRIVATE_ZONE=dev.internal.vpn.justice.gov.uk

--- a/.env.test
+++ b/.env.test
@@ -6,4 +6,4 @@ DNS_SERVICE_NAME=some-dns-service
 DNS_CLUSTER_NAME=some-dns-cluster
 PDNS_IPS="1.2.3.4,7.7.7.7"
 KEA_CONTROL_AGENT_URI=http://kea.example.com/
-
+PRIVATE_ZONE=test.internal.vpn.justice.gov.uk

--- a/app/controllers/zones_controller.rb
+++ b/app/controllers/zones_controller.rb
@@ -80,7 +80,8 @@ class ZonesController < ApplicationController
   def generate_bind_config
     UseCases::GenerateBindConfig.new(
       zones: Zone.all,
-      pdns_ips: ENV["PDNS_IPS"]
+      pdns_ips: ENV["PDNS_IPS"],
+      private_zone: ENV["PRIVATE_ZONE"]
     )
   end
 

--- a/app/lib/use_cases/generate_bind_config.rb
+++ b/app/lib/use_cases/generate_bind_config.rb
@@ -1,5 +1,5 @@
 class UseCases::GenerateBindConfig
-  def initialize(pdns_ips:, zones: [], private_zone:)
+  def initialize(pdns_ips:, private_zone:, zones: [])
     @zones = zones
     @pdns_ips = parse_pdns_ips(pdns_ips)
     @private_zone = private_zone
@@ -57,7 +57,7 @@ zone "." IN {
   private
 
   attr_reader :zones,
-              :private_zone
+    :private_zone
 
   def parse_pdns_ips(pdns_ips)
     raise "PDNS IPs have not been set" if pdns_ips.blank?

--- a/app/lib/use_cases/generate_bind_config.rb
+++ b/app/lib/use_cases/generate_bind_config.rb
@@ -1,7 +1,8 @@
 class UseCases::GenerateBindConfig
-  def initialize(pdns_ips:, zones: [])
+  def initialize(pdns_ips:, zones: [], private_zone:)
     @zones = zones
     @pdns_ips = parse_pdns_ips(pdns_ips)
+    @private_zone = private_zone
   end
 
   def call
@@ -41,6 +42,7 @@ zone "127.in-addr.arpa" IN {
   allow-update { none; };
   notify no;
 };
+#{render_reverse_lookup_zone}
 #{render_zones}
 zone "." IN {
   type forward;
@@ -54,7 +56,8 @@ zone "." IN {
 
   private
 
-  attr_reader :zones
+  attr_reader :zones,
+              :private_zone
 
   def parse_pdns_ips(pdns_ips)
     raise "PDNS IPs have not been set" if pdns_ips.blank?
@@ -76,5 +79,17 @@ zone "#{zone.name}" IN {
 
   def format_zone_forwarders(forwarders)
     forwarders.join(";") + ";"
+  end
+
+  def render_reverse_lookup_zone
+    raise "No Private Zone has been set" if private_zone.blank?
+
+    %(
+zone "0.0.100.in-addr.arpa" IN {
+  type master;
+  file "/etc/bind/zones/reverse.#{private_zone}";
+  allow-update { none; };
+  notify no;
+};)
   end
 end

--- a/spec/gateways/bind_verifier_spec.rb
+++ b/spec/gateways/bind_verifier_spec.rb
@@ -5,7 +5,7 @@ describe Gateways::BindVerifier do
 
   describe "#verify_config" do
     context "when the config is valid" do
-      let(:generated_config) { UseCases::GenerateBindConfig.new(zones: [], pdns_ips: "7.7.7.7,5.5.5.5").call }
+      let(:generated_config) { UseCases::GenerateBindConfig.new(zones: [], pdns_ips: "7.7.7.7,5.5.5.5", private_zone: "some.zone").call }
 
       it "returns successfully" do
         expect(subject.verify_config(generated_config)).to eq(true)

--- a/spec/use_cases/generate_bind_config_spec.rb
+++ b/spec/use_cases/generate_bind_config_spec.rb
@@ -105,7 +105,7 @@ zone "example2.test.com" IN {
 
     it "contains a path to a reverse lookup dns zone file" do
       expect(generated_config).to include(
-%(zone "0.0.100.in-addr.arpa" IN {
+        %(zone "0.0.100.in-addr.arpa" IN {
   type master;
   file "/etc/bind/zones/reverse.#{private_zone}";
   allow-update { none; };

--- a/spec/use_cases/generate_bind_config_spec.rb
+++ b/spec/use_cases/generate_bind_config_spec.rb
@@ -1,7 +1,8 @@
 require "rails_helper"
 
 describe UseCases::GenerateBindConfig do
-  let(:generated_config) { UseCases::GenerateBindConfig.new(zones: all_zones, pdns_ips: "7.7.7.7,5.5.5.5").call }
+  let(:private_zone) { "some.internal.zone" }
+  let(:generated_config) { UseCases::GenerateBindConfig.new(zones: all_zones, pdns_ips: "7.7.7.7,5.5.5.5", private_zone: private_zone).call }
 
   describe "#call" do
     let(:all_zones) { [] }
@@ -40,6 +41,13 @@ zone "localhost" IN {
 zone "127.in-addr.arpa" IN {
   type master;
   file "pri/127.zone";
+  allow-update { none; };
+  notify no;
+};
+
+zone "0.0.100.in-addr.arpa" IN {
+  type master;
+  file "/etc/bind/zones/reverse.#{private_zone}";
   allow-update { none; };
   notify no;
 };
@@ -84,10 +92,26 @@ zone "example2.test.com" IN {
   end
 
   describe "Unset pdns ips" do
-    let(:generated_config) { UseCases::GenerateBindConfig.new(pdns_ips: "").call }
+    let(:generated_config) { UseCases::GenerateBindConfig.new(pdns_ips: "", private_zone: private_zone).call }
 
     it "raises an error when PDNS IPs have not been defined" do
       expect { generated_config }.to raise_error("PDNS IPs have not been set")
+    end
+  end
+
+  describe "reverse lookup zones" do
+    let(:private_zone) { "my.made.up.zone" }
+    let(:generated_config) { described_class.new(pdns_ips: "1.1.1.1", private_zone: private_zone).call }
+
+    it "contains a path to a reverse lookup dns zone file" do
+      expect(generated_config).to include(
+%(zone "0.0.100.in-addr.arpa" IN {
+  type master;
+  file "/etc/bind/zones/reverse.#{private_zone}";
+  allow-update { none; };
+  notify no;
+};)
+      )
     end
   end
 end


### PR DESCRIPTION
# What

Add a reverse lookup zone to the DNS config which adds paths to the correct zone file for each environment

# Why

We need reverse lookups for Global Protect

# Notes

Zone files are stored statically on the DNS server container
