### PR TITLE
:zap: Migrate from ECR to DockerHub

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,5 @@ coverage
 !/.env.example
 !/.env.development
 !/.env.test
+
+.DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
-ARG SHARED_SERVICES_ACCOUNT_ID
-FROM ${SHARED_SERVICES_ACCOUNT_ID}.dkr.ecr.eu-west-2.amazonaws.com/admin:ruby-3-0-3-alpine3-15
+FROM ruby:3.0.3-alpine3.15
 
 ARG UID=1001
 ARG GROUP=app

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -16,7 +16,8 @@ env:
     SECRET_KEY_BASE: "/codebuild/dhcp/admin/rails_master_key"
     ROLE_ARN: "/codebuild/pttp-ci-infrastructure-core-pipeline/${ENV}/assume_role"
     DHCP_DNS_TERRAFORM_OUTPUTS: "/terraform_dns_dhcp/$ENV/outputs"
-    SHARED_SERVICES_ACCOUNT_ID: /codebuild/staff_device_shared_services_account_id
+    DOCKER_USERNAME: "/moj-network-access-control/docker/username"
+    DOCKER_PASSWORD: "/moj-network-access-control/docker/password"
 
 phases:
   install:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.4"
 
 services:
   admin-db:
-    image: "${SHARED_SERVICES_ACCOUNT_ID}.dkr.ecr.eu-west-2.amazonaws.com/admin-mysql:mysql-5-7"
+    image: "mysql:5.7"
     env_file: .env.${ENV}
     expose:
       - "3306"
@@ -17,7 +17,6 @@ services:
       args:
         UID: "${UID}"
         BUNDLE_INSTALL_FLAGS: "${BUNDLE_INSTALL_FLAGS:- --jobs 20 --retry 5}"
-        SHARED_SERVICES_ACCOUNT_ID: "${SHARED_SERVICES_ACCOUNT_ID}"
     user: "${UID}:${UID}"
     command: bash -c "rm -f tmp/pids/server.pid && bundle exec rails s -p 3000 -b '0.0.0.0'"
     volumes:

--- a/scripts/authenticate_docker.sh
+++ b/scripts/authenticate_docker.sh
@@ -2,4 +2,6 @@
 
 set -euo pipefail
 
-aws ecr get-login-password --region eu-west-2 | docker login --username AWS --password-stdin ${SHARED_SERVICES_ACCOUNT_ID}.dkr.ecr.eu-west-2.amazonaws.com
+if [[ -n "${DOCKER_USERNAME}" && -n "${DOCKER_PASSWORD}" ]]; then
+  docker login --username ${DOCKER_USERNAME} --password ${DOCKER_PASSWORD}
+fi


### PR DESCRIPTION
# What
Add docker credentials and pull images from DockerHub directly
# Why
To remove dependencies on AWS ECR as no longer required
