### PR TITLE
Fix db names conflict

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,6 +1,9 @@
 RAILS_ENV=development
 MYSQL_ROOT_PASSWORD=root
 MYSQL_DATABASE=staff_device_dns_dhcp_admin_development
+DB_HOST=db
+DB_USER=root
+DB_PASS=root
 DB_NAME=staff_device_dns_dhcp_admin_development
 DNS_SERVICE_NAME=some-dns-service
 DNS_CLUSTER_NAME=some-dns-cluster

--- a/.env.development
+++ b/.env.development
@@ -1,7 +1,7 @@
 RAILS_ENV=development
 MYSQL_ROOT_PASSWORD=root
 MYSQL_DATABASE=staff_device_dns_dhcp_admin_development
-DB_HOST=db
+DB_HOST=admin-db
 DB_USER=root
 DB_PASS=root
 DB_NAME=staff_device_dns_dhcp_admin_development

--- a/.env.test
+++ b/.env.test
@@ -1,7 +1,7 @@
 RAILS_ENV=test
 MYSQL_ROOT_PASSWORD=root
 MYSQL_DATABASE=staff_device_dns_dhcp_admin_test
-DB_HOST=db
+DB_HOST=admin-db
 DB_USER=root
 DB_PASS=root
 DB_NAME=staff_device_dns_dhcp_admin_test

--- a/.env.test
+++ b/.env.test
@@ -1,6 +1,9 @@
 RAILS_ENV=test
 MYSQL_ROOT_PASSWORD=root
 MYSQL_DATABASE=staff_device_dns_dhcp_admin_test
+DB_HOST=db
+DB_USER=root
+DB_PASS=root
 DB_NAME=staff_device_dns_dhcp_admin_test
 DNS_SERVICE_NAME=some-dns-service
 DNS_CLUSTER_NAME=some-dns-cluster

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ ARG APPDIR=$HOME/staff-device-dns-dhcp-admin
 ARG CERTDIR=$HOME/cert
 
 ARG RACK_ENV=development
-ARG DB_HOST=db
+ARG DB_HOST=admin-db
 ARG DB_USER=root
 ARG DB_PASS=root
 ARG SECRET_KEY_BASE="fakekeybase"

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ build-dev:
 	$(DOCKER_COMPOSE) build
 
 start-db:
-	$(DOCKER_COMPOSE) up -d db
+	$(DOCKER_COMPOSE) up -d admin-db --remove-orphans
 	ENV=${ENV} ./scripts/wait_for_db.sh
 
 db-setup: start-db

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.4"
 
 services:
-  db:
+  admin-db:
     image: "${SHARED_SERVICES_ACCOUNT_ID}.dkr.ecr.eu-west-2.amazonaws.com/admin-mysql:mysql-5-7"
     env_file: .env.${ENV}
     expose:
@@ -24,7 +24,7 @@ services:
       - .:/home/app/staff-device-dns-dhcp-admin
       - node_modules:/home/app/staff-device-dns-dhcp-admin/node_modules
     links:
-      - db
+      - admin-db
     expose:
       - "3000"
     ports:

--- a/scripts/wait_for_db.sh
+++ b/scripts/wait_for_db.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 printf "Waiting for database to be ready"
-until docker-compose exec -T db /bin/bash -c 'mysql -h127.0.0.1 -uroot -p$MYSQL_ROOT_PASSWORD -e "SELECT 1"' &> /dev/null
+until docker-compose exec -T admin-db /bin/bash -c 'mysql -h127.0.0.1 -uroot -p$MYSQL_ROOT_PASSWORD -e "SELECT 1"' &> /dev/null
 do
   printf "."
   sleep 1


### PR DESCRIPTION
# What
Renames DB app name to admin-db
# Why
previously was call 'db' which had a conflict with db app in DHCP repo
# Screenshots
![image](https://user-images.githubusercontent.com/69799571/134524636-0834cd89-385f-41ef-8ac1-1d377c35e12b.png)

# Notes
