### PR TITLE
:zap: remove kea config upload from import

### DIFF
--- a/app/controllers/import_controller.rb
+++ b/app/controllers/import_controller.rb
@@ -16,12 +16,14 @@ class ImportController < ApplicationController
   private
 
   def import_params
-    params.require(:import).permit(:file, :kea_config_file, :fits_id, :subnet_list)
+    params.require(:import).permit(:file, :fits_id, :subnet_list)
   end
 
   def config_parser
+    kea_config_json = UseCases::GenerateKeaConfig.new.call.to_json
+
     DhcpConfigParser.new(
-      kea_config_filepath: import_params[:kea_config_file],
+      kea_config_json: kea_config_json,
       legacy_config_filepath: import_params[:file]
     )
   end

--- a/app/lib/dhcp_config_parser.rb
+++ b/app/lib/dhcp_config_parser.rb
@@ -10,23 +10,20 @@ class DhcpConfigParser
 
   # refactor run to create more flexibility
 
-  def initialize(kea_config_filepath:, legacy_config_filepath:)
-    @kea_config_filepath = kea_config_filepath
+  def initialize(kea_config_json:, legacy_config_filepath:)
+    @kea_config_json = kea_config_json
     @legacy_config_filepath = legacy_config_filepath
   end
 
   def run(fits_id:, subnet_list:)
-    throw StandardError unless kea_config_exists?
     throw StandardError unless export_file_exists?
 
-    # Populate these with data from the portal/export before running.
-    # See readme if you're feeling ¯\_(ツ)_/¯
     shared_network_id = fits_id
 
     exclusion_data = get_legacy_exclusions(File.read(@legacy_config_filepath), subnet_list)
 
     compared_reservations = find_missing_reservations(
-      kea_reservations: get_kea_reservations(shared_network_id, File.read(@kea_config_filepath)),
+      kea_reservations: get_kea_reservations(shared_network_id, @kea_config_json),
       legacy_reservations: get_legacy_reservations(File.read(@legacy_config_filepath), subnet_list)
     )
 
@@ -55,10 +52,6 @@ class DhcpConfigParser
         )
       end
     end
-  end
-
-  def kea_config_exists?
-    File.exist?(@kea_config_filepath)
   end
 
   def export_file_exists?

--- a/app/lib/dhcp_config_parser.rb
+++ b/app/lib/dhcp_config_parser.rb
@@ -5,11 +5,6 @@ class DhcpConfigParser
 
   # Integration test for the class with expectation to have reservations created when they are missing on the kea config
 
-  # dhcp_config_parser_spec calls .run which has no arguments, i.e. the entire method is called
-  # this means that KEA_CONFIG_FILEPATH, is called which is a statically defined file.
-
-  # refactor run to create more flexibility
-
   def initialize(kea_config_json:, legacy_config_filepath:)
     @kea_config_json = kea_config_json
     @legacy_config_filepath = legacy_config_filepath

--- a/app/views/import/index.html.erb
+++ b/app/views/import/index.html.erb
@@ -19,11 +19,6 @@
     <%= f.file_field "file", class: "govuk-input", required: true %>
   </div>
 
-  <div class="govuk-form-group">
-    <%= f.label "kea_config_file", 'Kea Config file', class: "govuk-label" %>
-    <%= f.file_field "kea_config_file", class: "govuk-input", required: true %>
-  </div>
-
   <%= f.submit "Submit", {
     class: "govuk-button",
     "data-module" => "govuk-button"

--- a/spec/acceptance/run_dhcp_config_parser_spec.rb
+++ b/spec/acceptance/run_dhcp_config_parser_spec.rb
@@ -45,14 +45,11 @@ describe "dhcp config parser page", type: :feature do
       # When I select a config file
       attach_file "Import file", "./spec/fixtures/dxc_exports/export.txt"
 
-      # And I provide a kea config file
-      attach_file "Kea Config file", "./spec/fixtures/kea_configs/kea.json"
-
       # And I provide a subnet list
       fill_in "Subnet list", with: "192.168.0.1, 192.168.1.1"
 
       # And I provide a fits_id
-      fill_in "FITS id", with: "MYFITS101"
+      fill_in "FITS id", with: subnet.shared_network.name
 
       expect_config_to_be_verified
       expect_config_to_be_published
@@ -69,9 +66,6 @@ describe "dhcp config parser page", type: :feature do
       # Then I can see a reservation
       expect(page).to have_content("a1:b2:c3:d4:e5:f7")
 
-      # Also,
-      # Act, Arrange, Assert
-      # Given, When, Then
     end
 
     it "tells the user about any errors importing dhcp configs" do
@@ -88,13 +82,10 @@ describe "dhcp config parser page", type: :feature do
       fill_in "Subnet list", with: "192.168.0.1, 192.168.1.1"
 
       # and i fill in the fits id
-      fill_in "FITS id", with: "MYFITS101"
+      fill_in "FITS id", with: subnet.shared_network.name
 
       # and i upload the import file
       attach_file "Import file", "./spec/fixtures/dxc_exports/export.txt"
-
-      # And I provide a kea config file
-      attach_file "Kea Config file", "./spec/fixtures/kea_configs/kea.json"
 
       # and the kea server says the config is invalid
       allow_config_verification_to_fail_with_message("this isnt what kea looks like :(")
@@ -127,13 +118,10 @@ describe "dhcp config parser page", type: :feature do
       fill_in "Subnet list", with: "192.168.0.0"
 
       # and i fill in the fits id
-      fill_in "FITS id", with: "MYFITS101"
+      fill_in "FITS id", with: subnet.shared_network.name
 
       # and i upload the import file
       attach_file "Import file", "./spec/fixtures/dxc_exports/export.txt"
-
-      # And I provide a kea config file
-      attach_file "Kea Config file", "./spec/fixtures/kea_configs/kea.json"
 
       # when i submit
       click_on "Submit"

--- a/spec/lib/dhcp_config_parser_spec.rb
+++ b/spec/lib/dhcp_config_parser_spec.rb
@@ -1,11 +1,11 @@
 require "rails_helper"
 
 describe DhcpConfigParser do
-  let(:kea_config_filepath) { "./spec/lib/data/kea.json" }
+  let(:kea_config_json) { File.read("./spec/lib/data/kea.json") }
   let(:legacy_config_filepath) { "./spec/lib/data/export.txt" }
   let(:subnet_list) { ["192.168.1.0", "192.168.2.0"] }
   let(:fits_id) { "FITS_1646" }
-  subject { described_class.new(kea_config_filepath: kea_config_filepath, legacy_config_filepath: legacy_config_filepath) }
+  subject { described_class.new(kea_config_json: kea_config_json, legacy_config_filepath: legacy_config_filepath) }
 
   describe "#run" do
     before do
@@ -22,7 +22,7 @@ describe DhcpConfigParser do
     end
 
     it "creates reservations from the legacy config which do not exist in the kea config" do
-      described_class.new(legacy_config_filepath: "./spec/lib/data/brand_new_reservation.txt", kea_config_filepath: kea_config_filepath)
+      described_class.new(legacy_config_filepath: "./spec/lib/data/brand_new_reservation.txt", kea_config_json: kea_config_json)
         .run(fits_id: fits_id, subnet_list: subnet_list)
 
       expect(Reservation.count).to eql(2)
@@ -69,22 +69,6 @@ describe DhcpConfigParser do
       }
 
       expect { subject.create_reservations(reservations_by_subnet) }.to change { Reservation.count }.by(1)
-    end
-  end
-
-  describe ".kea_config_exists?" do
-    context "when kea.json is not present" do
-      it "returns false" do
-        expect(File).to receive(:exist?).and_return(false)
-        expect(subject.kea_config_exists?).to eq(false)
-      end
-    end
-
-    context "when kea.json is present" do
-      it "returns true" do
-        expect(File).to receive(:exist?).with("./spec/lib/data/kea.json").and_return(true)
-        expect(subject.kea_config_exists?).to eq(true)
-      end
     end
   end
 


### PR DESCRIPTION
# What
This PR removes the need to upload a kea.json file when performing a data import.  Instead it will call an existing usecase to  generate a config and pass that through to the dhcp_config_parser.

# Why
To remove the dependency on AWS access to complete data imports

# Screenshots
![image](https://user-images.githubusercontent.com/68431297/143064964-c75e0cb8-0ad6-46fd-905f-52688b307e03.png)


