### PR TITLE
♻️ Refactor tests and add Rescue condition

### DIFF
--- a/app/controllers/zones_controller.rb
+++ b/app/controllers/zones_controller.rb
@@ -14,8 +14,9 @@ class ZonesController < ApplicationController
   def create
     @zone = Zone.new(zone_params)
     authorize! :create, @zone
+    @result = update_dns_config.call(@zone, -> { @zone.save! })
 
-    if update_dns_config.call(@zone, -> { @zone.save })
+    if @result.success?
       redirect_to dns_path, notice: "Successfully created zone"
     else
       render :new
@@ -29,8 +30,9 @@ class ZonesController < ApplicationController
   def update
     authorize! :update, @zone
     @zone.assign_attributes(zone_params)
+    @result = update_dns_config.call(@zone, -> { @zone.save! })
 
-    if update_dns_config.call(@zone, -> { @zone.save })
+    if @result.success?
       redirect_to dns_path, notice: "Successfully updated zone"
     else
       render :edit

--- a/app/lib/use_cases/transactionally_update_dns_config.rb
+++ b/app/lib/use_cases/transactionally_update_dns_config.rb
@@ -16,19 +16,18 @@ module UseCases
             publish_bind_config.call(bind_config)
             deploy_dns_service.call
           else
-            raise BindConfigInvalidError.new(config_verification_result.error.message)
+            raise BindConfigInvalidError.new(config_verification_result.errors.first.message)
           end
         else
           raise OperationFailedError.new
         end
       end
 
-      true
+      Result.new
     rescue BindConfigInvalidError => error
-      record.errors.add(:base, error.message)
-      false
-    rescue OperationFailedError
-      false
+      Result.new(error)
+    rescue OperationFailedError => error
+      Result.new(error)
     end
 
     private

--- a/app/lib/use_cases/transactionally_update_dns_config.rb
+++ b/app/lib/use_cases/transactionally_update_dns_config.rb
@@ -28,6 +28,8 @@ module UseCases
       Result.new(error)
     rescue OperationFailedError => error
       Result.new(error)
+    rescue ActiveRecord::RecordInvalid => error
+      Result.new(error)
     end
 
     private

--- a/app/views/zones/edit.html.erb
+++ b/app/views/zones/edit.html.erb
@@ -1,4 +1,4 @@
-<%= render "layouts/form_errors", resource: @zone %>
+<%= render "layouts/form_errors", resource: @result %>
 
 <h2 class="govuk-heading-l">Editing a DNS zone</h2>
 

--- a/app/views/zones/new.html.erb
+++ b/app/views/zones/new.html.erb
@@ -1,4 +1,4 @@
-<%= render "layouts/form_errors", resource: @zone %>
+<%= render "layouts/form_errors", resource: @result %>
 
 <h2 class="govuk-heading-l">Create a new DNS zone</h2>
 

--- a/spec/acceptance/create_reservations_spec.rb
+++ b/spec/acceptance/create_reservations_spec.rb
@@ -23,16 +23,19 @@ describe "create reservations", type: :feature do
     end
 
     it "creates a new subnet reservation" do
+      reservation_ip = reservation.subnet.start_address.chop + "25"
+
       visit "/subnets/#{reservation.subnet_id}"
 
       click_on "Create a new reservation"
 
       expect(page).to have_content(reservation.subnet.start_address + " to " + reservation.subnet.end_address)
+      
 
-      fill_in "HW address", with: "01:bb:cc:dd:ee:fe"
-      fill_in "IP address", with: reservation.subnet.end_address
-      fill_in "Hostname", with: "test.example2.com"
-      fill_in "Description", with: "Test reservation"
+      fill_in "HW address", with: "1a:bb:cc:dd:ee:fe"
+      fill_in "IP address", with: reservation_ip
+      fill_in "Hostname", with: "test.example3.com"
+      fill_in "Description", with: "Test reservation 2"
 
       expect_config_to_be_verified
       expect_config_to_be_published
@@ -41,10 +44,10 @@ describe "create reservations", type: :feature do
 
       expect(page).to have_content("Successfully created reservation")
       expect(page).to have_content("This could take up to 10 minutes to apply.")
-      expect(page).to have_content("01:bb:cc:dd:ee:fe")
-      expect(page).to have_content(reservation.subnet.end_address)
-      expect(page).to have_content("test.example2.com")
-      expect(page).to have_content("Test reservation")
+      expect(page).to have_content("1a:bb:cc:dd:ee:fe")
+      expect(page).to have_content(reservation_ip)
+      expect(page).to have_content("test.example3.com")
+      expect(page).to have_content("Test reservation 2")
 
       expect_audit_log_entry_for(second_line_support.email, "create", "Reservation")
     end

--- a/spec/acceptance/create_reservations_spec.rb
+++ b/spec/acceptance/create_reservations_spec.rb
@@ -30,7 +30,6 @@ describe "create reservations", type: :feature do
       click_on "Create a new reservation"
 
       expect(page).to have_content(reservation.subnet.start_address + " to " + reservation.subnet.end_address)
-      
 
       fill_in "HW address", with: "1a:bb:cc:dd:ee:fe"
       fill_in "IP address", with: reservation_ip

--- a/spec/use_cases/transactionally_update_dns_config_spec.rb
+++ b/spec/use_cases/transactionally_update_dns_config_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe UseCases::TransactionallyUpdateDnsConfig do
         expect(record).not_to be_persisted
       end
 
-      xit "adds errors to the record" do
+      it "adds errors to the record" do
         use_case.call(record, operation)
         expect(record.errors[:base]).to include(result.error.message)
       end

--- a/spec/use_cases/transactionally_update_dns_config_spec.rb
+++ b/spec/use_cases/transactionally_update_dns_config_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe UseCases::TransactionallyUpdateDnsConfig do
   let(:verify_bind_config) { spy(:verify_bind_config) }
   let(:publish_bind_config) { spy(:publish_bind_config) }
   let(:deploy_dns_service) { spy(:deploy_dns_service) }
-  let(:record) { build(:reservation) }
+  let(:record) { build(:zone) }
   let(:operation) { -> { record.save } }
 
   subject(:use_case) do
@@ -75,7 +75,6 @@ RSpec.describe UseCases::TransactionallyUpdateDnsConfig do
 
       it "adds errors to the result" do
         result = use_case.call(record, operation)
-        p result.errors.full_messages
         expect(result.errors.full_messages).to include("im borked")
       end
     end

--- a/spec/use_cases/transactionally_update_dns_config_spec.rb
+++ b/spec/use_cases/transactionally_update_dns_config_spec.rb
@@ -44,9 +44,9 @@ RSpec.describe UseCases::TransactionallyUpdateDnsConfig do
         expect(deploy_dns_service).to have_received(:call)
       end
 
-      it "returns true" do
+      it "returns a successful result" do
         result = use_case.call(record, operation)
-        expect(result).to eql(true)
+        expect(result.success?).to eql(true)
       end
     end
 
@@ -55,17 +55,17 @@ RSpec.describe UseCases::TransactionallyUpdateDnsConfig do
         allow(record).to receive(:valid?).and_return(false)
       end
 
-      it "returns false" do
+      it "returns an unsuccessful result" do
         result = use_case.call(record, operation)
-        expect(result).to eql(false)
+        expect(result.success?).to eql(false)
       end
     end
 
-    context "when the bind config is invalid" do
-      let(:result) { double(:result, success?: false, error: StandardError.new("im borked")) }
-
+    context "when the bind config fails verification" do
       before do
-        allow(verify_bind_config).to receive(:call).and_return(result)
+        allow(verify_bind_config).to receive(:call).and_return(
+          UseCases::Result.new(StandardError.new("im borked"))
+          )
       end
 
       it "does not save the record" do
@@ -73,9 +73,10 @@ RSpec.describe UseCases::TransactionallyUpdateDnsConfig do
         expect(record).not_to be_persisted
       end
 
-      it "adds errors to the record" do
-        use_case.call(record, operation)
-        expect(record.errors[:base]).to include(result.error.message)
+      it "adds errors to the result" do
+        result = use_case.call(record, operation)
+        p result.errors.full_messages
+        expect(result.errors.full_messages).to include("im borked")
       end
     end
   end

--- a/spec/use_cases/transactionally_update_dns_config_spec.rb
+++ b/spec/use_cases/transactionally_update_dns_config_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe UseCases::TransactionallyUpdateDnsConfig do
       before do
         allow(verify_bind_config).to receive(:call).and_return(
           UseCases::Result.new(StandardError.new("im borked"))
-          )
+        )
       end
 
       it "does not save the record" do

--- a/spec/use_cases/transactionally_update_dns_config_spec.rb
+++ b/spec/use_cases/transactionally_update_dns_config_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe UseCases::TransactionallyUpdateDnsConfig do
         expect(record).not_to be_persisted
       end
 
-      it "adds errors to the record" do
+      xit "adds errors to the record" do
         use_case.call(record, operation)
         expect(record.errors[:base]).to include(result.error.message)
       end


### PR DESCRIPTION
# What 
Refactored DNS tests and add Rescue condition, previously this looked to ActiveRecord.

# Why
This was required to bring DNS into line with refactoring performed on DHCP tests etc.
