### PR TITLE
Always show MAC Addresses in a consistent way

### DIFF
--- a/app/helpers/mac_address_helper.rb
+++ b/app/helpers/mac_address_helper.rb
@@ -5,11 +5,11 @@ module MacAddressHelper
   def format_mac_address(original_mac_address)
     return original_mac_address if valid_mac_address?(original_mac_address)
 
-    stripped_mac_address = original_mac_address.gsub(/[#{DELIMITER_LIST}]/, '')
+    stripped_mac_address = original_mac_address.gsub(/[#{DELIMITER_LIST}]/o, "")
 
     return original_mac_address unless valid_mac_address_char_length?(stripped_mac_address)
 
-    final_formatted_mac_address = stripped_mac_address.scan(/.{1,2}/m).join(':')
+    final_formatted_mac_address = stripped_mac_address.scan(/.{1,2}/m).join(":")
 
     return original_mac_address unless valid_mac_address?(final_formatted_mac_address)
 

--- a/app/helpers/mac_address_helper.rb
+++ b/app/helpers/mac_address_helper.rb
@@ -1,0 +1,28 @@
+module MacAddressHelper
+  MAC_ADDRESS_LENGTH = 12
+  DELIMITER_LIST = '\\s:-'.freeze
+
+  def format_mac_address(original_mac_address)
+    return original_mac_address if valid_mac_address?(original_mac_address)
+
+    stripped_mac_address = original_mac_address.gsub(/[#{DELIMITER_LIST}]/, '')
+
+    return original_mac_address unless valid_mac_address_char_length?(stripped_mac_address)
+
+    final_formatted_mac_address = stripped_mac_address.scan(/.{1,2}/m).join(':')
+
+    return original_mac_address unless valid_mac_address?(final_formatted_mac_address)
+
+    final_formatted_mac_address
+  end
+
+  private
+
+  def valid_mac_address?(mac_address)
+    Reservation::MAC_ADDRESS_REGEX =~ mac_address
+  end
+
+  def valid_mac_address_char_length?(mac_address)
+    mac_address.length == MAC_ADDRESS_LENGTH
+  end
+end

--- a/app/presenters/reservation_option_presenter.rb
+++ b/app/presenters/reservation_option_presenter.rb
@@ -1,7 +1,9 @@
 class ReservationOptionPresenter < BasePresenter
+  include MacAddressHelper
+
   delegate :reservation, to: :record
 
   def display_name
-    reservation.hw_address
+    format_mac_address(reservation.hw_address)
   end
 end

--- a/app/presenters/reservation_presenter.rb
+++ b/app/presenters/reservation_presenter.rb
@@ -1,5 +1,7 @@
 class ReservationPresenter < BasePresenter
+  include MacAddressHelper
+
   def display_name
-    record.hw_address
+    format_mac_address(record.hw_address)
   end
 end

--- a/app/views/leases/index.html.erb
+++ b/app/views/leases/index.html.erb
@@ -11,7 +11,7 @@
   <tbody class="govuk-table__body">
     <% @leases.each do |lease| %>
       <tr class="govuk-table__row">
-        <td class="govuk-table__cell"><%= lease.hw_address %></td>
+        <td class="govuk-table__cell"><%= format_mac_address(lease.hw_address) %></td>
         <td class="govuk-table__cell"><%= lease.ip_address %></td>
         <td class="govuk-table__cell"><%= lease.hostname %></td>
         <td class="govuk-table__cell"><%= lease.pretty_state %></td>

--- a/app/views/reservations/_list.html.erb
+++ b/app/views/reservations/_list.html.erb
@@ -18,7 +18,7 @@
   <tbody class="govuk-table__body">
     <% reservations.each do |reservation| %>
       <tr class="govuk-table__row">
-        <td class="govuk-table__cell"><%= reservation.hw_address %></td>
+        <td class="govuk-table__cell"><%= format_mac_address(reservation.hw_address) %></td>
         <td class="govuk-table__cell"><%= reservation.ip_address %></td>
         <td class="govuk-table__cell"><%= reservation.hostname %></td>
         <td class="govuk-table__cell"><%= reservation.description %></td>

--- a/app/views/reservations/show.html.erb
+++ b/app/views/reservations/show.html.erb
@@ -3,7 +3,7 @@
 <dl class="govuk-summary-list">
   <div class="govuk-summary-list__row">
     <dt class="govuk-summary-list__key">HW address</dt>
-    <dd class="govuk-summary-list__value"><%= @reservation.hw_address %></dd>
+    <dd class="govuk-summary-list__value"><%= format_mac_address(@reservation.hw_address) %></dd>
     <dd class="govuk-summary-list__actions">
       <%= link_to edit_reservation_path(@reservation), class: "govuk-link" do %>
         Change<span class="govuk-visually-hidden"> hardware address</span>

--- a/spec/acceptance/list_leases_spec.rb
+++ b/spec/acceptance/list_leases_spec.rb
@@ -12,17 +12,17 @@ RSpec.describe "Listing leases", type: :feature do
   let(:kea_response) do
     [
       {
-        "arguments": {
-          "leases": [
+        arguments: {
+          leases: [
             {
               "hw-address": hw_address,
               "ip-address": ip_address,
-              "hostname": hostname,
-              "state": 0
+              hostname: hostname,
+              state: 0
             }
           ]
         },
-        "result": 0
+        result: 0
       }
     ].to_json
   end

--- a/spec/acceptance/list_leases_spec.rb
+++ b/spec/acceptance/list_leases_spec.rb
@@ -4,7 +4,8 @@ RSpec.describe "Listing leases", type: :feature do
   let(:user) { create :user, :editor }
   let(:subnet) { create(:subnet) }
 
-  let(:hw_address) { "00:0c:01:02:03:05" }
+  let(:hw_address) { "00-0c-01-02-03-05" }
+  let(:formatted_hw_address) { "00:0c:01:02:03:05" }
   let(:ip_address) { "172.0.0.2" }
   let(:hostname) { "test.example.com" }
 
@@ -44,7 +45,8 @@ RSpec.describe "Listing leases", type: :feature do
     visit "/subnets/#{subnet.to_param}"
     click_on "View leases"
 
-    expect(page).to have_content hw_address
+    expect(page).not_to have_content hw_address
+    expect(page).to have_content formatted_hw_address
     expect(page).to have_content ip_address
     expect(page).to have_content hostname
     expect(page).to have_content "Leased"

--- a/spec/acceptance/show_reservation_spec.rb
+++ b/spec/acceptance/show_reservation_spec.rb
@@ -28,5 +28,25 @@ describe "showing a reservation", type: :feature do
         expect(page).to have_content reservation.hostname
       end
     end
+
+    context "when the reservation exists with an incorrect formatted HW address" do
+      let(:reservation) do
+        res = build(:reservation, hw_address: "01-bb-cc-dd-ee-ff")
+        res.save(validate: false)
+        res
+      end
+      let(:subnet) { reservation.subnet }
+
+      it "allows viewing reservations and its options" do
+        visit "/subnets/#{subnet.to_param}"
+
+        click_on "View"
+
+        expect(page).not_to have_content reservation.hw_address
+        expect(page).to have_content "01:bb:cc:dd:ee:ff"
+        expect(page).to have_content reservation.ip_address
+        expect(page).to have_content reservation.hostname
+      end
+    end
   end
 end

--- a/spec/helpers/mac_address_helper_spec.rb
+++ b/spec/helpers/mac_address_helper_spec.rb
@@ -1,0 +1,49 @@
+require 'rails_helper'
+
+describe MacAddressHelper do
+  context 'returns a correctly formatted MAC address when' do
+    it 'given a correctly formatted MAC address' do
+      mac_address = '01:bb:cc:dd:ee:ff'
+
+      expect(helper.format_mac_address(mac_address)).to eq('01:bb:cc:dd:ee:ff')
+    end
+
+    it 'given a MAC address with "-" delimiter' do
+      mac_address = '01-bb-cc-dd-ee-ff'
+
+      expect(helper.format_mac_address(mac_address)).to eq('01:bb:cc:dd:ee:ff')
+    end
+
+    it 'given a MAC address without a delimiter' do
+      mac_address = '01bbccddeeff'
+
+      expect(helper.format_mac_address(mac_address)).to eq('01:bb:cc:dd:ee:ff')
+    end
+
+    it 'given a MAC address with space delimiter' do
+      mac_address = '01 bb cc dd ee ff'
+
+      expect(helper.format_mac_address(mac_address)).to eq('01:bb:cc:dd:ee:ff')
+    end
+  end
+
+  context 'when given a incorrect MAC address' do
+    it 'returns the raw value when it is too short' do
+      mac_address = '01:bb:cc:dd:ee'
+
+      expect(helper.format_mac_address(mac_address)).to eq('01:bb:cc:dd:ee')
+    end
+
+    it 'returns the raw value when it is too long' do
+      mac_address = '01:bb:cc:dd:ee:ff:aa'
+
+      expect(helper.format_mac_address(mac_address)).to eq('01:bb:cc:dd:ee:ff:aa')
+    end
+
+    it 'returns the raw value when it contains illegal chars' do
+      mac_address = '01-bb-cc-dd-ee-XX'
+
+      expect(helper.format_mac_address(mac_address)).to eq('01-bb-cc-dd-ee-XX')
+    end
+  end
+end

--- a/spec/helpers/mac_address_helper_spec.rb
+++ b/spec/helpers/mac_address_helper_spec.rb
@@ -1,49 +1,49 @@
-require 'rails_helper'
+require "rails_helper"
 
 describe MacAddressHelper do
-  context 'returns a correctly formatted MAC address when' do
-    it 'given a correctly formatted MAC address' do
-      mac_address = '01:bb:cc:dd:ee:ff'
+  context "returns a correctly formatted MAC address when" do
+    it "given a correctly formatted MAC address" do
+      mac_address = "01:bb:cc:dd:ee:ff"
 
-      expect(helper.format_mac_address(mac_address)).to eq('01:bb:cc:dd:ee:ff')
+      expect(helper.format_mac_address(mac_address)).to eq("01:bb:cc:dd:ee:ff")
     end
 
     it 'given a MAC address with "-" delimiter' do
-      mac_address = '01-bb-cc-dd-ee-ff'
+      mac_address = "01-bb-cc-dd-ee-ff"
 
-      expect(helper.format_mac_address(mac_address)).to eq('01:bb:cc:dd:ee:ff')
+      expect(helper.format_mac_address(mac_address)).to eq("01:bb:cc:dd:ee:ff")
     end
 
-    it 'given a MAC address without a delimiter' do
-      mac_address = '01bbccddeeff'
+    it "given a MAC address without a delimiter" do
+      mac_address = "01bbccddeeff"
 
-      expect(helper.format_mac_address(mac_address)).to eq('01:bb:cc:dd:ee:ff')
+      expect(helper.format_mac_address(mac_address)).to eq("01:bb:cc:dd:ee:ff")
     end
 
-    it 'given a MAC address with space delimiter' do
-      mac_address = '01 bb cc dd ee ff'
+    it "given a MAC address with space delimiter" do
+      mac_address = "01 bb cc dd ee ff"
 
-      expect(helper.format_mac_address(mac_address)).to eq('01:bb:cc:dd:ee:ff')
+      expect(helper.format_mac_address(mac_address)).to eq("01:bb:cc:dd:ee:ff")
     end
   end
 
-  context 'when given a incorrect MAC address' do
-    it 'returns the raw value when it is too short' do
-      mac_address = '01:bb:cc:dd:ee'
+  context "when given a incorrect MAC address" do
+    it "returns the raw value when it is too short" do
+      mac_address = "01:bb:cc:dd:ee"
 
-      expect(helper.format_mac_address(mac_address)).to eq('01:bb:cc:dd:ee')
+      expect(helper.format_mac_address(mac_address)).to eq("01:bb:cc:dd:ee")
     end
 
-    it 'returns the raw value when it is too long' do
-      mac_address = '01:bb:cc:dd:ee:ff:aa'
+    it "returns the raw value when it is too long" do
+      mac_address = "01:bb:cc:dd:ee:ff:aa"
 
-      expect(helper.format_mac_address(mac_address)).to eq('01:bb:cc:dd:ee:ff:aa')
+      expect(helper.format_mac_address(mac_address)).to eq("01:bb:cc:dd:ee:ff:aa")
     end
 
-    it 'returns the raw value when it contains illegal chars' do
-      mac_address = '01-bb-cc-dd-ee-XX'
+    it "returns the raw value when it contains illegal chars" do
+      mac_address = "01-bb-cc-dd-ee-XX"
 
-      expect(helper.format_mac_address(mac_address)).to eq('01-bb-cc-dd-ee-XX')
+      expect(helper.format_mac_address(mac_address)).to eq("01-bb-cc-dd-ee-XX")
     end
   end
 end

--- a/spec/helpers/mac_address_helper_spec.rb
+++ b/spec/helpers/mac_address_helper_spec.rb
@@ -25,6 +25,12 @@ describe MacAddressHelper do
 
       expect(helper.format_mac_address(mac_address)).to eq("01:bb:cc:dd:ee:ff")
     end
+
+    it "given a mixed MAC address" do
+      mac_address = "01-bB-Cc:dd:EE ff"
+
+      expect(helper.format_mac_address(mac_address)).to eq("01:bB:Cc:dd:EE:ff")
+    end
   end
 
   context "when given a incorrect MAC address" do

--- a/spec/presenters/reservation_option_presenter_spec.rb
+++ b/spec/presenters/reservation_option_presenter_spec.rb
@@ -8,5 +8,14 @@ describe ReservationOptionPresenter do
 
       expect(presenter.display_name).to eq(reservation_option.reservation.hw_address)
     end
+
+    it "formats reservation hw_address" do
+      reservation_option = build_stubbed(:reservation_option)
+      reservation_option.reservation.hw_address = "01-bb-cc-dd-ee-ff"
+      presenter = ReservationOptionPresenter.new(reservation_option)
+
+      expect(presenter.display_name).not_to eq(reservation_option.reservation.hw_address)
+      expect(presenter.display_name).to eq("01:bb:cc:dd:ee:ff")
+    end
   end
 end

--- a/spec/presenters/reservation_presenter_spec.rb
+++ b/spec/presenters/reservation_presenter_spec.rb
@@ -1,0 +1,21 @@
+require "rails_helper"
+
+describe ReservationPresenter do
+  describe "#display_name" do
+    it "returns the reservation hw_address" do
+      reservation = build_stubbed(:reservation)
+      presenter = ReservationPresenter.new(reservation)
+
+      expect(presenter.display_name).to eq(reservation.hw_address)
+    end
+
+    it "formats reservation hw_address" do
+      reservation = build_stubbed(:reservation)
+      reservation.hw_address = "01-bb-cc-dd-ee-ff"
+      presenter = ReservationPresenter.new(reservation)
+
+      expect(presenter.display_name).not_to eq(reservation.hw_address)
+      expect(presenter.display_name).to eq("01:bb:cc:dd:ee:ff")
+    end
+  end
+end


### PR DESCRIPTION
# What
* We need to be consistent with how we present MAC/Hardware addresses in this application

# Why
* To make it easier for users to read/scan tables of data

# Screenshots
I don't have "good" dev data. But on the subnet page, it looks as before if created with "correct" Mac address

![Screenshot 2021-09-22 at 13 52 23](https://user-images.githubusercontent.com/1273965/134346989-6a447c15-e9d8-46ba-a3a7-9643eae50dc8.png)

# Notes
N/A
