### PR TITLE
⏪ Revert ":bricks: Generate bind tcp 5353 config (#583)"

### DIFF
--- a/app/lib/use_cases/generate_bind_config.rb
+++ b/app/lib/use_cases/generate_bind_config.rb
@@ -15,7 +15,6 @@ options {
   };
 
   listen-on port 53 { any; };
-  listen-on port 5353 { any; };
   listen-on-v6 { none; };
 
   pid-file "/var/run/named/named.pid";

--- a/spec/use_cases/generate_bind_config_spec.rb
+++ b/spec/use_cases/generate_bind_config_spec.rb
@@ -17,7 +17,6 @@ options {
   };
 
   listen-on port 53 { any; };
-  listen-on port 5353 { any; };
   listen-on-v6 { none; };
 
   pid-file "/var/run/named/named.pid";


### PR DESCRIPTION
This reverts commit 6885ac74b6d8669a0a8ceb3a2d341534b461a2fe.

# Why - this feature was deemed unnecessary and having this commit in the repository is blocking the codepipeline.
