### PR TITLE
Allow subnets to be extended with another existing subnet

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,6 @@ start-db:
 	ENV=${ENV} ./scripts/wait_for_db.sh
 
 db-setup: start-db
-	$(DOCKER_COMPOSE) run --rm app ls -l
 	$(DOCKER_COMPOSE) run --rm app ./bin/rails db:drop db:create db:schema:load
 
 serve: stop start-db

--- a/app/models/subnet.rb
+++ b/app/models/subnet.rb
@@ -78,6 +78,14 @@ class Subnet < ApplicationRecord
     shared_network.subnets - [self]
   end
 
+  def subnets_in_same_site
+    site.subnets - [self]
+  end
+
+  def subnets_in_same_site_not_network
+    subnets_in_same_site - subnets_in_same_shared_network
+  end
+
   private
 
   def cidr_block_is_a_valid_ipv4_subnet

--- a/app/views/subnet_extensions/confirm_update.html.erb
+++ b/app/views/subnet_extensions/confirm_update.html.erb
@@ -22,7 +22,7 @@
 
 <%= button_to "Add to shared network", subnet_update_extensions_path(@subnet),
   method: :put,
-  class: "govuk-button govuk-button--warning govuk-!-margin-right-1",
+  class: "govuk-button govuk-!-margin-right-1",
   data: {
     "module" => "govuk-button"
   },

--- a/app/views/subnet_extensions/confirm_update.html.erb
+++ b/app/views/subnet_extensions/confirm_update.html.erb
@@ -20,7 +20,7 @@
   <%= render "subnets/list", subnets: @extension.subnets_in_same_shared_network, hide_actions: true %>
 <% end %>
 
-<%= button_to "Add to shared network", subnet_update_extensions_path(@extension),
+<%= button_to "Add to shared network", subnet_update_extensions_path(@subnet),
   method: :put,
   class: "govuk-button govuk-button--warning govuk-!-margin-right-1",
   data: {

--- a/app/views/subnet_extensions/confirm_update.html.erb
+++ b/app/views/subnet_extensions/confirm_update.html.erb
@@ -1,0 +1,42 @@
+<h2 class="govuk-heading-l">Are you sure?</h2>
+
+<div class="govuk-inset-text">
+  <h4 class="govuk-heading-s">Subnet to be added to shared network:</h4>
+  <p class="govuk-body"><%= @extension.cidr_block %></p>
+
+
+</div>
+
+<div class="govuk-warning-text">
+  <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+  <strong class="govuk-warning-text__text">
+    <span class="govuk-warning-text__assistive">Warning</span>
+      Are you sure you want to add the above subnet to a shared network?
+  </strong>
+</div>
+
+<% if @extension.subnets_in_same_shared_network.any? %>
+  <p class="govuk-body">The following subnets exist in this shared network</p>
+  <%= render "subnets/list", subnets: @extension.subnets_in_same_shared_network, hide_actions: true %>
+<% end %>
+
+<%= button_to "Add to shared network", subnet_update_extensions_path(@extension),
+  method: :put,
+  class: "govuk-button govuk-button--warning govuk-!-margin-right-1",
+  data: {
+    "module" => "govuk-button"
+  },
+  params: {
+    confirm: true,
+    extension_id: @extension.id
+  },
+  form: {
+    class: 'govuk-!-display-inline-block'
+  }
+%>
+<%= link_to "Cancel", subnet_path(@subnet),
+  class: "govuk-button govuk-button--secondary",
+  data: {
+    module: "govuk-button"
+  }
+%>

--- a/app/views/subnet_extensions/new.html.erb
+++ b/app/views/subnet_extensions/new.html.erb
@@ -1,21 +1,23 @@
 <%= render "layouts/form_errors", resource: @extension %>
 
-<h2 class="govuk-heading-l">Extending a subnet</h2>
+<h2 class="govuk-heading-l">Extending a shared network</h2>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h3 class="govuk-heading-m">Extend the network with an existing subnet</h3>
+    <h3 class="govuk-heading-m">Extend with an existing subnet</h3>
 
 
     <%= form_tag(subnet_update_extensions_path(@subnet), method: :put, local: true) do %>
-      <%= label_tag :extension_id, "Subnet", class: "govuk-label" %>
-      <%= select_tag :extension_id,
-        options_for_select(
-          @subnet.subnets_in_same_site_not_network.collect { |s| [s.cidr_block, s.id] }
-        ),
-        prompt: "Select a subnet",
-        class: "govuk-input"
-      %>
+      <div class="govuk-form-group">
+        <%= label_tag :extension_id, "Subnet", class: "govuk-label" %>
+        <%= select_tag :extension_id,
+          options_for_select(
+            @subnet.subnets_in_same_site_not_network.collect { |s| [s.cidr_block, s.id] }
+          ),
+          prompt: "Select a subnet",
+          class: "govuk-input"
+        %>
+      </div>
 
       <%= submit_tag "Add to shared network", {
         class: "govuk-button",
@@ -25,7 +27,7 @@
   </div>
 
   <div class="govuk-grid-column-two-thirds">
-    <h3 class="govuk-heading-m">Extend the network with a new subnet</h3>
+    <h3 class="govuk-heading-m">Extend with a new subnet</h3>
     <%= form_with(model: @extension, url: subnet_extensions_path(@subnet), local: true) do |form| %>
       <%= render "subnets/form", f: form %>
 

--- a/app/views/subnet_extensions/new.html.erb
+++ b/app/views/subnet_extensions/new.html.erb
@@ -4,6 +4,28 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
+    <h3 class="govuk-heading-m">Extend the network with an existing subnet</h3>
+
+
+    <%= form_tag(subnet_update_extensions_path(@subnet), method: :put, local: true) do %>
+      <%= label_tag :extension_id, "Subnet", class: "govuk-label" %>
+      <%= select_tag :extension_id,
+        options_for_select(
+          @subnet.subnets_in_same_site_not_network.collect { |s| [s.cidr_block, s.id] }
+        ),
+        prompt: "Select a subnet",
+        class: "govuk-input"
+      %>
+
+      <%= submit_tag "Add to shared network", {
+        class: "govuk-button",
+        "data-module" => "govuk-button"
+      } %>
+    <% end %>
+  </div>
+
+  <div class="govuk-grid-column-two-thirds">
+    <h3 class="govuk-heading-m">Extend the network with a new subnet</h3>
     <%= form_with(model: @extension, url: subnet_extensions_path(@subnet), local: true) do |form| %>
       <%= render "subnets/form", f: form %>
 

--- a/app/views/subnets/show.html.erb
+++ b/app/views/subnets/show.html.erb
@@ -54,9 +54,9 @@
   <%= render "exclusions/details", exclusion: @subnet.exclusions.first %>
 <% end %>
 
-<h3 class="govuk-heading-m">Other subnets in the same shared network</h3>
+<h3 class="govuk-heading-m">Subnets in the same shared network</h3>
 <%= render "subnets/list", subnets: @subnet.subnets_in_same_shared_network %>
-<%= link_to "Extend this network with another subnet", new_subnet_extension_path(@subnet), class: "govuk-button" if can?(:update, @subnet) %>
+<%= link_to "Add a subnet to this shared network", new_subnet_extension_path(@subnet), class: "govuk-button" if can?(:update, @subnet) %>
 
 <h3 class="govuk-heading-m">Leases</h3>
 <%= link_to "View leases", subnet_leases_path(@subnet), class: "govuk-button govuk-button--secondary" %>

--- a/app/views/subnets/show.html.erb
+++ b/app/views/subnets/show.html.erb
@@ -54,9 +54,17 @@
   <%= render "exclusions/details", exclusion: @subnet.exclusions.first %>
 <% end %>
 
-<h3 class="govuk-heading-m">Subnets in the same shared network</h3>
-<%= render "subnets/list", subnets: @subnet.subnets_in_same_shared_network %>
-<%= link_to "Add a subnet to this shared network", new_subnet_extension_path(@subnet), class: "govuk-button" if can?(:update, @subnet) %>
+<% if @subnet.subnets_in_same_shared_network.any? %>
+  <h3 class="govuk-heading-m">Subnets in the same shared network</h3>
+  <%= render "subnets/list", subnets: @subnet.subnets_in_same_shared_network %>
+  <%= link_to "Add a subnet to this shared network", new_subnet_extension_path(@subnet), class: "govuk-button" if can?(:update, @subnet) %>
+<% else %>
+  <h3 class="govuk-heading-m">Subnets in the same shared network</h3>
+  <h4 class="govuk-inset-text">None</h4>        
+  <%= link_to "Add a subnet to this shared network", new_subnet_extension_path(@subnet), class: "govuk-button" if can?(:update, @subnet) %>
+<% end %>
+
+
 
 <h3 class="govuk-heading-m">Leases</h3>
 <%= link_to "View leases", subnet_leases_path(@subnet), class: "govuk-button govuk-button--secondary" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,7 +21,7 @@ Rails.application.routes.draw do
     resources :leases, only: [:index, :destroy]
 
     resources :extensions, only: [:new, :create], controller: :subnet_extensions
-    put "/extensions/update", controller: :subnet_extensions, :action => :update, as: :update_extensions
+    put "/extensions/update", controller: :subnet_extensions, action: :update, as: :update_extensions
   end
 
   resources :leases, only: [:destroy]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,6 +21,7 @@ Rails.application.routes.draw do
     resources :leases, only: [:index, :destroy]
 
     resources :extensions, only: [:new, :create], controller: :subnet_extensions
+    put "/extensions/update", controller: :subnet_extensions, :action => :update, as: :update_extensions
   end
 
   resources :leases, only: [:destroy]

--- a/spec/acceptance/create_subnet_extension_spec.rb
+++ b/spec/acceptance/create_subnet_extension_spec.rb
@@ -11,7 +11,9 @@ describe "creating a subnet extension", type: :feature do
     subnet = Audited.audit_class.as_user(editor) { create :subnet }
     visit "/subnets/#{subnet.to_param}"
 
-    click_on "Extend this network with another subnet"
+    expect(page).to have_content("Subnets in the same shared network")
+
+    click_on "Add a subnet to this shared network"
 
     fill_in "CIDR block", with: "10.0.1.0/24"
     fill_in "Start address", with: "10.0.1.1"
@@ -35,7 +37,7 @@ describe "creating a subnet extension", type: :feature do
     subnet = create :subnet
     visit "/subnets/#{subnet.to_param}"
 
-    click_on "Extend this network with another subnet"
+    click_on "Add a subnet to this shared network"
 
     fill_in "CIDR block", with: "a"
     fill_in "Start address", with: "b"

--- a/spec/acceptance/create_subnet_extension_spec.rb
+++ b/spec/acceptance/create_subnet_extension_spec.rb
@@ -15,6 +15,10 @@ describe "creating a subnet extension", type: :feature do
 
     click_on "Add a subnet to this shared network"
 
+    expect(page).to have_content("Extending a shared network")
+    expect(page).to have_content("Extend with an existing subnet")
+    expect(page).to have_content("Extend with a new subnet")
+
     fill_in "CIDR block", with: "10.0.1.0/24"
     fill_in "Start address", with: "10.0.1.1"
     fill_in "End address", with: "10.0.1.255"

--- a/spec/acceptance/show_subnet_spec.rb
+++ b/spec/acceptance/show_subnet_spec.rb
@@ -30,7 +30,7 @@ describe "showing a subnet", type: :feature do
 
       it "should only show shared network table if sharing one with another subnet" do
         visit "/subnets/#{subnet.to_param}"
-    
+
         expect(page).to have_no_content("List of subnets")
       end
 

--- a/spec/acceptance/show_subnet_spec.rb
+++ b/spec/acceptance/show_subnet_spec.rb
@@ -28,6 +28,12 @@ describe "showing a subnet", type: :feature do
         expect(page).to have_content subnet.end_address
       end
 
+      it "should only show shared network table if sharing one with another subnet" do
+        visit "/subnets/#{subnet.to_param}"
+    
+        expect(page).to have_no_content("List of subnets")
+      end
+
       it "allows viewing other subnets in the same shared network" do
         other_subnet = create(:subnet, shared_network: subnet.shared_network)
         visit "/subnets/#{subnet.to_param}"

--- a/spec/acceptance/update_subnet_extension_spec.rb
+++ b/spec/acceptance/update_subnet_extension_spec.rb
@@ -31,4 +31,32 @@ describe "updating a subnet extension", type: :feature do
 
     expect_audit_log_entry_for(editor.email, "update", "Subnet")
   end
+
+  it "deletes the original shared network when assigned a new one" do
+    subnet = Audited.audit_class.as_user(editor) { create :subnet }
+    other_subnet = Audited.audit_class.as_user(editor) do
+      create :subnet, shared_network: create(:shared_network, site: subnet.shared_network.site)
+    end
+
+    visit "/subnets/#{subnet.to_param}"
+
+    click_on "Extend this network with another subnet"
+
+    select other_subnet.cidr_block, from: "Subnet"
+
+    expect_config_to_be_verified
+    expect_config_to_be_published
+
+    
+    expect(subnet.shared_network).not_to eq(other_subnet.shared_network)
+
+    click_button "Add to shared network"
+    
+    expect(SharedNetwork.find_by(id: other_subnet.shared_network.id)).to eq(nil)
+
+    other_subnet.reload
+    subnet.reload
+    expect(subnet.shared_network).to eq(other_subnet.shared_network)
+  end
+  
 end

--- a/spec/acceptance/update_subnet_extension_spec.rb
+++ b/spec/acceptance/update_subnet_extension_spec.rb
@@ -7,60 +7,36 @@ describe "updating a subnet extension", type: :feature do
     login_as editor
   end
 
-  it "extends the subnet with another pre existing subnet" do
-    subnet = Audited.audit_class.as_user(editor) { create :subnet }
-    other_subnet = Audited.audit_class.as_user(editor) do
-      create :subnet, shared_network: create(:shared_network, site: subnet.shared_network.site)
-    end
+  it "moves a subnet from one shared network to another" do
+    subnet_a = create :subnet
+    subnet_b = create :subnet, shared_network: create(:shared_network, site: subnet_a.shared_network.site)
+    subnet_in_subnet_b_shared_network = create :subnet, shared_network: subnet_b.shared_network
 
-    visit "/subnets/#{subnet.to_param}"
+    visit "/subnets/#{subnet_in_subnet_b_shared_network.to_param}"
+    expect(page).to have_content(subnet_b.cidr_block)
+
+    visit "/subnets/#{subnet_a.to_param}"
+    expect(page).to have_no_content(subnet_b.cidr_block)
 
     click_on "Add a subnet to this shared network"
 
-    select other_subnet.cidr_block, from: "Subnet"
+    select subnet_b.cidr_block, from: "Subnet"
+
+    click_button "Add to shared network"
+
+    expect(page).to have_content("Are you sure you want to add the above subnet to a shared network?")
 
     expect_config_to_be_verified
     expect_config_to_be_published
 
     click_button "Add to shared network"
 
-    expect(page).to have_content("Are you sure you want to add the above subnet to a shared network?")
-    expect(page).to have_content(other_subnet.cidr_block)
-    expect(page).to have_content(subnet.cidr_block)
+    expect(page).to have_content(subnet_a.cidr_block)
+    expect(page).to have_content(subnet_b.cidr_block)
 
-    click_button "Add to shared network"
+    visit "/subnets/#{subnet_in_subnet_b_shared_network.to_param}"
 
-    expect(page).to have_content(other_subnet.cidr_block)
-    expect(page).to have_content(other_subnet.start_address)
-    expect(page).to have_content(other_subnet.end_address)
-    expect(page).to have_content(other_subnet.routers.join(", "))
-
-    expect_audit_log_entry_for(editor.email, "update", "Subnet")
+    expect(page).to have_content(subnet_in_subnet_b_shared_network.cidr_block)
+    expect(page).to have_no_content(subnet_b.cidr_block)
   end
-
-  # it "deletes the original shared network when assigned a new one" do
-  #   subnet = Audited.audit_class.as_user(editor) { create :subnet }
-  #   other_subnet = Audited.audit_class.as_user(editor) do
-  #     create :subnet, shared_network: create(:shared_network, site: subnet.shared_network.site)
-  #   end
-
-  #   visit "/subnets/#{subnet.to_param}"
-
-  #   click_on "Add a subnet to this shared network"
-
-  #   select other_subnet.cidr_block, from: "Subnet"
-
-  #   expect_config_to_be_verified
-  #   expect_config_to_be_published
-
-  #   expect(subnet.shared_network).not_to eq(other_subnet.shared_network)
-
-  #   click_button "Add to shared network"
-
-  #   expect(SharedNetwork.find_by(id: other_subnet.shared_network.id)).to eq(nil)
-
-  #   other_subnet.reload
-  #   subnet.reload
-  #   expect(subnet.shared_network).to eq(other_subnet.shared_network)
-  # end
 end

--- a/spec/acceptance/update_subnet_extension_spec.rb
+++ b/spec/acceptance/update_subnet_extension_spec.rb
@@ -15,7 +15,7 @@ describe "updating a subnet extension", type: :feature do
 
     visit "/subnets/#{subnet.to_param}"
 
-    click_on "Extend this network with another subnet"
+    click_on "Add a subnet to this shared network"
 
     select other_subnet.cidr_block, from: "Subnet"
 
@@ -40,23 +40,22 @@ describe "updating a subnet extension", type: :feature do
 
     visit "/subnets/#{subnet.to_param}"
 
-    click_on "Extend this network with another subnet"
+    click_on "Add a subnet to this shared network"
 
     select other_subnet.cidr_block, from: "Subnet"
 
     expect_config_to_be_verified
     expect_config_to_be_published
 
-    
+
     expect(subnet.shared_network).not_to eq(other_subnet.shared_network)
 
     click_button "Add to shared network"
-    
+
     expect(SharedNetwork.find_by(id: other_subnet.shared_network.id)).to eq(nil)
 
     other_subnet.reload
     subnet.reload
     expect(subnet.shared_network).to eq(other_subnet.shared_network)
   end
-  
 end

--- a/spec/acceptance/update_subnet_extension_spec.rb
+++ b/spec/acceptance/update_subnet_extension_spec.rb
@@ -1,0 +1,34 @@
+require "rails_helper"
+
+describe "updating a subnet extension", type: :feature do
+  let(:editor) { create(:user, :editor) }
+
+  before do
+    login_as editor
+  end
+
+  it "extends the subnet with another pre existing subnet" do
+    subnet = Audited.audit_class.as_user(editor) { create :subnet }
+    other_subnet = Audited.audit_class.as_user(editor) do
+      create :subnet, shared_network: create(:shared_network, site: subnet.shared_network.site)
+    end
+
+    visit "/subnets/#{subnet.to_param}"
+
+    click_on "Extend this network with another subnet"
+
+    select other_subnet.cidr_block, from: "Subnet"
+
+    expect_config_to_be_verified
+    expect_config_to_be_published
+
+    click_button "Add to shared network"
+
+    expect(page).to have_content(other_subnet.cidr_block)
+    expect(page).to have_content(other_subnet.start_address)
+    expect(page).to have_content(other_subnet.end_address)
+    expect(page).to have_content(other_subnet.routers.join(", "))
+
+    expect_audit_log_entry_for(editor.email, "update", "Subnet")
+  end
+end

--- a/spec/acceptance/update_subnet_extension_spec.rb
+++ b/spec/acceptance/update_subnet_extension_spec.rb
@@ -24,6 +24,12 @@ describe "updating a subnet extension", type: :feature do
 
     click_button "Add to shared network"
 
+    expect(page).to have_content("Are you sure you want to add the above subnet to a shared network?")
+    expect(page).to have_content(other_subnet.cidr_block)
+    expect(page).to have_content(subnet.cidr_block)
+
+    click_button "Add to shared network"
+
     expect(page).to have_content(other_subnet.cidr_block)
     expect(page).to have_content(other_subnet.start_address)
     expect(page).to have_content(other_subnet.end_address)
@@ -32,30 +38,29 @@ describe "updating a subnet extension", type: :feature do
     expect_audit_log_entry_for(editor.email, "update", "Subnet")
   end
 
-  it "deletes the original shared network when assigned a new one" do
-    subnet = Audited.audit_class.as_user(editor) { create :subnet }
-    other_subnet = Audited.audit_class.as_user(editor) do
-      create :subnet, shared_network: create(:shared_network, site: subnet.shared_network.site)
-    end
+  # it "deletes the original shared network when assigned a new one" do
+  #   subnet = Audited.audit_class.as_user(editor) { create :subnet }
+  #   other_subnet = Audited.audit_class.as_user(editor) do
+  #     create :subnet, shared_network: create(:shared_network, site: subnet.shared_network.site)
+  #   end
 
-    visit "/subnets/#{subnet.to_param}"
+  #   visit "/subnets/#{subnet.to_param}"
 
-    click_on "Add a subnet to this shared network"
+  #   click_on "Add a subnet to this shared network"
 
-    select other_subnet.cidr_block, from: "Subnet"
+  #   select other_subnet.cidr_block, from: "Subnet"
 
-    expect_config_to_be_verified
-    expect_config_to_be_published
+  #   expect_config_to_be_verified
+  #   expect_config_to_be_published
 
+  #   expect(subnet.shared_network).not_to eq(other_subnet.shared_network)
 
-    expect(subnet.shared_network).not_to eq(other_subnet.shared_network)
+  #   click_button "Add to shared network"
 
-    click_button "Add to shared network"
+  #   expect(SharedNetwork.find_by(id: other_subnet.shared_network.id)).to eq(nil)
 
-    expect(SharedNetwork.find_by(id: other_subnet.shared_network.id)).to eq(nil)
-
-    other_subnet.reload
-    subnet.reload
-    expect(subnet.shared_network).to eq(other_subnet.shared_network)
-  end
+  #   other_subnet.reload
+  #   subnet.reload
+  #   expect(subnet.shared_network).to eq(other_subnet.shared_network)
+  # end
 end


### PR DESCRIPTION
# What
Allow existing subnets to be moved into the shared network of another subnet

# Why
So that we can easily merge subnets into a single logical vlan from the old world. This helps us to migrate our old superscopes

# Screenshots
<img width="944" alt="Screenshot 2021-06-22 at 11 41 03" src="https://user-images.githubusercontent.com/326561/122911006-be62fc00-d34e-11eb-9291-65b2b599ea4f.png">


# Notes
This is a WIP and needs creases ironing out
