### PR TITLE
:bricks: Generate bind tcp 5353 config

### DIFF
--- a/app/lib/use_cases/generate_bind_config.rb
+++ b/app/lib/use_cases/generate_bind_config.rb
@@ -15,6 +15,7 @@ options {
   };
 
   listen-on port 53 { any; };
+  listen-on port 5353 { any; };
   listen-on-v6 { none; };
 
   pid-file "/var/run/named/named.pid";

--- a/spec/use_cases/generate_bind_config_spec.rb
+++ b/spec/use_cases/generate_bind_config_spec.rb
@@ -17,6 +17,7 @@ options {
   };
 
   listen-on port 53 { any; };
+  listen-on port 5353 { any; };
   listen-on-v6 { none; };
 
   pid-file "/var/run/named/named.pid";


### PR DESCRIPTION
Update admin to generate valid bind config to allow communication over tcp/5353

# What

# Why

# Screenshots

# Notes
