### PR TITLE
DHCP option 234 feature

### DIFF
--- a/app/controllers/sites_controller.rb
+++ b/app/controllers/sites_controller.rb
@@ -84,6 +84,6 @@ class SitesController < ApplicationController
   end
 
   def site_params
-    params.require(:site).permit(:fits_id, :name)
+    params.require(:site).permit(:fits_id, :name, :windows_update_delivery_optimisation_enabled)
   end
 end

--- a/app/lib/use_cases/generate_kea_config.rb
+++ b/app/lib/use_cases/generate_kea_config.rb
@@ -196,6 +196,14 @@ module UseCases
     def default_config
       {
         Dhcp4: {
+          "option-def": [
+            {
+              name: "delivery-optimisation",
+              code: 234,
+              type: "string",
+              space: "dhcp4"
+            }
+          ],
           "interfaces-config": {
             interfaces: ["*"],
             "dhcp-socket-type": "udp",

--- a/app/lib/use_cases/kea_config/generate_option_data_config.rb
+++ b/app/lib/use_cases/kea_config/generate_option_data_config.rb
@@ -10,22 +10,31 @@ module UseCases
 
         if option.respond_to?(:domain_name) && option.domain_name.present?
           result[:"option-data"] << {
-            "name": "domain-name",
-            "data": option.domain_name
+            name: "domain-name",
+            data: option.domain_name
           }
         end
 
         if option.respond_to?(:domain_name_servers) && option.domain_name_servers.present?
           result[:"option-data"] << {
-            "name": "domain-name-servers",
-            "data": option.domain_name_servers.join(", ")
+            name: "domain-name-servers",
+            data: option.domain_name_servers.join(", ")
           }
         end
 
         if option.respond_to?(:routers) && option.routers.any?
           result[:"option-data"] << {
-            "name": "routers",
-            "data": option.routers.join(", ")
+            name: "routers",
+            data: option.routers.join(", ")
+          }
+        end
+
+        if option.respond_to?(:site) && option.site.windows_update_delivery_optimisation_enabled?
+          result[:"option-data"] << {
+            name: "delivery-optimisation",
+            space: "dhcp4",
+            code: 234,
+            data: option.site.uuid
           }
         end
 

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -5,5 +5,13 @@ class Site < ApplicationRecord
   validates :fits_id, presence: true, uniqueness: {case_sensitive: false}
   validates :name, presence: true, uniqueness: {case_sensitive: false}
 
+  before_save :ensure_uuid_has_a_value
+
   audited
+
+  private
+
+  def ensure_uuid_has_a_value
+    self.uuid = SecureRandom.uuid unless uuid.present?
+  end
 end

--- a/app/views/sites/_form.html.erb
+++ b/app/views/sites/_form.html.erb
@@ -12,6 +12,20 @@
     <%= f.text_field :name, class: "govuk-input" %>
   </div>
 
+    <div class="govuk-form-group">
+   <div id="action-hint" class="govuk-label">Windows update delivery optimisation</div>
+   <div class="govuk-radios" data-module="govuk-radios">
+      <div class="govuk-radios__item">
+        <%= f.radio_button :windows_update_delivery_optimisation_enabled, true, checked: site.windows_update_delivery_optimisation_enabled?, class: "govuk-radios__input" %>
+        <%= f.label :windows_update_delivery_optimisation_enabled, "Enabled", class: "govuk-label govuk-radios__label" %>
+      </div>
+      <div class="govuk-radios__item">
+        <%= f.radio_button :windows_update_delivery_optimisation_enabled, false, checked: !site.windows_update_delivery_optimisation_enabled?, class: "govuk-radios__input" %>
+        <%= f.label :windows_update_delivery_optimisation_enabled, "Disabled", class: "govuk-label govuk-radios__label" %>
+      </div>
+    </div>
+  </div>
+
   <%= f.submit f.object.new_record? ? "Create" : "Update", {
     class: "govuk-button",
     "data-module" => "govuk-button"

--- a/app/views/sites/show.html.erb
+++ b/app/views/sites/show.html.erb
@@ -5,9 +5,11 @@
     <dt class="govuk-summary-list__key">FITS id</dt>
     <dd class="govuk-summary-list__value"><%= @site.fits_id %></dd>
     <dd class="govuk-summary-list__actions">
+    <% if can? :manage, Site %>
       <%= link_to edit_site_path(@site), class: "govuk-link" do %>
         Change<span class="govuk-visually-hidden"> FITS id</span>
       <% end %>
+    <% end %>
     </dd>
   </div>
 
@@ -15,11 +17,24 @@
     <dt class="govuk-summary-list__key">Name</dt>
     <dd class="govuk-summary-list__value"><%= @site.name %></dd>
     <dd class="govuk-summary-list__actions">
+    <% if can? :manage, Site %>
       <%= link_to edit_site_path(@site), class: "govuk-link" do %>
         Change<span class="govuk-visually-hidden"> name</span>
       <% end %>
+    <% end %>
     </dd>
   </div>
+
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">Windows update delivery optimisation</dt>
+    <dd class="govuk-summary-list__value"><%= @site.windows_update_delivery_optimisation_enabled? ? "Enabled (uuid: #{@site.uuid})" : "Disabled" %></dd>
+    <dd class="govuk-summary-list__actions">
+    <% if can? :manage, Site %>
+      <%= link_to edit_site_path(@site), class: "govuk-link", id: "change-windows-update-delivery-optimisation" do %>
+        Change<span class="govuk-visually-hidden"> Windows update delivery optimisation</span>
+      <% end %>
+    <% end %>
+    </dd>
 </dl>
 
 <% if can? :create, Subnet %>

--- a/db/migrate/20220526105538_add_uuid_to_sites.rb
+++ b/db/migrate/20220526105538_add_uuid_to_sites.rb
@@ -1,0 +1,5 @@
+class AddUuidToSites < ActiveRecord::Migration[7.0]
+  def change
+    add_column :sites, :uuid, :string, null: false, unique: true
+  end
+end

--- a/db/migrate/20220527100242_add_delivery_optimisation_enabled_to_sites.rb
+++ b/db/migrate/20220527100242_add_delivery_optimisation_enabled_to_sites.rb
@@ -1,0 +1,5 @@
+class AddDeliveryOptimisationEnabledToSites < ActiveRecord::Migration[7.0]
+  def change
+    add_column :sites, :windows_update_delivery_optimisation_enabled, :bool, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_10_28_095031) do
+ActiveRecord::Schema[7.0].define(version: 2022_05_27_100242) do
   create_table "audits", charset: "latin1", force: :cascade do |t|
     t.integer "auditable_id"
     t.string "auditable_type"
@@ -38,8 +38,8 @@ ActiveRecord::Schema.define(version: 2021_10_28_095031) do
     t.string "client_id", null: false
     t.string "domain_name_servers", null: false
     t.string "domain_name", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["client_id"], name: "index_client_classes_on_client_id", unique: true
     t.index ["name"], name: "index_client_classes_on_name", unique: true
   end
@@ -47,8 +47,8 @@ ActiveRecord::Schema.define(version: 2021_10_28_095031) do
   create_table "exclusions", charset: "latin1", force: :cascade do |t|
     t.string "start_address"
     t.string "end_address"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.bigint "subnet_id", null: false
     t.index ["subnet_id"], name: "index_exclusions_on_subnet_id"
   end
@@ -56,8 +56,8 @@ ActiveRecord::Schema.define(version: 2021_10_28_095031) do
   create_table "global_options", charset: "latin1", force: :cascade do |t|
     t.string "domain_name_servers", null: false
     t.string "domain_name", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.integer "valid_lifetime", unsigned: true
     t.string "valid_lifetime_unit"
   end
@@ -65,8 +65,8 @@ ActiveRecord::Schema.define(version: 2021_10_28_095031) do
   create_table "options", charset: "latin1", force: :cascade do |t|
     t.string "domain_name_servers"
     t.string "domain_name"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.bigint "subnet_id", null: false
     t.integer "valid_lifetime", unsigned: true
     t.string "valid_lifetime_unit"
@@ -77,8 +77,8 @@ ActiveRecord::Schema.define(version: 2021_10_28_095031) do
     t.string "domain_name"
     t.string "routers"
     t.bigint "reservation_id", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["reservation_id"], name: "index_reservation_options_on_reservation_id"
   end
 
@@ -88,14 +88,14 @@ ActiveRecord::Schema.define(version: 2021_10_28_095031) do
     t.string "ip_address"
     t.string "hostname"
     t.string "description"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["subnet_id"], name: "index_reservations_on_subnet_id"
   end
 
   create_table "shared_networks", charset: "latin1", force: :cascade do |t|
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.bigint "site_id"
     t.index ["site_id"], name: "index_shared_networks_on_site_id"
   end
@@ -103,24 +103,26 @@ ActiveRecord::Schema.define(version: 2021_10_28_095031) do
   create_table "sites", charset: "latin1", force: :cascade do |t|
     t.string "name", null: false
     t.string "fits_id", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "uuid", null: false
+    t.boolean "windows_update_delivery_optimisation_enabled", default: false
   end
 
   create_table "subnets", charset: "latin1", force: :cascade do |t|
     t.string "cidr_block", null: false
     t.string "start_address", null: false
     t.string "end_address", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.string "routers", null: false
     t.bigint "shared_network_id"
     t.index ["shared_network_id"], name: "index_subnets_on_shared_network_id"
   end
 
   create_table "users", charset: "latin1", force: :cascade do |t|
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.string "provider"
     t.string "uid"
     t.boolean "editor", default: false
@@ -132,8 +134,8 @@ ActiveRecord::Schema.define(version: 2021_10_28_095031) do
     t.string "name", null: false
     t.string "forwarders", null: false
     t.string "purpose"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   add_foreign_key "exclusions", "subnets"

--- a/spec/acceptance/manage_windows_update_delivery_optmisation_spec.rb
+++ b/spec/acceptance/manage_windows_update_delivery_optmisation_spec.rb
@@ -1,0 +1,75 @@
+require "rails_helper"
+
+describe "windows update delivery optmisation", type: :feature do
+  let(:site) do
+    Audited.audit_class.as_user(User.first) do
+      create(:site)
+    end
+  end
+
+  context "when the user is a viewer" do
+    before do
+      login_as create(:user, :viewer)
+    end
+
+    it "does not allow editing windows update delivery optmisation" do
+      visit "/sites/#{site.to_param}"
+
+      expect(page).not_to have_link "Change name"
+      expect(page).not_to have_link "Change FITS id"
+      expect(page).not_to have_link "Change Windows update delivery optimisation"
+    end
+  end
+
+  context "when the user is an editor" do
+    let(:editor) { create(:user, :editor) }
+
+    before do
+      login_as editor
+      site
+    end
+
+    it "enables windows update delivery optimisation for an existing site" do
+      visit "/sites/#{site.id}"
+
+      click_on "Change Windows update delivery optimisation"
+
+      expect(page).to have_content("Windows update delivery optimisation")
+      expect(page).to have_checked_field("site_windows_update_delivery_optimisation_enabled_false")
+
+      choose("site_windows_update_delivery_optimisation_enabled_true")
+
+      expect(page).to have_checked_field("site_windows_update_delivery_optimisation_enabled_true")
+
+      expect_config_to_be_verified
+      expect_config_to_be_published
+
+      click_on "Update"
+
+      expect(current_path).to eq("/sites/#{site.id}")
+
+      expect(page).to have_text("Windows update delivery optimisation Enabled (uuid: #{site.uuid})")
+
+      expect_audit_log_entry_for(editor.email, "update", "Site")
+    end
+
+    it "disables windows update delivery optimisation for an existing site" do
+      site.toggle!(:windows_update_delivery_optimisation_enabled)
+
+      visit "/sites/#{site.id}"
+
+      click_on "Change Windows update delivery optimisation"
+
+      expect(page).to have_checked_field("site_windows_update_delivery_optimisation_enabled_true")
+
+      choose("site_windows_update_delivery_optimisation_enabled_false")
+
+      expect_config_to_be_verified
+      expect_config_to_be_published
+
+      click_on "Update"
+
+      expect(page).to have_text("Windows update delivery optimisation Disabled")
+    end
+  end
+end

--- a/spec/factories/sites.rb
+++ b/spec/factories/sites.rb
@@ -2,6 +2,7 @@ FactoryBot.define do
   factory :site do
     sequence(:fits_id) { |n| "FITS#{n}" }
     sequence(:name) { |n| "Site #{n}" }
+    uuid { SecureRandom.uuid }
 
     trait :with_subnet do
       after :create do |site|

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -11,4 +11,20 @@ RSpec.describe Site, type: :model do
   it { is_expected.to validate_uniqueness_of(:fits_id).case_insensitive }
   it { is_expected.to validate_presence_of :name }
   it { is_expected.to validate_uniqueness_of(:name).case_insensitive }
+
+  it "expects model to have a valid uuid" do
+    site = Site.create(fits_id: "FITS_0005", name: "Test Site 0005")
+    expect(site.uuid.length).to eq(36)
+  end
+
+  it "does not create a uuid if its already there" do
+    site = Site.create(fits_id: "FITS_0005", name: "Test Site 0005", uuid: "3dc6c608-992f-4190-8808-4eab8c0cb03d")
+    site.save!
+    expect(site.reload.uuid).to eq("3dc6c608-992f-4190-8808-4eab8c0cb03d")
+  end
+
+  it "defaults windows_update_delivery_optimisation_enabled? to False" do
+    site = Site.create(fits_id: "FITS_0005", name: "Test Site 0005")
+    expect(site.windows_update_delivery_optimisation_enabled?).to be false
+  end
 end

--- a/spec/use_cases/generate_kea_config_spec.rb
+++ b/spec/use_cases/generate_kea_config_spec.rb
@@ -67,7 +67,7 @@ describe UseCases::GenerateKeaConfig do
       shared_network = build_stubbed(:shared_network, site: site)
       exclusion = build_stubbed(:exclusion, start_address: "10.0.1.90", end_address: "10.0.1.100")
       subnet1 = build_stubbed(:subnet, cidr_block: "10.0.1.0/24", start_address: "10.0.1.1",
-                                       end_address: "10.0.1.255", exclusions: [exclusion], routers: "10.0.1.2,10.0.1.3", shared_network: shared_network)
+        end_address: "10.0.1.255", exclusions: [exclusion], routers: "10.0.1.2,10.0.1.3", shared_network: shared_network)
 
       config = UseCases::GenerateKeaConfig.new(subnets: [subnet1]).call
 
@@ -104,7 +104,7 @@ describe UseCases::GenerateKeaConfig do
       shared_network = build_stubbed(:shared_network, site: site)
       exclusion = build_stubbed(:exclusion, start_address: "10.0.1.50", end_address: "10.0.1.60")
       subnet1 = build_stubbed(:subnet, cidr_block: "10.0.1.0/24", start_address: "10.0.1.1",
-                                       end_address: "10.0.1.255", exclusions: [exclusion], routers: "10.0.1.2,10.0.1.3", shared_network: shared_network)
+        end_address: "10.0.1.255", exclusions: [exclusion], routers: "10.0.1.2,10.0.1.3", shared_network: shared_network)
 
       config = UseCases::GenerateKeaConfig.new(subnets: [subnet1]).call
 
@@ -141,7 +141,7 @@ describe UseCases::GenerateKeaConfig do
       shared_network = build_stubbed(:shared_network, site: site)
       exclusion = build_stubbed(:exclusion, start_address: "10.0.1.150", end_address: "10.0.1.170")
       subnet1 = build_stubbed(:subnet, cidr_block: "10.0.1.0/24", start_address: "10.0.1.1",
-                                       end_address: "10.0.1.255", exclusions: [exclusion], routers: "10.0.1.2,10.0.1.3", shared_network: shared_network)
+        end_address: "10.0.1.255", exclusions: [exclusion], routers: "10.0.1.2,10.0.1.3", shared_network: shared_network)
 
       config = UseCases::GenerateKeaConfig.new(subnets: [subnet1]).call
 
@@ -178,7 +178,7 @@ describe UseCases::GenerateKeaConfig do
       shared_network = build_stubbed(:shared_network, site: site)
       exclusion = build_stubbed(:exclusion, start_address: "10.0.2.150", end_address: "10.0.2.170")
       subnet1 = build_stubbed(:subnet, cidr_block: "10.0.2.0/24", start_address: "10.0.2.1",
-                                       end_address: "10.0.2.255", exclusions: [exclusion], routers: "10.0.2.2,10.0.2.3", shared_network: shared_network)
+        end_address: "10.0.2.255", exclusions: [exclusion], routers: "10.0.2.2,10.0.2.3", shared_network: shared_network)
 
       config = UseCases::GenerateKeaConfig.new(subnets: [subnet1]).call
 
@@ -215,7 +215,7 @@ describe UseCases::GenerateKeaConfig do
       shared_network = build_stubbed(:shared_network, site: site)
       exclusion = build_stubbed(:exclusion, start_address: "10.0.2.1", end_address: "10.0.2.170")
       subnet1 = build_stubbed(:subnet, cidr_block: "10.0.2.0/24", start_address: "10.0.2.1",
-                                       end_address: "10.0.2.255", exclusions: [exclusion], routers: "10.0.2.2,10.0.2.3", shared_network: shared_network)
+        end_address: "10.0.2.255", exclusions: [exclusion], routers: "10.0.2.2,10.0.2.3", shared_network: shared_network)
 
       config = UseCases::GenerateKeaConfig.new(subnets: [subnet1]).call
 
@@ -249,7 +249,7 @@ describe UseCases::GenerateKeaConfig do
       shared_network = build_stubbed(:shared_network, site: site)
       exclusion = build_stubbed(:exclusion, start_address: "10.0.2.1", end_address: "10.0.2.70")
       subnet1 = build_stubbed(:subnet, cidr_block: "10.0.2.0/24", start_address: "10.0.2.1",
-                                       end_address: "10.0.2.255", exclusions: [exclusion], routers: "10.0.2.2,10.0.2.3", shared_network: shared_network)
+        end_address: "10.0.2.255", exclusions: [exclusion], routers: "10.0.2.2,10.0.2.3", shared_network: shared_network)
 
       config = UseCases::GenerateKeaConfig.new(subnets: [subnet1]).call
 
@@ -283,7 +283,7 @@ describe UseCases::GenerateKeaConfig do
       shared_network = build_stubbed(:shared_network, site: site)
       exclusion = build_stubbed(:exclusion, start_address: "10.0.1.1", end_address: "10.0.1.70")
       subnet1 = build_stubbed(:subnet, cidr_block: "10.0.1.0/24", start_address: "10.0.1.1",
-                                       end_address: "10.0.1.255", exclusions: [exclusion], routers: "10.0.1.2,10.0.1.3", shared_network: shared_network)
+        end_address: "10.0.1.255", exclusions: [exclusion], routers: "10.0.1.2,10.0.1.3", shared_network: shared_network)
 
       config = UseCases::GenerateKeaConfig.new(subnets: [subnet1]).call
 
@@ -317,7 +317,7 @@ describe UseCases::GenerateKeaConfig do
       shared_network = build_stubbed(:shared_network, site: site)
       exclusion = build_stubbed(:exclusion, start_address: "10.0.2.200", end_address: "10.0.2.255")
       subnet1 = build_stubbed(:subnet, cidr_block: "10.0.2.0/24", start_address: "10.0.2.1",
-                                       end_address: "10.0.2.255", exclusions: [exclusion], routers: "10.0.2.2,10.0.2.3", shared_network: shared_network)
+        end_address: "10.0.2.255", exclusions: [exclusion], routers: "10.0.2.2,10.0.2.3", shared_network: shared_network)
 
       config = UseCases::GenerateKeaConfig.new(subnets: [subnet1]).call
 
@@ -351,7 +351,7 @@ describe UseCases::GenerateKeaConfig do
       shared_network = build_stubbed(:shared_network, site: site)
       exclusion = build_stubbed(:exclusion, start_address: "10.0.2.230", end_address: "10.0.2.255")
       subnet1 = build_stubbed(:subnet, cidr_block: "10.0.2.0/24", start_address: "10.0.2.1",
-                                       end_address: "10.0.2.255", exclusions: [exclusion], routers: "10.0.2.2,10.0.2.3", shared_network: shared_network)
+        end_address: "10.0.2.255", exclusions: [exclusion], routers: "10.0.2.2,10.0.2.3", shared_network: shared_network)
 
       config = UseCases::GenerateKeaConfig.new(subnets: [subnet1]).call
 
@@ -385,7 +385,7 @@ describe UseCases::GenerateKeaConfig do
       shared_network = build_stubbed(:shared_network, site: site)
       exclusion = build_stubbed(:exclusion, start_address: "10.0.1.230", end_address: "10.0.1.255")
       subnet1 = build_stubbed(:subnet, cidr_block: "10.0.1.0/24", start_address: "10.0.1.1",
-                                       end_address: "10.0.1.255", exclusions: [exclusion], routers: "10.0.1.2,10.0.1.3", shared_network: shared_network)
+        end_address: "10.0.1.255", exclusions: [exclusion], routers: "10.0.1.2,10.0.1.3", shared_network: shared_network)
 
       config = UseCases::GenerateKeaConfig.new(subnets: [subnet1]).call
 
@@ -419,7 +419,7 @@ describe UseCases::GenerateKeaConfig do
       shared_network = build_stubbed(:shared_network, site: site)
       exclusion = build_stubbed(:exclusion, start_address: "10.0.1.1", end_address: "10.0.1.255")
       subnet1 = build_stubbed(:subnet, cidr_block: "10.0.1.0/24", start_address: "10.0.1.1",
-                                       end_address: "10.0.1.255", exclusions: [exclusion], routers: "10.0.1.2,10.0.1.3", shared_network: shared_network)
+        end_address: "10.0.1.255", exclusions: [exclusion], routers: "10.0.1.2,10.0.1.3", shared_network: shared_network)
 
       config = UseCases::GenerateKeaConfig.new(subnets: [subnet1]).call
 
@@ -451,7 +451,7 @@ describe UseCases::GenerateKeaConfig do
         :"host-reservation-identifiers", :"hosts-database", :"interfaces-config",
         :"lease-database", :"valid-lifetime", :loggers, :subnet4,
         :"control-socket", :"hooks-libraries", :"multi-threading",
-        :"shared-networks"
+        :"shared-networks", :"option-def"
       ])
     end
 
@@ -755,6 +755,7 @@ describe UseCases::GenerateKeaConfig do
 
     it "stores subnet options as a client class" do
       subnet = create(:subnet, :with_option)
+      subnet.site.toggle!(:windows_update_delivery_optimisation_enabled)
       config = UseCases::GenerateKeaConfig.new(subnets: [subnet]).call
 
       expect(config.dig(:Dhcp4, :"shared-networks")&.first&.dig(:subnet4)).to include(
@@ -769,7 +770,8 @@ describe UseCases::GenerateKeaConfig do
           "option-data": match_array([
             {name: "domain-name-servers", data: subnet.domain_name_servers.join(", ")},
             {name: "routers", data: subnet.routers.join(", ")},
-            {name: "domain-name", data: subnet.domain_name}
+            {name: "domain-name", data: subnet.domain_name},
+            {name: "delivery-optimisation", space: "dhcp4", code: 234, data: subnet.site.uuid}
           ])
         }
       ])
@@ -792,6 +794,19 @@ describe UseCases::GenerateKeaConfig do
 
       config = UseCases::GenerateKeaConfig.new(subnets: [subnet, subnet2]).call
       expect(config.dig(:Dhcp4, :"client-classes")).to_not include nil
+    end
+
+    it "expect to see option-def in the kea config file" do
+      subnet = create(:subnet, index: 0)
+      subnet2 = create(:subnet, :with_option, index: 1)
+
+      config = UseCases::GenerateKeaConfig.new(subnets: [subnet, subnet2]).call
+      expect(config.dig(:Dhcp4, :"option-def")).to eq([{
+        name: "delivery-optimisation",
+        code: 234,
+        type: "string",
+        space: "dhcp4"
+      }])
     end
   end
 end


### PR DESCRIPTION
# What
DHCP Option 234 feature is a request from the EUC Team.
This option 234 will be used by dhcp clients to optimise Windows updates delivery. All clients in a single site with same data for option 234 will share Windows updates to reduce the load on the WLAN.
 - A custom dhcp option with id 234 is defined at the top of the config
 - All sites will have a UUID by default
 - A new toggle button is added to site to enable `Delivery Optimisation`
 - When that button is toggled for a pre existing site, a UUID will be generated and DHCP option data will be populated in the option config for all the subnets in that site.  

Closes #513  

## Screenshots
![Screenshot 2022-05-30 at 15 55 28](https://user-images.githubusercontent.com/69799571/171151229-e0676c7c-827c-4806-b474-2665581f8c6a.png)
![Screenshot 2022-05-30 at 15 55 47](https://user-images.githubusercontent.com/69799571/171151237-8e8d3331-3cec-4eb3-b7b3-51f2cf0687f4.png)
![Screenshot 2022-05-30 at 15 55 52](https://user-images.githubusercontent.com/69799571/171151241-f85ccd62-e2ba-475e-bd53-a88074c77052.png)
![Screenshot 2022-05-30 at 15 56 06](https://user-images.githubusercontent.com/69799571/171151245-c08f75ee-5898-40e6-953b-ec245e45b198.png)

