### PR TITLE
:sparkles: issue-to-project

### DIFF
--- a/.github/workflows/issue-to-project.yml
+++ b/.github/workflows/issue-to-project.yml
@@ -1,0 +1,16 @@
+name: Add issues to project
+
+on:
+  issues:
+    types:
+      - opened
+
+jobs:
+  add-to-project:
+    name: Add issue to project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@main
+        with:
+          project-url: https://github.com/orgs/ministryofjustice/projects/11
+          github-token: ${{ secrets.TECH_SERVICES_GITHUB_TOKEN }}


### PR DESCRIPTION
Automatically adds issues to the CloupsOps GitHub project board.