### PR TITLE
🐛 PTTP-8302 fix blank hostname for import

### DIFF
--- a/app/lib/dhcp_config_parser.rb
+++ b/app/lib/dhcp_config_parser.rb
@@ -43,7 +43,7 @@ class DhcpConfigParser
           subnet: subnet,
           hw_address: format_mac_address(reservation["legacy"]["hw-address"]),
           ip_address: reservation["legacy"]["ip-address"],
-          hostname: reservation["legacy"]["hostname"].gsub(/\.$/, "")
+          hostname: reservation["legacy"]["hostname"].to_s.gsub(/\.$/, "")
         )
       end
     end
@@ -87,7 +87,7 @@ class DhcpConfigParser
     legacy_reservations = []
 
     subnet_list.each do |subnet|
-      ip_mac_hostname_regex = /#{subnet.chop}\d{1,3}.(?:[a-fA-F0-9]{12})."[^"]*"."[^"]*"/
+      ip_mac_hostname_regex = /#{subnet.chop}\d{1,3}.(?:[a-fA-F0-9]{12})."[^"]*"."/
       reservations_data = export.scan(ip_mac_hostname_regex)
       reservations_data.each do |reservation|
         reservations = reservation.tr('"', "").split(" ")

--- a/spec/acceptance/run_dhcp_config_parser_spec.rb
+++ b/spec/acceptance/run_dhcp_config_parser_spec.rb
@@ -42,11 +42,11 @@ describe "dhcp config parser page", type: :feature do
       # Given I am on the import page
       visit "/import"
 
-      # When I select a config file
+      # When I select a export file containing 2 reservations, one with a blank hostname
       attach_file "Import file", "./spec/fixtures/dxc_exports/export.txt"
 
       # And I provide a subnet list
-      fill_in "Subnet list", with: "192.168.0.1, 192.168.1.1"
+      fill_in "Subnet list", with: "192.168.0.0"
 
       # And I provide a fits_id
       fill_in "FITS id", with: subnet.shared_network.name
@@ -63,8 +63,9 @@ describe "dhcp config parser page", type: :feature do
       # When I visit subnet page
       visit "/subnets/#{subnet.to_param}"
 
-      # Then I can see a reservation
+      # Then I can see the reservations
       expect(page).to have_content("a1:b2:c3:d4:e5:f7")
+      expect(page).to have_content("a1:b2:c3:d4:e5:f8")
     end
 
     it "tells the user about any errors importing dhcp configs" do

--- a/spec/fixtures/dxc_exports/export.txt
+++ b/spec/fixtures/dxc_exports/export.txt
@@ -1,1 +1,2 @@
 Dhcp Server \\DHCPSERVER.test.net.local Scope 192.168.0.0 Add reservedip 192.168.0.30 a1b2c3d4e5f7 "windowsmachine2.test.space.local" "win2" "BOTH"
+Dhcp Server \\DHCPSERVER.test.net.local Scope 192.168.0.0 Add reservedip 192.168.0.31 a1b2c3d4e5f8 "" "win3" "BOTH"

--- a/spec/lib/data/export.txt
+++ b/spec/lib/data/export.txt
@@ -103,7 +103,7 @@ Dhcp Server \\DHCPSERVER.test.net.local Scope 192.168.2.0 set optionvalue 15 STR
    # ======================================================================
 
 
-Dhcp Server \\DHCPSERVER.test.net.local Scope 192.168.2.0 Add reservedip 192.168.2.249 0000aaabbc02 "win6.test.space.local." "win6" "BOTH"
+Dhcp Server \\DHCPSERVER.test.net.local Scope 192.168.2.0 Add reservedip 192.168.2.249 0000aaabbc02 "" "win6" "BOTH"
 Dhcp Server \\DHCPSERVER.test.net.local Scope 192.168.2.0 Add reservedip 192.168.2.219 0000aabbc015 "win7.test.space.local" "win7" "BOTH"
 Dhcp Server \\DHCPSERVER.test.net.local Scope 192.168.2.0 Add reservedip 192.168.2.239 0000223656de "prn6.test.space.local" "prn6" "BOTH"
 Dhcp Server \\DHCPSERVER.test.net.local Scope 192.168.2.0 Add reservedip 192.168.2.221 0000223656df "prn7.test.space.local" "prn7" "BOTH"

--- a/spec/lib/data/legacy_reservations.txt
+++ b/spec/lib/data/legacy_reservations.txt
@@ -12,7 +12,7 @@
   "hostname":"printer2.test.space.local"},
  {"ip-address":"192.168.2.249",
   "hw-address":"0000aaabbc02",
-  "hostname":"win6.test.space.local."},
+  "hostname":null},
  {"ip-address":"192.168.2.219",
   "hw-address":"0000aabbc015",
   "hostname":"win7.test.space.local"},

--- a/spec/lib/dhcp_config_parser_spec.rb
+++ b/spec/lib/dhcp_config_parser_spec.rb
@@ -163,7 +163,7 @@ describe DhcpConfigParser do
           "legacy" => {
             "hw-address" => "0000aaabbc02",
             "ip-address" => "192.168.2.249",
-            "hostname" => "win6.test.space.local."
+            "hostname" => nil # This line tests for empty string as a hostname.
           }
         },
         {


### PR DESCRIPTION
# What
This PR will allow the Import function to create reservations even when the hostname field is blank.

# Why
The legacy data being imported into the system contains some entries with blank hostnames.  As reservations are based on MAC addresses, the hostname can technically be blank.  

# Screenshots
![image](https://user-images.githubusercontent.com/68431297/148081881-290e5b44-db7b-4324-b35f-0a3c90842cad.png)

# Notes
