### PR TITLE
Extending a network

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -51,8 +51,8 @@ class ApplicationController < ActionController::Base
   def generate_kea_config
     UseCases::GenerateKeaConfig.new(
       subnets: Subnet.includes(
-        :site,
         :option,
+        shared_network: [:site],
         reservations: [:reservation_option]
       ).all,
       global_option: GlobalOption.first,

--- a/app/controllers/subnet_extensions_controller.rb
+++ b/app/controllers/subnet_extensions_controller.rb
@@ -1,0 +1,35 @@
+class SubnetExtensionsController < ApplicationController
+  before_action :set_subnet, only: [:new, :create]
+
+  def new
+    @extension = @subnet.shared_network.subnets.build
+    authorize! :create, @extension
+    @global_option = GlobalOption.first
+  end
+
+  def create
+    @extension = @subnet.shared_network.subnets.build(extension_params)
+    authorize! :create, @extension
+
+    if update_dhcp_config.call(@extension, -> { @extension.save })
+      redirect_to @extension, notice: "Successfully extended subnet." + CONFIG_UPDATE_DELAY_NOTICE
+    else
+      @global_option = GlobalOption.first
+      render :new
+    end
+  end
+
+  private
+
+  def set_subnet
+    @subnet = Subnet.find(subnet_id)
+  end
+
+  def subnet_id
+    params.fetch(:subnet_id)
+  end
+
+  def extension_params
+    params.require(:subnet).permit(:cidr_block, :start_address, :end_address, :routers)
+  end
+end

--- a/app/controllers/subnets_controller.rb
+++ b/app/controllers/subnets_controller.rb
@@ -1,6 +1,6 @@
 class SubnetsController < ApplicationController
   before_action :set_site, only: [:new, :create]
-  before_action :set_subnet, only: [:show, :edit, :update, :destroy]
+  before_action :set_subnet, only: [:show, :edit, :update, :destroy, :extend]
 
   def new
     @subnet = @site.subnets.build
@@ -9,7 +9,9 @@ class SubnetsController < ApplicationController
   end
 
   def create
-    @subnet = @site.subnets.build(subnet_params)
+    @subnet = Subnet.new(subnet_params)
+    @subnet.shared_network = SharedNetwork.new(site: @site)
+
     authorize! :create, @subnet
 
     if update_dhcp_config.call(@subnet, -> { @subnet.save })

--- a/app/lib/use_cases/generate_kea_config.rb
+++ b/app/lib/use_cases/generate_kea_config.rb
@@ -160,14 +160,14 @@ module UseCases
 
     def subnet_option_client_classes
       @subnet_option_client_classes ||= begin
-        option_client_classes = @subnets.filter_map { |subnet|
+        option_client_classes = @subnets.filter_map do |subnet|
           options_config = UseCases::KeaConfig::GenerateOptionDataConfig.new.call(subnet)
           {
             name: subnet.client_class_name,
             test: "member('ALL')",
             "only-if-required": true
           }.merge(options_config)
-        }
+        end
 
         option_client_classes
       end

--- a/app/models/shared_network.rb
+++ b/app/models/shared_network.rb
@@ -1,0 +1,4 @@
+class SharedNetwork < ApplicationRecord
+  has_many :subnets, dependent: :destroy
+  belongs_to :site
+end

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -1,5 +1,7 @@
 class Site < ApplicationRecord
-  has_many :subnets, dependent: :destroy
+
+  has_many :shared_networks, dependent: :destroy
+  has_many :subnets, through: :shared_networks
 
   validates :fits_id, presence: true, uniqueness: {case_sensitive: false}
   validates :name, presence: true, uniqueness: {case_sensitive: false}

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -1,5 +1,4 @@
 class Site < ApplicationRecord
-
   has_many :shared_networks, dependent: :destroy
   has_many :subnets, through: :shared_networks
 

--- a/app/models/subnet.rb
+++ b/app/models/subnet.rb
@@ -70,6 +70,10 @@ class Subnet < ApplicationRecord
     "#{CLIENT_CLASS_NAME_PREFIX}-#{ip_addr}-client"
   end
 
+  def subnets_in_same_shared_network
+    shared_network.subnets - [self]
+  end
+
   private
 
   def cidr_block_is_a_valid_ipv4_subnet

--- a/app/models/subnet.rb
+++ b/app/models/subnet.rb
@@ -3,7 +3,7 @@ class Subnet < ApplicationRecord
   CLIENT_CLASS_NAME_PREFIX = "subnet"
   INVALID_IPV4_LIST_MESSAGE = "contains an invalid IPv4 address or is not separated using commas"
 
-  belongs_to :site
+  belongs_to :shared_network
   has_one :option, dependent: :destroy
   has_many :reservations, dependent: :destroy
   has_many :exclusions, dependent: :destroy
@@ -27,6 +27,10 @@ class Subnet < ApplicationRecord
     :valid_lifetime,
     :valid_lifetime_unit,
     to: :option,
+    allow_nil: true
+
+  delegate :site,
+    to: :shared_network,
     allow_nil: true
 
   def routers

--- a/app/views/subnet_extensions/new.html.erb
+++ b/app/views/subnet_extensions/new.html.erb
@@ -1,13 +1,13 @@
-<%= render "layouts/form_errors", resource: @subnet %>
+<%= render "layouts/form_errors", resource: @extension %>
 
-<h2 class="govuk-heading-l">Create a new subnet</h2>
+<h2 class="govuk-heading-l">Extending a subnet</h2>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with(model: @subnet, url: site_subnets_path(@site), local: true) do |form| %>
+    <%= form_with(model: @extension, url: subnet_extensions_path(@subnet), local: true) do |form| %>
       <%= render "subnets/form", f: form %>
 
-      <%= link_to "Cancel", site_path(@site),
+      <%= link_to "Cancel", subnet_path(@subnet),
         class: "govuk-button govuk-button--secondary",
         data: {
           module: "govuk-button"

--- a/app/views/subnets/_form.html.erb
+++ b/app/views/subnets/_form.html.erb
@@ -1,46 +1,36 @@
- <%= form_with(model: (subnet.new_record? ? [subnet.site, subnet] : subnet), local: true) do |f| %>
-  <div class="govuk-form-group <%= field_error(f.object, :cidr_block )%>">
-    <%= f.label :cidr_block, class: "govuk-label" %>
-    <div id="cidr_block-hint" class="govuk-hint">
-      Must be in the form: 127.0.0.0/24
-    </div>
-    <%= f.text_field :cidr_block, class: "govuk-input" %>
+<div class="govuk-form-group <%= field_error(f.object, :cidr_block )%>">
+  <%= f.label :cidr_block, class: "govuk-label" %>
+  <div id="cidr_block-hint" class="govuk-hint">
+    Must be in the form: 127.0.0.0/24
   </div>
+  <%= f.text_field :cidr_block, class: "govuk-input" %>
+</div>
 
-  <div class="govuk-form-group <%= field_error(f.object, :start_address) %>">
-    <%= f.label :start_address, class: "govuk-label" %>
-    <div id="start_address-hint" class="govuk-hint">
-      Must be in the form: 127.0.0.1
-    </div>
-    <%= f.text_field :start_address, class: "govuk-input" %>
+<div class="govuk-form-group <%= field_error(f.object, :start_address) %>">
+  <%= f.label :start_address, class: "govuk-label" %>
+  <div id="start_address-hint" class="govuk-hint">
+    Must be in the form: 127.0.0.1
   </div>
+  <%= f.text_field :start_address, class: "govuk-input" %>
+</div>
 
-  <div class="govuk-form-group <%= field_error(f.object, :end_address) %>">
-    <%= f.label :end_address, class: "govuk-label" %>
-    <div id="end_address-hint" class="govuk-hint">
-      Must be in the form: 127.0.0.1
-    </div>
-    <%= f.text_field :end_address, class: "govuk-input" %>
+<div class="govuk-form-group <%= field_error(f.object, :end_address) %>">
+  <%= f.label :end_address, class: "govuk-label" %>
+  <div id="end_address-hint" class="govuk-hint">
+    Must be in the form: 127.0.0.1
   </div>
+  <%= f.text_field :end_address, class: "govuk-input" %>
+</div>
 
-  <div class="govuk-form-group <%= field_error(f.object, :routers )%>">
-    <%= f.label :routers, class: "govuk-label" %>
-    <div id="options_routers-hint" class="govuk-hint">
-      Must be in the form: 127.0.0.1,127.0.0.2
-    </div>
-    <%= f.text_area :routers, value: f.object.routers.join(","), class: "govuk-input" %>
+<div class="govuk-form-group <%= field_error(f.object, :routers )%>">
+  <%= f.label :routers, class: "govuk-label" %>
+  <div id="options_routers-hint" class="govuk-hint">
+    Must be in the form: 127.0.0.1,127.0.0.2
   </div>
+  <%= f.text_area :routers, value: f.object.routers.join(","), class: "govuk-input" %>
+</div>
 
-  <%= f.submit f.object.new_record? ? "Create" : "Update", {
-    class: "govuk-button",
-    "data-module" => "govuk-button"
-  } %>
-
-  <%= link_to "Cancel", f.object.new_record? ? site_path(subnet.site) : subnet,
-  class: "govuk-button govuk-button--secondary",
-  data: {
-    module: "govuk-button"
-  }
-%>
-
-<% end %>
+<%= f.submit f.object.new_record? ? "Create" : "Update", {
+  class: "govuk-button",
+  "data-module" => "govuk-button"
+} %>

--- a/app/views/subnets/destroy.html.erb
+++ b/app/views/subnets/destroy.html.erb
@@ -32,7 +32,7 @@
     class: 'govuk-!-display-inline-block'
   }
 %>
-<%= link_to "Cancel", site_path(@subnet.site_id),
+<%= link_to "Cancel", site_path(@subnet.site),
   class: "govuk-button govuk-button--secondary",
   data: {
     module: "govuk-button"

--- a/app/views/subnets/edit.html.erb
+++ b/app/views/subnets/edit.html.erb
@@ -4,7 +4,16 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= render "subnets/form", subnet: @subnet %>
+    <%= form_with(model: @subnet, url: subnet_path(@subnet), local: true) do |form| %>
+      <%= render "subnets/form", f: form %>
+
+      <%= link_to "Cancel", subnet_path(@subnet),
+        class: "govuk-button govuk-button--secondary",
+        data: {
+          module: "govuk-button"
+        }
+      %>
+    <% end %>
   </div>
 
   <div class="govuk-grid-column-one-third">

--- a/app/views/subnets/show.html.erb
+++ b/app/views/subnets/show.html.erb
@@ -44,6 +44,7 @@
 
 <%= link_to "View leases", subnet_leases_path(@subnet), class: "govuk-button govuk-button--secondary" %>
 
+<!--
 <h3 class="govuk-heading-m">Exclusion</h3>
 
 <% if @subnet.exclusions.any? %>
@@ -55,6 +56,9 @@
 <% if @subnet.exclusions.any? %>
   <%= render "exclusions/details", exclusion: @subnet.exclusions.first %>
 <% end %>
+-->
+
+<%= link_to "Extend this network with another subnet", new_subnet_extension_path(@subnet), class: "govuk-button" if can?(:update, @subnet) %>
 
 <h3 class="govuk-heading-m">Options</h3>
 <% if @subnet.option %>

--- a/app/views/subnets/show.html.erb
+++ b/app/views/subnets/show.html.erb
@@ -58,7 +58,12 @@
 <% end %>
 -->
 
+<h3 class="govuk-heading-m">Other subnets in the same shared network</h3>
+<%= render "subnets/list", subnets: @subnet.subnets_in_same_shared_network %>
 <%= link_to "Extend this network with another subnet", new_subnet_extension_path(@subnet), class: "govuk-button" if can?(:update, @subnet) %>
+
+<h3 class="govuk-heading-m">Leases</h3>
+<%= link_to "View leases", subnet_leases_path(@subnet), class: "govuk-button govuk-button--secondary" %>
 
 <h3 class="govuk-heading-m">Options</h3>
 <% if @subnet.option %>

--- a/app/views/subnets/show.html.erb
+++ b/app/views/subnets/show.html.erb
@@ -42,8 +42,6 @@
   </div>
 </dl>
 
-<%= link_to "View leases", subnet_leases_path(@subnet), class: "govuk-button govuk-button--secondary" %>
-
 <!--
 <h3 class="govuk-heading-m">Exclusion</h3>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,11 +13,14 @@ Rails.application.routes.draw do
   resources :sites, except: [:index] do
     resources :subnets, only: [:new, :create]
   end
+
   resources :subnets, only: [:show, :edit, :update, :destroy] do
     resources :exclusions, only: [:new, :create]
     resource :options, only: [:new, :create, :edit, :update, :destroy]
     resource :reservations, only: [:new, :create]
     resources :leases, only: [:index]
+
+    resources :extensions, only: [:new, :create], controller: :subnet_extensions
   end
   resources :reservations, only: [:show, :edit, :update, :destroy] do
     resource :reservation_options, only: [:new, :create], path: "/options"

--- a/db/migrate/20210615125149_create_shared_network.rb
+++ b/db/migrate/20210615125149_create_shared_network.rb
@@ -1,0 +1,17 @@
+class CreateSharedNetwork < ActiveRecord::Migration[6.1]
+  def change
+    create_table :shared_networks do |t|
+      t.timestamps
+    end
+
+    add_reference :shared_networks, :site, index: true, foreign_key: true
+    add_reference :subnets, :shared_network, index: true, foreign_key: true
+
+    Subnet.find_each do |subnet|
+      shared_network = SharedNetwork.create!(site_id: subnet.site_id, name: "some name or other")
+      subnet.update!(shared_network_id: shared_network.id)
+    end
+
+    remove_reference :subnets, :site, index: true, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,6 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema.define(version: 2021_06_15_125149) do
-
   create_table "audits", charset: "latin1", force: :cascade do |t|
     t.integer "auditable_id"
     t.string "auditable_type"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,8 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_11_141023) do
+ActiveRecord::Schema.define(version: 2021_06_15_125149) do
+
   create_table "audits", charset: "latin1", force: :cascade do |t|
     t.integer "auditable_id"
     t.string "auditable_type"
@@ -93,6 +94,13 @@ ActiveRecord::Schema.define(version: 2021_06_11_141023) do
     t.index ["subnet_id"], name: "index_reservations_on_subnet_id"
   end
 
+  create_table "shared_networks", charset: "latin1", force: :cascade do |t|
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.bigint "site_id"
+    t.index ["site_id"], name: "index_shared_networks_on_site_id"
+  end
+
   create_table "sites", charset: "latin1", force: :cascade do |t|
     t.string "name", null: false
     t.string "fits_id", null: false
@@ -106,9 +114,9 @@ ActiveRecord::Schema.define(version: 2021_06_11_141023) do
     t.string "end_address", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.bigint "site_id", null: false
     t.string "routers", null: false
-    t.index ["site_id"], name: "index_subnets_on_site_id"
+    t.bigint "shared_network_id"
+    t.index ["shared_network_id"], name: "index_subnets_on_shared_network_id"
   end
 
   create_table "users", charset: "latin1", force: :cascade do |t|
@@ -132,5 +140,6 @@ ActiveRecord::Schema.define(version: 2021_06_11_141023) do
   add_foreign_key "options", "subnets"
   add_foreign_key "reservation_options", "reservations"
   add_foreign_key "reservations", "subnets"
-  add_foreign_key "subnets", "sites"
+  add_foreign_key "shared_networks", "sites"
+  add_foreign_key "subnets", "shared_networks"
 end

--- a/spec/acceptance/create_reservations_spec.rb
+++ b/spec/acceptance/create_reservations_spec.rb
@@ -46,7 +46,7 @@ describe "create reservations", type: :feature do
       expect(page).to have_content(reservation.subnet.start_address + " to " + reservation.subnet.end_address)
 
       fill_in "HW address", with: "01:bb:cc:dd:ee:fe"
-      fill_in "IP address", with: "192.0.2.2"
+      fill_in "IP address", with: reservation.subnet.end_address
       fill_in "Hostname", with: "test.example2.com"
       fill_in "Description", with: "Test reservation"
 
@@ -58,7 +58,7 @@ describe "create reservations", type: :feature do
       expect(page).to have_content("Successfully created reservation")
       expect(page).to have_content("This could take up to 10 minutes to apply.")
       expect(page).to have_content("01:bb:cc:dd:ee:fe")
-      expect(page).to have_content("192.0.2.2")
+      expect(page).to have_content(reservation.subnet.end_address)
       expect(page).to have_content("test.example2.com")
       expect(page).to have_content("Test reservation")
 

--- a/spec/acceptance/create_subnet_extension_spec.rb
+++ b/spec/acceptance/create_subnet_extension_spec.rb
@@ -1,0 +1,49 @@
+require "rails_helper"
+
+describe "creating a subnet extension", type: :feature do
+  let(:editor) { create(:user, :editor) }
+
+  before do
+    login_as editor
+  end
+
+  it "creates a new subnet in a shared network" do
+    subnet = Audited.audit_class.as_user(editor) { create :subnet }
+    visit "/subnets/#{subnet.to_param}"
+
+    click_on "Extend this network with another subnet"
+
+    fill_in "CIDR block", with: "10.0.1.0/24"
+    fill_in "Start address", with: "10.0.1.1"
+    fill_in "End address", with: "10.0.1.255"
+    fill_in "Routers", with: "10.0.1.0,10.0.1.2"
+
+    expect_config_to_be_verified
+    expect_config_to_be_published
+
+    click_button "Create"
+
+    expect(page).to have_content("10.0.1.0/24")
+    expect(page).to have_content("10.0.1.1")
+    expect(page).to have_content("10.0.1.255")
+    expect(page).to have_content("10.0.1.0, 10.0.1.2")
+
+    expect_audit_log_entry_for(editor.email, "create", "Subnet")
+  end
+
+  it "displays error if form cannot be submitted" do
+    subnet = create :subnet
+    visit "/subnets/#{subnet.to_param}"
+
+    click_on "Extend this network with another subnet"
+
+    fill_in "CIDR block", with: "a"
+    fill_in "Start address", with: "b"
+    fill_in "End address", with: "c"
+    fill_in "Routers", with: "d"
+
+    click_button "Create"
+
+    expect(page).to have_content "There is a problem"
+  end
+end

--- a/spec/acceptance/show_site_spec.rb
+++ b/spec/acceptance/show_site_spec.rb
@@ -16,8 +16,9 @@ describe "showing a site", type: :feature do
 
     context "when the site exists" do
       let!(:site) { create :site }
-      let!(:subnet) { create :subnet, index: 1, site: site }
-      let!(:subnet2) { create :subnet, index: 2, site: site }
+      let!(:shared_network) { create :shared_network, site: site }
+      let!(:subnet) { create :subnet, index: 1, shared_network: shared_network }
+      let!(:subnet2) { create :subnet, index: 2, shared_network: shared_network }
       let!(:subnet3) { create :subnet, index: 3 }
 
       it "allows viewing sites and its subnets" do

--- a/spec/acceptance/show_subnet_spec.rb
+++ b/spec/acceptance/show_subnet_spec.rb
@@ -18,7 +18,7 @@ describe "showing a subnet", type: :feature do
       let(:subnet) { create :subnet }
       let(:site) { subnet.site }
 
-      it "allows viewing subnets and its subnets" do
+      it "allows viewing subnets" do
         visit "/sites/#{site.to_param}"
 
         click_on "View"
@@ -26,6 +26,15 @@ describe "showing a subnet", type: :feature do
         expect(page).to have_content subnet.cidr_block
         expect(page).to have_content subnet.start_address
         expect(page).to have_content subnet.end_address
+      end
+
+      it "allows viewing other subnets in the same shared network" do
+        other_subnet = create(:subnet, shared_network: subnet.shared_network)
+        visit "/subnets/#{subnet.to_param}"
+
+        expect(page).to have_content other_subnet.cidr_block
+        expect(page).to have_content other_subnet.start_address
+        expect(page).to have_content other_subnet.end_address
       end
     end
   end

--- a/spec/acceptance/update_reservations_spec.rb
+++ b/spec/acceptance/update_reservations_spec.rb
@@ -51,7 +51,7 @@ describe "update reservations", type: :feature do
       expect(page).to have_field("Description", with: reservation.description)
 
       fill_in "HW address", with: "1a:1b:1c:1d:1e:1f"
-      fill_in "IP address", with: "192.0.2.3"
+      fill_in "IP address", with: reservation.subnet.end_address
       fill_in "Hostname", with: "testier.example.com"
       fill_in "Description", with: "Changed test reservation"
 
@@ -63,7 +63,7 @@ describe "update reservations", type: :feature do
       expect(page).to have_content("Successfully updated reservation")
       expect(page).to have_content("This could take up to 10 minutes to apply.")
       expect(page).to have_content("1a:1b:1c:1d:1e:1f")
-      expect(page).to have_content("192.0.2.3")
+      expect(page).to have_content(reservation.subnet.end_address)
       expect(page).to have_content("testier.example.com")
       expect(page).to have_content("Changed test reservation")
 

--- a/spec/controllers/sites_controller_spec.rb
+++ b/spec/controllers/sites_controller_spec.rb
@@ -24,10 +24,10 @@ describe SitesController, type: :controller do
 
     it "returns subnets ordered by cidr_block" do
       subnet1 = create :subnet, start_address: "10.1.12.1", end_address: "10.1.12.100", cidr_block: "10.1.12.0/24"
-      subnet2 = create :subnet, start_address: "10.1.3.1", end_address: "10.1.3.100", cidr_block: "10.1.3.0/24", site: subnet1.site
-      subnet3 = create :subnet, start_address: "10.1.10.1", end_address: "10.1.10.100", cidr_block: "10.1.10.0/24", site: subnet1.site
+      subnet2 = create :subnet, start_address: "10.1.3.1", end_address: "10.1.3.100", cidr_block: "10.1.3.0/24", shared_network: subnet1.shared_network
+      subnet3 = create :subnet, start_address: "10.1.10.1", end_address: "10.1.10.100", cidr_block: "10.1.10.0/24", shared_network: subnet1.shared_network
 
-      get :show, params: {id: subnet1.site_id}
+      get :show, params: { id: subnet1.site.id }
 
       expect(assigns(:subnets)).to eq [subnet2, subnet3, subnet1]
     end

--- a/spec/controllers/sites_controller_spec.rb
+++ b/spec/controllers/sites_controller_spec.rb
@@ -27,7 +27,7 @@ describe SitesController, type: :controller do
       subnet2 = create :subnet, start_address: "10.1.3.1", end_address: "10.1.3.100", cidr_block: "10.1.3.0/24", shared_network: subnet1.shared_network
       subnet3 = create :subnet, start_address: "10.1.10.1", end_address: "10.1.10.100", cidr_block: "10.1.10.0/24", shared_network: subnet1.shared_network
 
-      get :show, params: { id: subnet1.site.id }
+      get :show, params: {id: subnet1.site.id}
 
       expect(assigns(:subnets)).to eq [subnet2, subnet3, subnet1]
     end

--- a/spec/factories/reservations.rb
+++ b/spec/factories/reservations.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :reservation do
-    subnet factory: :subnet, start_address: "192.0.2.1", end_address: "192.0.2.255", cidr_block: "192.0.2.1/24"
+    subnet
     hw_address { "01:bb:cc:dd:ee:ff" }
     ip_address { subnet.start_address }
     hostname { "test.example.com" }

--- a/spec/factories/shared_network.rb
+++ b/spec/factories/shared_network.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :shared_network do
+    site
+  end
+end

--- a/spec/factories/sites.rb
+++ b/spec/factories/sites.rb
@@ -5,7 +5,8 @@ FactoryBot.define do
 
     trait :with_subnet do
       after :create do |site|
-        create(:subnet, site: site)
+        shared_network = create(:shared_network, site: site)
+        create(:subnet, shared_network: shared_network)
       end
     end
   end

--- a/spec/factories/subnets.rb
+++ b/spec/factories/subnets.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :subnet do
     transient do
-      index { 0 }
+      sequence(:index) { |n| n }
     end
 
     cidr_block { "10.#{index}.4.0/24" }

--- a/spec/factories/subnets.rb
+++ b/spec/factories/subnets.rb
@@ -9,7 +9,7 @@ FactoryBot.define do
     end_address { "10.#{index}.4.255" }
     routers { "10.#{index}.4.0,10.#{index}.4.2" }
 
-    site
+    shared_network
 
     trait :with_reservation do
       after :create do |subnet|

--- a/spec/models/reservation_spec.rb
+++ b/spec/models/reservation_spec.rb
@@ -25,11 +25,6 @@ RSpec.describe Reservation, type: :model do
     it { should_not allow_value("01:BB:cc:DD:EE:ff:XX:XX").for(:hw_address) }
   end
 
-  it "validates a correct ip address" do
-    reservation = build :reservation, ip_address: "10.0.4.1", subnet: build(:subnet, cidr_block: "10.0.4.0/24")
-    expect(reservation).to be_valid
-  end
-
   it "validates an incorrect ip address" do
     reservation = build :reservation, ip_address: "10.0.4"
     expect(reservation).not_to be_valid
@@ -37,14 +32,14 @@ RSpec.describe Reservation, type: :model do
   end
 
   it "is valid if the ip_address is within the subnet CIDR block" do
-    subnet = create(:subnet, cidr_block: "10.0.4.0/24")
-    reservation = build :reservation, subnet: subnet, ip_address: "10.0.4.20"
+    subnet = build(:subnet)
+    reservation = build :reservation, ip_address: subnet.start_address, subnet: subnet
     expect(reservation).to be_valid
   end
 
   it "is invalid if the ip_address is not within the subnet CIDR block" do
-    subnet = create(:subnet, cidr_block: "10.0.4.0/24")
-    reservation = build :reservation, subnet: subnet, ip_address: "10.0.10.20"
+    subnet = build(:subnet)
+    reservation = build :reservation, subnet: subnet, ip_address: "192.0.10.20"
     expect(reservation).to_not be_valid
     expect(reservation.errors[:ip_address]).to eq(["is not within the subnet range"])
   end

--- a/spec/models/subnet_spec.rb
+++ b/spec/models/subnet_spec.rb
@@ -13,8 +13,8 @@ RSpec.describe Subnet, type: :model do
   it { is_expected.to validate_presence_of :end_address }
   it { is_expected.to validate_presence_of :routers }
 
-  it "validates a correct CIDR block" do
-    subnet = build :subnet, cidr_block: "10.0.4.0/24"
+  it "is valid by default" do
+    subnet = build :subnet
     expect(subnet).to be_valid
   end
 
@@ -24,20 +24,10 @@ RSpec.describe Subnet, type: :model do
     expect(subnet.errors[:cidr_block]).to eq(["is not a valid IPv4 subnet"])
   end
 
-  it "validates a correct start address" do
-    subnet = build :subnet, start_address: "10.0.4.1"
-    expect(subnet).to be_valid
-  end
-
   it "validates an incorrect start address" do
     subnet = build :subnet, start_address: "10.0.4"
     expect(subnet).not_to be_valid
     expect(subnet.errors[:start_address]).to eq(["is not a valid IPv4 address"])
-  end
-
-  it "validates a correct end address" do
-    subnet = build :subnet, end_address: "10.0.4.1"
-    expect(subnet).to be_valid
   end
 
   it "validates an incorrect end address" do
@@ -53,16 +43,16 @@ RSpec.describe Subnet, type: :model do
   end
 
   it "validates cidr_block is unique by the address" do
-    create :subnet, cidr_block: "10.0.4.0/24"
-    subnet = build :subnet, cidr_block: "10.0.4.0/20"
+    existing_subnet = create :subnet
+    subnet = build :subnet, cidr_block: existing_subnet.cidr_block.gsub('/24', '/20')
 
     expect(subnet).not_to be_valid
     expect(subnet.errors[:cidr_block]).to eq(["matches a subnet with the same address"])
   end
 
   it "does not append the subnet address validation when the cidr_block matches exactly" do
-    create :subnet, cidr_block: "10.0.4.0/24"
-    subnet = build :subnet, cidr_block: "10.0.4.0/24"
+    existing_subnet = create :subnet
+    subnet = build :subnet, cidr_block: existing_subnet.cidr_block
 
     expect(subnet).not_to be_valid
     expect(subnet.errors[:cidr_block]).to_not include "matches a subnet with the same address"

--- a/spec/models/subnet_spec.rb
+++ b/spec/models/subnet_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe Subnet, type: :model do
 
   it "validates cidr_block is unique by the address" do
     existing_subnet = create :subnet
-    subnet = build :subnet, cidr_block: existing_subnet.cidr_block.gsub('/24', '/20')
+    subnet = build :subnet, cidr_block: existing_subnet.cidr_block.gsub("/24", "/20")
 
     expect(subnet).not_to be_valid
     expect(subnet.errors[:cidr_block]).to eq(["matches a subnet with the same address"])

--- a/spec/use_cases/generate_kea_config_spec.rb
+++ b/spec/use_cases/generate_kea_config_spec.rb
@@ -20,8 +20,9 @@ describe UseCases::GenerateKeaConfig do
 
     it "appends subnets to the subnet4 list" do
       site = build_stubbed(:site, fits_id: "FITSID01", name: "SITENAME01")
-      subnet1 = build_stubbed(:subnet, cidr_block: "10.0.1.0/24", start_address: "10.0.1.1", end_address: "10.0.1.255", routers: "10.0.1.2,10.0.1.3", site: site)
-      subnet2 = build_stubbed(:subnet, cidr_block: "10.0.2.0/24", start_address: "10.0.2.1", end_address: "10.0.2.255", routers: "10.0.2.2,10.0.2.3", site: site)
+      shared_network = build_stubbed(:shared_network, site: site)
+      subnet1 = build_stubbed(:subnet, cidr_block: "10.0.1.0/24", start_address: "10.0.1.1", end_address: "10.0.1.255", routers: "10.0.1.2,10.0.1.3", shared_network: shared_network)
+      subnet2 = build_stubbed(:subnet, cidr_block: "10.0.2.0/24", start_address: "10.0.2.1", end_address: "10.0.2.255", routers: "10.0.2.2,10.0.2.3", shared_network: shared_network)
 
       config = UseCases::GenerateKeaConfig.new(subnets: [subnet1, subnet2]).call
 
@@ -72,9 +73,10 @@ describe UseCases::GenerateKeaConfig do
 
     it "appends subnets to the subnet4 list with an exclusion" do
       site = build_stubbed(:site, fits_id: "FITSID01", name: "SITENAME01")
+      shared_network = build_stubbed(:shared_network, site: site)
       exclusion = build_stubbed(:exclusion, start_address: "10.0.1.90", end_address: "10.0.1.100")
       subnet1 = build_stubbed(:subnet, cidr_block: "10.0.1.0/24", start_address: "10.0.1.1",
-                                       end_address: "10.0.1.255", exclusions: [exclusion], routers: "10.0.1.2,10.0.1.3", site: site)
+                                       end_address: "10.0.1.255", exclusions: [exclusion], routers: "10.0.1.2,10.0.1.3", shared_network: shared_network)
 
       config = UseCases::GenerateKeaConfig.new(subnets: [subnet1]).call
 
@@ -112,9 +114,10 @@ describe UseCases::GenerateKeaConfig do
 
     it "appends subnets to the subnet4 list with another exclusion" do
       site = build_stubbed(:site, fits_id: "FITSID01", name: "SITENAME01")
+      shared_network = build_stubbed(:shared_network, site: site)
       exclusion = build_stubbed(:exclusion, start_address: "10.0.1.50", end_address: "10.0.1.60")
       subnet1 = build_stubbed(:subnet, cidr_block: "10.0.1.0/24", start_address: "10.0.1.1",
-                                       end_address: "10.0.1.255", exclusions: [exclusion], routers: "10.0.1.2,10.0.1.3", site: site)
+                                       end_address: "10.0.1.255", exclusions: [exclusion], routers: "10.0.1.2,10.0.1.3", shared_network: shared_network)
 
       config = UseCases::GenerateKeaConfig.new(subnets: [subnet1]).call
 
@@ -152,9 +155,10 @@ describe UseCases::GenerateKeaConfig do
 
     it "appends subnets to the subnet4 list with yet another exclusion" do
       site = build_stubbed(:site, fits_id: "FITSID01", name: "SITENAME01")
+      shared_network = build_stubbed(:shared_network, site: site)
       exclusion = build_stubbed(:exclusion, start_address: "10.0.1.150", end_address: "10.0.1.170")
       subnet1 = build_stubbed(:subnet, cidr_block: "10.0.1.0/24", start_address: "10.0.1.1",
-                                       end_address: "10.0.1.255", exclusions: [exclusion], routers: "10.0.1.2,10.0.1.3", site: site)
+                                       end_address: "10.0.1.255", exclusions: [exclusion], routers: "10.0.1.2,10.0.1.3", shared_network: shared_network)
 
       config = UseCases::GenerateKeaConfig.new(subnets: [subnet1]).call
 
@@ -192,9 +196,10 @@ describe UseCases::GenerateKeaConfig do
 
     it "appends another subnet to the subnet4 list with an exclusion" do
       site = build_stubbed(:site, fits_id: "FITSID01", name: "SITENAME01")
+      shared_network = build_stubbed(:shared_network, site: site)
       exclusion = build_stubbed(:exclusion, start_address: "10.0.2.150", end_address: "10.0.2.170")
       subnet1 = build_stubbed(:subnet, cidr_block: "10.0.2.0/24", start_address: "10.0.2.1",
-                                       end_address: "10.0.2.255", exclusions: [exclusion], routers: "10.0.2.2,10.0.2.3", site: site)
+                                       end_address: "10.0.2.255", exclusions: [exclusion], routers: "10.0.2.2,10.0.2.3", shared_network: shared_network)
 
       config = UseCases::GenerateKeaConfig.new(subnets: [subnet1]).call
 
@@ -232,9 +237,10 @@ describe UseCases::GenerateKeaConfig do
 
     it "appends a subnet to the subnet4 list with an exclusion at the start" do
       site = build_stubbed(:site, fits_id: "FITSID01", name: "SITENAME01")
+      shared_network = build_stubbed(:shared_network, site: site)
       exclusion = build_stubbed(:exclusion, start_address: "10.0.2.1", end_address: "10.0.2.170")
       subnet1 = build_stubbed(:subnet, cidr_block: "10.0.2.0/24", start_address: "10.0.2.1",
-                                       end_address: "10.0.2.255", exclusions: [exclusion], routers: "10.0.2.2,10.0.2.3", site: site)
+                                       end_address: "10.0.2.255", exclusions: [exclusion], routers: "10.0.2.2,10.0.2.3", shared_network: shared_network)
 
       config = UseCases::GenerateKeaConfig.new(subnets: [subnet1]).call
 
@@ -269,9 +275,10 @@ describe UseCases::GenerateKeaConfig do
 
     it "appends a subnet to the subnet4 list with a different exclusion at the start" do
       site = build_stubbed(:site, fits_id: "FITSID01", name: "SITENAME01")
+      shared_network = build_stubbed(:shared_network, site: site)
       exclusion = build_stubbed(:exclusion, start_address: "10.0.2.1", end_address: "10.0.2.70")
       subnet1 = build_stubbed(:subnet, cidr_block: "10.0.2.0/24", start_address: "10.0.2.1",
-                                       end_address: "10.0.2.255", exclusions: [exclusion], routers: "10.0.2.2,10.0.2.3", site: site)
+                                       end_address: "10.0.2.255", exclusions: [exclusion], routers: "10.0.2.2,10.0.2.3", shared_network: shared_network)
 
       config = UseCases::GenerateKeaConfig.new(subnets: [subnet1]).call
 
@@ -306,9 +313,10 @@ describe UseCases::GenerateKeaConfig do
 
     it "appends another subnet to the subnet4 list with an exclusion at the start" do
       site = build_stubbed(:site, fits_id: "FITSID01", name: "SITENAME01")
+      shared_network = build_stubbed(:shared_network, site: site)
       exclusion = build_stubbed(:exclusion, start_address: "10.0.1.1", end_address: "10.0.1.70")
       subnet1 = build_stubbed(:subnet, cidr_block: "10.0.1.0/24", start_address: "10.0.1.1",
-                                       end_address: "10.0.1.255", exclusions: [exclusion], routers: "10.0.1.2,10.0.1.3", site: site)
+                                       end_address: "10.0.1.255", exclusions: [exclusion], routers: "10.0.1.2,10.0.1.3", shared_network: shared_network)
 
       config = UseCases::GenerateKeaConfig.new(subnets: [subnet1]).call
 
@@ -343,9 +351,10 @@ describe UseCases::GenerateKeaConfig do
 
     it "appends a subnet to the subnet4 list with an exclusion at the end" do
       site = build_stubbed(:site, fits_id: "FITSID01", name: "SITENAME01")
+      shared_network = build_stubbed(:shared_network, site: site)
       exclusion = build_stubbed(:exclusion, start_address: "10.0.2.200", end_address: "10.0.2.255")
       subnet1 = build_stubbed(:subnet, cidr_block: "10.0.2.0/24", start_address: "10.0.2.1",
-                                       end_address: "10.0.2.255", exclusions: [exclusion], routers: "10.0.2.2,10.0.2.3", site: site)
+                                       end_address: "10.0.2.255", exclusions: [exclusion], routers: "10.0.2.2,10.0.2.3", shared_network: shared_network)
 
       config = UseCases::GenerateKeaConfig.new(subnets: [subnet1]).call
 
@@ -380,9 +389,10 @@ describe UseCases::GenerateKeaConfig do
 
     it "appends a subnet to the subnet4 list with another exclusion at the end" do
       site = build_stubbed(:site, fits_id: "FITSID01", name: "SITENAME01")
+      shared_network = build_stubbed(:shared_network, site: site)
       exclusion = build_stubbed(:exclusion, start_address: "10.0.2.230", end_address: "10.0.2.255")
       subnet1 = build_stubbed(:subnet, cidr_block: "10.0.2.0/24", start_address: "10.0.2.1",
-                                       end_address: "10.0.2.255", exclusions: [exclusion], routers: "10.0.2.2,10.0.2.3", site: site)
+                                       end_address: "10.0.2.255", exclusions: [exclusion], routers: "10.0.2.2,10.0.2.3", shared_network: shared_network)
 
       config = UseCases::GenerateKeaConfig.new(subnets: [subnet1]).call
 
@@ -417,9 +427,10 @@ describe UseCases::GenerateKeaConfig do
 
     it "appends a different subnet to the subnet4 list with an exclusion at the end" do
       site = build_stubbed(:site, fits_id: "FITSID01", name: "SITENAME01")
+      shared_network = build_stubbed(:shared_network, site: site)
       exclusion = build_stubbed(:exclusion, start_address: "10.0.1.230", end_address: "10.0.1.255")
       subnet1 = build_stubbed(:subnet, cidr_block: "10.0.1.0/24", start_address: "10.0.1.1",
-                                       end_address: "10.0.1.255", exclusions: [exclusion], routers: "10.0.1.2,10.0.1.3", site: site)
+                                       end_address: "10.0.1.255", exclusions: [exclusion], routers: "10.0.1.2,10.0.1.3", shared_network: shared_network)
 
       config = UseCases::GenerateKeaConfig.new(subnets: [subnet1]).call
 
@@ -454,9 +465,10 @@ describe UseCases::GenerateKeaConfig do
 
     it "creates an exclusion to cover the whole subnet" do
       site = build_stubbed(:site, fits_id: "FITSID01", name: "SITENAME01")
+      shared_network = build_stubbed(:shared_network, site: site)
       exclusion = build_stubbed(:exclusion, start_address: "10.0.1.1", end_address: "10.0.1.255")
       subnet1 = build_stubbed(:subnet, cidr_block: "10.0.1.0/24", start_address: "10.0.1.1",
-                                       end_address: "10.0.1.255", exclusions: [exclusion], routers: "10.0.1.2,10.0.1.3", site: site)
+                                       end_address: "10.0.1.255", exclusions: [exclusion], routers: "10.0.1.2,10.0.1.3", shared_network: shared_network)
 
       config = UseCases::GenerateKeaConfig.new(subnets: [subnet1]).call
 

--- a/spec/use_cases/generate_kea_config_spec.rb
+++ b/spec/use_cases/generate_kea_config_spec.rb
@@ -810,12 +810,12 @@ describe UseCases::GenerateKeaConfig do
       config = UseCases::GenerateKeaConfig.new(subnets: [subnet]).call
 
       expect(config.dig(:Dhcp4, :subnet4)).to include(
-        hash_including("require-client-classes": ["subnet-10.0.4.0-client"])
+        hash_including("require-client-classes": ["subnet-#{subnet.ip_addr}-client"])
       )
 
       expect(config.dig(:Dhcp4, :"client-classes")).to match([
         {
-          name: "subnet-10.0.4.0-client",
+          name: "subnet-#{subnet.ip_addr}-client",
           test: "member('ALL')",
           "only-if-required": true,
           "option-data": match_array([
@@ -834,7 +834,7 @@ describe UseCases::GenerateKeaConfig do
 
       client_class_names = config.dig(:Dhcp4, :"client-classes").map { |cc| cc[:name] }
       expect(client_class_names).to eq(
-        ["DOM1 device", "subnet-10.0.4.0-client"]
+        ["DOM1 device", "subnet-#{subnet.ip_addr}-client"]
       )
     end
 


### PR DESCRIPTION
# What
Allow users to extend an existing network with a non continuous range of ip addresses, or rather, a new subnet.

# Why
When extending subnets, we cannot always extend the subnet into the range of another subnet 
at another site. eg extending the `10.0.0.0/24` subnet to `10.0.0.0/23` when another subnet of range `10.0.1.0/24` already exists

# Screenshots
<img width="944" alt="Screenshot 2021-06-17 at 14 56 49" src="https://user-images.githubusercontent.com/326561/122410932-42e30280-cf7c-11eb-9fbd-8bcd38170a61.png">

# Notes
Currently these "shared networks" are not actually provisioned in the Kea config. This is the next step.

We have made some assumptions about the user journey here. We assume that this feature is useful when a user wants to add another, non continuous block of IP addresses to a single network. With this in mind it often would not make sense to a user to explicitly create a "shared network" and so we hide this jin model from the user. Id be interested to test this theory with users.

Co-authored by @wanieldilson 
Co-authored by @andycohen 

