### PR TITLE
♻ Refactor 404 Routing / View / Method

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -18,6 +18,16 @@ class ApplicationController < ActionController::Base
     end
   end
 
+  def error
+    if user_signed_in?
+      respond_to do |format|
+        format.html { render file: "#{Rails.root}/public/404.html", status: :not_found }
+      end
+    else
+      redirect_to new_user_session_path
+    end
+  end
+
   private
 
   def set_expect_ct_header

--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -1,9 +1,0 @@
-class ErrorsController < ApplicationController
-  def not_found
-    render status: :not_found
-  end
-
-  def server_error
-    render status: :server_error
-  end
-end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -48,10 +48,7 @@ Rails.application.routes.draw do
   get "/api/dhcp-stats", to: "api/dhcp_stats#index"
   post "/import", to: "import#create"
 
-  get "errors/not_found"
-  match "/404", via: :all, to: "errors#not_found"
-  get "errors/server_error"
-  match "/500", via: :all, to: "errors#server_error"
-
+  match "*path", via: :all, to: "application#error"
+  
   root "home#index"
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -49,6 +49,6 @@ Rails.application.routes.draw do
   post "/import", to: "import#create"
 
   match "*path", via: :all, to: "application#error"
-  
+
   root "home#index"
 end

--- a/public/404.html
+++ b/public/404.html
@@ -1,67 +1,10 @@
-<!DOCTYPE html>
-<html>
-<head>
-  <title>The page you were looking for doesn't exist (404)</title>
-  <meta name="viewport" content="width=device-width,initial-scale=1">
-  <style>
-  .rails-default-error-page {
-    background-color: #EFEFEF;
-    color: #2E2F30;
-    text-align: center;
-    font-family: arial, sans-serif;
-    margin: 0;
-  }
-
-  .rails-default-error-page div.dialog {
-    width: 95%;
-    max-width: 33em;
-    margin: 4em auto 0;
-  }
-
-  .rails-default-error-page div.dialog > div {
-    border: 1px solid #CCC;
-    border-right-color: #999;
-    border-left-color: #999;
-    border-bottom-color: #BBB;
-    border-top: #B00100 solid 4px;
-    border-top-left-radius: 9px;
-    border-top-right-radius: 9px;
-    background-color: white;
-    padding: 7px 12% 0;
-    box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
-  }
-
-  .rails-default-error-page h1 {
-    font-size: 100%;
-    color: #730E15;
-    line-height: 1.5em;
-  }
-
-  .rails-default-error-page div.dialog > p {
-    margin: 0 0 1em;
-    padding: 1em;
-    background-color: #F7F7F7;
-    border: 1px solid #CCC;
-    border-right-color: #999;
-    border-left-color: #999;
-    border-bottom-color: #999;
-    border-bottom-left-radius: 4px;
-    border-bottom-right-radius: 4px;
-    border-top-color: #DADADA;
-    color: #666;
-    box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
-  }
-  </style>
-</head>
-
-<body class="rails-default-error-page">
-  <!-- This file lives in public/404.html -->
-  <div class="dialog">
-    <div>
-      <h1>The page you were looking for doesn't exist.</h1>
-      <p>You may have mistyped the address or the page may have moved.</p>
-    </div>
-    <p>If you are the application owner check the logs for more information.</p>
-  </div>
-</body>
-</html>
+<h1 class="govuk-heading-l">Page not found</h1>
+<p class="govuk-body">
+  If you typed the web address, check it is correct.
+</p>
+<p class="govuk-body">
+  If you pasted the web address, check you copied the entire address.
+</p>
+<p class="govuk-body">
+  If the web address is correct or you selected a link or button, contact the CloudOps team if you need to speak to someone.
+</p>

--- a/spec/acceptance/sign_in_spec.rb
+++ b/spec/acceptance/sign_in_spec.rb
@@ -8,6 +8,11 @@ RSpec.describe "GET /sign_in", type: :feature do
     expect(page).to have_content "Sign in"
   end
 
+  it "displays sign in when not signed in and route is not found" do
+    visit "/some-undefined-route"
+    expect(page).to have_content "Sign in"
+  end
+
   context "user signed in" do
     before do
       # Simulate logging in via Cognito Omniauth provider


### PR DESCRIPTION
This PR refactors the 404 page methodology to replicate the same setup which exists in NACS. In particular this leverages a new section in `sign_in.spec.rb`

```
  it "displays sign in when not signed in and route is not found" do
    visit "/some-undefined-route"
    expect(page).to have_content "Sign in"
  end
```

Adding the new `error` methodology to the Application Controller allows the `public/404.html` page to leverage the CSS.

Additionally  refactoring `routes.rb` to 
```
 match "*path", via: :all, to: "application#error"
```
leverages the new `error` method, which redirects to the login page when appropraite

```
  def error
    if user_signed_in?
      respond_to do |format|
        format.html { render file: "#{Rails.root}/public/404.html", status: :not_found }
      end
    else
      redirect_to new_user_session_path
    end
  end
```
