### PR TITLE
Pttp 6320/dhcp script exclusions

### DIFF
--- a/scripts/config-parser/bin/dhcp_config_parser.rb
+++ b/scripts/config-parser/bin/dhcp_config_parser.rb
@@ -2,10 +2,12 @@
 
 require_relative "../lib/dhcp_config_parser"
 
-puts "There are #{DhcpConfigParser.run.length} differences in reservation data"
+parsed_config = DhcpConfigParser.run
+
+puts "There are #{parsed_config.length} differences in reservation data"
 puts "Take a look at ./data/reservation_diff.json for a breakdown"
 
 reservation_diff = File.open("./data/reservation_diff.json", "w")
 
-reservation_diff << DhcpConfigParser.run.to_json
+reservation_diff << parsed_config.to_json
 reservation_diff.close

--- a/scripts/config-parser/bin/dhcp_config_parser.rb
+++ b/scripts/config-parser/bin/dhcp_config_parser.rb
@@ -2,6 +2,9 @@
 
 require_relative "../lib/dhcp_config_parser"
 
+puts "There are #{DhcpConfigParser.run.length} differences in reservation data"
+puts "Take a look at ./data/reservation_diff.json for a breakdown"
+
 reservation_diff = File.open("./data/reservation_diff.json", "w")
 
 reservation_diff << DhcpConfigParser.run.to_json

--- a/scripts/config-parser/lib/dhcp_config_parser.rb
+++ b/scripts/config-parser/lib/dhcp_config_parser.rb
@@ -27,6 +27,22 @@ class DhcpConfigParser
     File.exist?(LEGACY_CONFIG_FILEPATH)
   end
 
+  def self.get_legacy_exclusions(export, subnet_list)
+    exclusion_fields = ["type", "start-ip", "end-ip"]
+    legacy_exclusions = []
+  
+    subnet_list.each do |subnet|
+      exclusion_regex = /excluderange.#{subnet.chop}\d{1,3}.#{subnet.chop}\d{1,3}/
+      export.scan(exclusion_regex)
+        .each do |exclusion|
+          exclusions = exclusion.split(" ")
+        legacy_exclusions.push(exclusions)
+      end
+    end
+  
+    legacy_exclusions.map { |row| exclusion_fields.zip(row).to_h }
+  end
+
   def self.get_kea_reservations(shared_network_id, kea_config)
     kea_config_hash = JSON.parse(kea_config)
     shared_networks = kea_config_hash["Dhcp4"]["shared-networks"].select { |shared_network| shared_network["name"].include?(shared_network_id) }

--- a/scripts/config-parser/lib/dhcp_config_parser.rb
+++ b/scripts/config-parser/lib/dhcp_config_parser.rb
@@ -13,6 +13,12 @@ class DhcpConfigParser
     shared_network_id = "FITS_####"
     subnet_list = ["192.168.1.0", "192.168.2.0", "192.168.3.0"]
 
+    exclusion_data = get_legacy_exclusions(File.read(LEGACY_CONFIG_FILEPATH), subnet_list)
+
+    puts "This site has the following #{exclusion_data.length} exclusions configured :"
+    puts exclusion_data
+    puts "----"
+
     compared_reservations = find_missing_reservations(
       kea_reservations: get_kea_reservations(shared_network_id, File.read(KEA_CONFIG_FILEPATH)),
       legacy_reservations: get_legacy_reservations(File.read(LEGACY_CONFIG_FILEPATH), subnet_list)

--- a/scripts/config-parser/lib/dhcp_config_parser.rb
+++ b/scripts/config-parser/lib/dhcp_config_parser.rb
@@ -36,16 +36,16 @@ class DhcpConfigParser
   def self.get_legacy_exclusions(export, subnet_list)
     exclusion_fields = ["type", "start-ip", "end-ip"]
     legacy_exclusions = []
-  
+
     subnet_list.each do |subnet|
       exclusion_regex = /excluderange.#{subnet.chop}\d{1,3}.#{subnet.chop}\d{1,3}/
       export.scan(exclusion_regex)
         .each do |exclusion|
-          exclusions = exclusion.split(" ")
+        exclusions = exclusion.split(" ")
         legacy_exclusions.push(exclusions)
       end
     end
-  
+
     legacy_exclusions.map { |row| exclusion_fields.zip(row).to_h }
   end
 

--- a/scripts/config-parser/readme.md
+++ b/scripts/config-parser/readme.md
@@ -46,3 +46,5 @@ The data directory is .gitignored, so be sure to use it.
 
 This will create a `reservation_diff.json` in your data directory. A `kea` or `legacy` key with a value of `null` means that reservation is missing from the associated config. 
 
+You'll also see the exclusion information output directly into the terminal.
+

--- a/scripts/config-parser/spec/dhcp_config_parser_spec.rb
+++ b/scripts/config-parser/spec/dhcp_config_parser_spec.rb
@@ -141,4 +141,38 @@ describe DhcpConfigParser do
       ])
     end
   end
+
+  describe "get_legacy_exclusions" do
+    let(:export) { File.read("spec/data/export.txt") }
+    let(:subnet_list) { ["192.168.1.0", "192.168.7.0", "192.168.2.0"] }
+    it "returns a hash of all exlcusions for the given list of subnets" do
+
+      expect(DhcpConfigParser.get_legacy_exclusions(export, subnet_list
+    )).to match_array([
+      {
+        "type"=>"excluderange", 
+        "start-ip"=>"192.168.1.1", 
+        "end-ip"=>"192.168.1.39"
+      },
+      {
+        "type"=>"excluderange",
+        "start-ip"=>"192.168.1.40",
+        "end-ip"=>"192.168.1.120"
+      },
+      {
+        "type"=>"excluderange", 
+        "start-ip"=>"192.168.2.1", 
+        "end-ip"=>"192.168.2.39"
+      },
+      {
+        "type"=>"excluderange",
+        "start-ip"=>"192.168.2.121",
+        "end-ip"=>"192.168.2.200"
+      }
+    ])
+    end
+  end
+
+
+
 end

--- a/scripts/config-parser/spec/dhcp_config_parser_spec.rb
+++ b/scripts/config-parser/spec/dhcp_config_parser_spec.rb
@@ -146,33 +146,28 @@ describe DhcpConfigParser do
     let(:export) { File.read("spec/data/export.txt") }
     let(:subnet_list) { ["192.168.1.0", "192.168.7.0", "192.168.2.0"] }
     it "returns a hash of all exlcusions for the given list of subnets" do
-
-      expect(DhcpConfigParser.get_legacy_exclusions(export, subnet_list
-    )).to match_array([
-      {
-        "type"=>"excluderange", 
-        "start-ip"=>"192.168.1.1", 
-        "end-ip"=>"192.168.1.39"
-      },
-      {
-        "type"=>"excluderange",
-        "start-ip"=>"192.168.1.40",
-        "end-ip"=>"192.168.1.120"
-      },
-      {
-        "type"=>"excluderange", 
-        "start-ip"=>"192.168.2.1", 
-        "end-ip"=>"192.168.2.39"
-      },
-      {
-        "type"=>"excluderange",
-        "start-ip"=>"192.168.2.121",
-        "end-ip"=>"192.168.2.200"
-      }
-    ])
+      expect(DhcpConfigParser.get_legacy_exclusions(export, subnet_list)).to match_array([
+        {
+          "type" => "excluderange",
+          "start-ip" => "192.168.1.1",
+          "end-ip" => "192.168.1.39"
+        },
+        {
+          "type" => "excluderange",
+          "start-ip" => "192.168.1.40",
+          "end-ip" => "192.168.1.120"
+        },
+        {
+          "type" => "excluderange",
+          "start-ip" => "192.168.2.1",
+          "end-ip" => "192.168.2.39"
+        },
+        {
+          "type" => "excluderange",
+          "start-ip" => "192.168.2.121",
+          "end-ip" => "192.168.2.200"
+        }
+      ])
     end
   end
-
-
-
 end


### PR DESCRIPTION
# What

✨ Adding a feature to the DHCP script to output the exclusion information from a legacy DHCP export.

# Why

To make the pre go-live data checks easier

# Screenshots

![image](https://user-images.githubusercontent.com/68431297/133491338-93bf5e48-8094-4df5-9183-cbc66b1800d0.png)

# Notes
