### PR TITLE
Pttp 7460/make hostname field optional

### DIFF
--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -94,5 +94,4 @@ class Reservation < ApplicationRecord
       errors.add(:hostname, "is not valid")
     end
   end
-
 end

--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -5,7 +5,7 @@ class Reservation < ApplicationRecord
   has_one :reservation_option, dependent: :destroy
 
   validates :ip_address, presence: true
-  validates :hostname, domain_name: true, presence: true
+  validates :hostname, host_name: true, presence: true
   validates :hw_address, format: {with: MAC_ADDRESS_REGEX, message: "%{value} must be in the form 1a:1b:1c:1d:1e:1f"}, presence: true
 
   validate :ip_address_is_a_valid_ipv4_address
@@ -88,4 +88,11 @@ class Reservation < ApplicationRecord
       errors.add(:hostname, "#{hostname} has already been reserved in the subnet #{subnet.cidr_block}")
     end
   end
+
+  def hostname_is_valid
+    unless HOSTNAME_REGEX.match?(:hostname)
+      errors.add(:hostname, "is not valid")
+    end
+  end
+
 end

--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -5,7 +5,7 @@ class Reservation < ApplicationRecord
   has_one :reservation_option, dependent: :destroy
 
   validates :ip_address, presence: true
-  validates :hostname, host_name: true, presence: true
+  validates :hostname, host_name: true
   validates :hw_address, format: {with: MAC_ADDRESS_REGEX, message: "%{value} must be in the form 1a:1b:1c:1d:1e:1f"}, presence: true
 
   validate :ip_address_is_a_valid_ipv4_address

--- a/app/validators/host_name_validator.rb
+++ b/app/validators/host_name_validator.rb
@@ -1,5 +1,5 @@
 class HostNameValidator < ActiveModel::EachValidator
-    HOSTNAME_REGEX = /\A[\w+\.\-]+\z/
+  HOSTNAME_REGEX = /\A[\w+.\-]+\z/
 
   def validate_each(record, attribute, value)
     return if value.blank?

--- a/app/validators/host_name_validator.rb
+++ b/app/validators/host_name_validator.rb
@@ -1,0 +1,11 @@
+class HostNameValidator < ActiveModel::EachValidator
+    HOSTNAME_REGEX = /\A[\w+\.\-]+\z/
+
+  def validate_each(record, attribute, value)
+    return if value.blank?
+
+    unless HOSTNAME_REGEX.match?(value)
+      record.errors.add(attribute, "is not valid")
+    end
+  end
+end

--- a/spec/acceptance/create_reservations_spec.rb
+++ b/spec/acceptance/create_reservations_spec.rb
@@ -33,7 +33,7 @@ describe "create reservations", type: :feature do
 
       fill_in "HW address", with: "1a:bb:cc:dd:ee:fe"
       fill_in "IP address", with: reservation_ip
-      fill_in "Hostname", with: "test.example3.com"
+      fill_in "Hostname", with: "test_example3.com"
       fill_in "Description", with: "Test reservation 2"
 
       expect_config_to_be_verified
@@ -45,7 +45,7 @@ describe "create reservations", type: :feature do
       expect(page).to have_content("This could take up to 10 minutes to apply.")
       expect(page).to have_content("1a:bb:cc:dd:ee:fe")
       expect(page).to have_content(reservation_ip)
-      expect(page).to have_content("test.example3.com")
+      expect(page).to have_content("test_example3.com")
       expect(page).to have_content("Test reservation 2")
 
       expect_audit_log_entry_for(second_line_support.email, "create", "Reservation")

--- a/spec/acceptance/create_reservations_spec.rb
+++ b/spec/acceptance/create_reservations_spec.rb
@@ -112,8 +112,8 @@ describe "create reservations", type: :feature do
       expect(page).to have_content(reservation.subnet.start_address + " to " + reservation.subnet.end_address)
 
       fill_in "HW address", with: "02:bb:cc:dd:ee:fe"
-      fill_in "IP address", with:  no_hostname_reservation_ip
-      
+      fill_in "IP address", with: no_hostname_reservation_ip
+
       expect_config_to_be_verified
       expect_config_to_be_published
 

--- a/spec/acceptance/create_reservations_spec.rb
+++ b/spec/acceptance/create_reservations_spec.rb
@@ -102,6 +102,30 @@ describe "create reservations", type: :feature do
       expect_audit_log_entry_for(editor.email, "create", "Reservation")
     end
 
+    it "creates a new subnet reservation without a hostname" do
+      no_hostname_reservation_ip = reservation.subnet.start_address.chop + "26"
+
+      visit "/subnets/#{reservation.subnet_id}"
+
+      click_on "Create a new reservation"
+
+      expect(page).to have_content(reservation.subnet.start_address + " to " + reservation.subnet.end_address)
+
+      fill_in "HW address", with: "02:bb:cc:dd:ee:fe"
+      fill_in "IP address", with:  no_hostname_reservation_ip
+      
+      expect_config_to_be_verified
+      expect_config_to_be_published
+
+      click_on "Create"
+
+      expect(page).to have_content("Successfully created reservation")
+      expect(page).to have_content("This could take up to 10 minutes to apply.")
+      expect(page).to have_content("02:bb:cc:dd:ee:fe")
+      expect(page).to have_content(no_hostname_reservation_ip)
+      expect_audit_log_entry_for(editor.email, "create", "Reservation")
+    end
+
     it "displays validations errors if form cannot be submitted" do
       visit "/subnets/#{reservation.subnet_id}/reservations/new"
 

--- a/spec/models/reservation_spec.rb
+++ b/spec/models/reservation_spec.rb
@@ -5,9 +5,9 @@ RSpec.describe Reservation, type: :model do
 
   it { is_expected.to validate_presence_of :ip_address }
   it { is_expected.to validate_presence_of :hw_address }
-  it { is_expected.to validate_presence_of :hostname }
 
   context "hostname validation" do
+    it { should allow_value("").for(:hostname) }
     it { should allow_value("example").for(:hostname) }
     it { should allow_value("example.com").for(:hostname) }
     it { should allow_value("foo.example.com").for(:hostname) }

--- a/spec/models/reservation_spec.rb
+++ b/spec/models/reservation_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Reservation, type: :model do
   it { is_expected.to validate_presence_of :hostname }
 
   context "hostname validation" do
+    it { should allow_value("example").for(:hostname) }
     it { should allow_value("example.com").for(:hostname) }
     it { should allow_value("foo.example.com").for(:hostname) }
     it { should allow_value("foo-bar-1.abc.123.example.com").for(:hostname) }


### PR DESCRIPTION
# What
Make the hostname field optional when creating reservations.
 
# Why
The import data from DXC contains some malformed or empty hostnames.  In order to capture all data during the go-live process, we need to accommodate this.

