### PR TITLE
:truck: Update 404 page, Documentation & Codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @ministryofjustice/cloud-ops-admins
+* @ministryofjustice/nvvs-devops-admins

--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 # Staff Device DNS / DHCP Admin
 
-This is the web portal for managing Staff Device [DNS](https://ministryofjustice.github.io/cloud-operations/documentation/products/dns.html) / [DHCP](https://ministryofjustice.github.io/cloud-operations/documentation/products/dhcp.html) servers
+This is the web portal for managing Staff Device [DNS](https://ministryofjustice.github.io/nvvs-devops/documentation/products/dns.html) / [DHCP](https://ministryofjustice.github.io/nvvs-devops/documentation/products/dhcp.html) servers
 
 ## Getting Started
 
 ### Authenticate with AWS
 
-Assuming you have been granted necessary access permissions to the Shared Service Account, please follow the CloudOps best practices provided [step-by-step guide](https://ministryofjustice.github.io/cloud-operations/documentation/team-guide/best-practices/use-aws-sso.html#re-configure-aws-vault) to configure your AWS Vault and AWS Cli with AWS SSO.
+Assuming you have been granted necessary access permissions to the Shared Service Account, please follow the NVVS DevOps best practices provided [step-by-step guide](https://ministryofjustice.github.io/nvvs-devops/documentation/team-guide/best-practices/use-aws-sso.html#re-configure-aws-vault) to configure your AWS Vault and AWS Cli with AWS SSO.
 
 ### Prepare the variables
 
@@ -18,7 +18,7 @@ Assuming you have been granted necessary access permissions to the Shared Servic
 
 | Variables                     | How?                                                                                                                                                                                                                                              |
 | ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `AWS_PROFILE=`                | your **AWS-CLI** profile name for the **Shared Services** AWS account. Check [this guide](https://ministryofjustice.github.io/cloud-operations/documentation/team-guide/best-practices/use-aws-sso.html#re-configure-aws-vault) if you need help. |
+| `AWS_PROFILE=`                | your **AWS-CLI** profile name for the **Shared Services** AWS account. Check [this guide](https://ministryofjustice.github.io/nvvs-devops/documentation/team-guide/best-practices/use-aws-sso.html#re-configure-aws-vault) if you need help. |
 | `SHARED_SERVICES_ACCOUNT_ID=` | Account ID of the MoJO Shared Services AWS account.                                                                                                                                                                                               |
 | `REGISTRY_URL=`               | `<MoJO Development AWS Account ID>`.dkr.ecr.eu-west-2.amazonaws.com                                                                                                                                                                               |
 | `ENV=`                        | Your Terraform namespace from the DNS DHCP Infrastructure repo.                                                                                                                                                                                   |

--- a/README.md
+++ b/README.md
@@ -16,12 +16,12 @@ Assuming you have been granted necessary access permissions to the Shared Servic
 1. Copy `.env.example` to `.env`
 1. Modify the `.env` file and provide values for variables as below:
 
-| Variables                     | How?                                                                                                                                                                                                                                              |
-| ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Variables                     | How?                                                                                                                                                                                                                                         |
+| ----------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `AWS_PROFILE=`                | your **AWS-CLI** profile name for the **Shared Services** AWS account. Check [this guide](https://ministryofjustice.github.io/nvvs-devops/documentation/team-guide/best-practices/use-aws-sso.html#re-configure-aws-vault) if you need help. |
-| `SHARED_SERVICES_ACCOUNT_ID=` | Account ID of the MoJO Shared Services AWS account.                                                                                                                                                                                               |
-| `REGISTRY_URL=`               | `<MoJO Development AWS Account ID>`.dkr.ecr.eu-west-2.amazonaws.com                                                                                                                                                                               |
-| `ENV=`                        | Your Terraform namespace from the DNS DHCP Infrastructure repo.                                                                                                                                                                                   |
+| `SHARED_SERVICES_ACCOUNT_ID=` | Account ID of the MoJO Shared Services AWS account.                                                                                                                                                                                          |
+| `REGISTRY_URL=`               | `<MoJO Development AWS Account ID>`.dkr.ecr.eu-west-2.amazonaws.com                                                                                                                                                                          |
+| `ENV=`                        | Your Terraform namespace from the DNS DHCP Infrastructure repo.                                                                                                                                                                              |
 
 3. Copy `.env.development` to `.env.<your terraform namespace>`
 

--- a/docs/cutover_data_checks.md
+++ b/docs/cutover_data_checks.md
@@ -17,7 +17,7 @@ _This process can take ~30 minutes._
 
 1. Navigate to the [portal](https://dhcp-dns-admin.staff.service.justice.gov.uk/sign_in).
 1. Click on 'Sign In'.
-    (If you don't have access to this please contact Cloud Ops via the [#ask-cloud-ops](https://mojdt.slack.com/archives/C026AFE617T) Slack channel).
+    (If you don't have access to this please contact NVVS DevOps via the [#ask-nvvs-devops](https://mojdt.slack.com/archives/C026AFE617T) Slack channel).
 1. Click on 'DHCP'.
 1. Find (Ctrl + F), on the DHCP page, the site in question.
 1. Click on 'Manage' for this site.

--- a/docs/cutover_data_checks.md
+++ b/docs/cutover_data_checks.md
@@ -8,16 +8,16 @@ _This process can take ~30 minutes._
 
 ### Required Information
 
-- Sanitised DHCP export file (save attachment from current provider as export.txt)
-    - See [Network Cutover Tools - Pre-load of export files](https://github.com/ministryofjustice/staff-device-network-cutover-reporting-tools#pre-load-of-export-files) for a script and instructions.
-- FITS ID
-- List of subnets. (Detailed in the email with the export.)
+-   Sanitised DHCP export file (save attachment from current provider as export.txt)
+    -   See [Network Cutover Tools - Pre-load of export files](https://github.com/ministryofjustice/staff-device-network-cutover-reporting-tools#pre-load-of-export-files) for a script and instructions.
+-   FITS ID
+-   List of subnets. (Detailed in the email with the export.)
 
 ### DHCP Admin Procedure
 
 1. Navigate to the [portal](https://dhcp-dns-admin.staff.service.justice.gov.uk/sign_in).
 1. Click on 'Sign In'.
-    (If you don't have access to this please contact NVVS DevOps via the [#ask-nvvs-devops](https://mojdt.slack.com/archives/C026AFE617T) Slack channel).
+   (If you don't have access to this please contact NVVS DevOps via the [#ask-nvvs-devops](https://mojdt.slack.com/archives/C026AFE617T) Slack channel).
 1. Click on 'DHCP'.
 1. Find (Ctrl + F), on the DHCP page, the site in question.
 1. Click on 'Manage' for this site.
@@ -29,17 +29,18 @@ _This process can take ~30 minutes._
 1. Confirm each of the subnets specified by the current supplier are listed.
     - If they are not, click 'create a new subnet'.
         1. Populate each of the fields (all mandatory).  
-        Defaults are:
-            | Item          | Value      |
-            |---------------|------------|
-            | CIDR          | x.x.x.0/24 |
-            | Start Address | x.x.x.1    |
-            | End Address   | x.x.x.254  |
-            | Routers       | x.x.x.1    |
+           Defaults are:
+           | Item | Value |
+           |---------------|------------|
+           | CIDR | x.x.x.0/24 |
+           | Start Address | x.x.x.1 |
+           | End Address | x.x.x.254 |
+           | Routers | x.x.x.1 |
         1. Click on 'Create'.
 1. Confirm an exclusion range in each subnet.
     - Ensure the range is `1..39`.
 1. Confirm any Super scopes.
+
     - Open export.txt.
     - Find (Ctrl + F) `superscope` and note any entries that specify the subnet's for the site.
     - Example Super Scope
@@ -52,6 +53,7 @@ _This process can take ~30 minutes._
     - For any superscopes:
         - Site > Subnet > Add a subnet to this shared network.
         - Select the corresponding subnet from the drop down list.
+
 1. Click on Import
 1. Populate the fields (subnet list should be comma separated)
 1. Click Submit

--- a/public/404.html
+++ b/public/404.html
@@ -6,5 +6,5 @@
   If you pasted the web address, check you copied the entire address.
 </p>
 <p class="govuk-body">
-  If the web address is correct or you selected a link or button, contact the CloudOps team if you need to speak to someone.
+  If the web address is correct or you selected a link or button, contact the NVVS DevOps team if you need to speak to someone.
 </p>


### PR DESCRIPTION
Update 404 page, Documentation & Codeowners file to reference NVVS DevOps instead of Cloud-Ops