### PR TITLE
updating readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,4 +154,4 @@ For information on how to perform the data import before network cutover, please
 
 ## Known Issues
 
-Dependabot currently does not support a container image monitoring solution. so the [Docker container](Dockerfile)  needs to be  updated manually,This cannot currently be automated through a dependabot and therefore this process needs to be done manually.
+- Dependabot currently does not support a container image monitoring solution only for the [Docker container](Dockerfile) *ruby:3.2.2-alpine3.16*, this alpine images needs to be  updated manually.

--- a/README.md
+++ b/README.md
@@ -153,4 +153,4 @@ For information on how to perform the data import before network cutover, please
 
 ## Known Issues
 
-- Dependabot currently does not support a container image monitoring solution only for the [Docker container](Dockerfile) *ruby:3.2.2-alpine3.16*, this alpine images needs to be  updated manually.
+-   Dependabot currently does not support a container image monitoring solution only for the [Docker container](Dockerfile) _ruby:3.2.2-alpine3.16_, this alpine images needs to be updated manually.

--- a/README.md
+++ b/README.md
@@ -153,4 +153,4 @@ For information on how to perform the data import before network cutover, please
 
 ## Known Issues
 
-Dependabot currently does not support a container image monitoring solution. so the [Docker container](Dockerfile) needs to be updated manually,This cannot currently be automated through a dependabot and therefore this process needs to be done manually.
+- Dependabot currently does not support a container image monitoring solution only for the [Docker container](Dockerfile) *ruby:3.2.2-alpine3.16*, this alpine images needs to be  updated manually.

--- a/README.md
+++ b/README.md
@@ -150,3 +150,8 @@ For information on how to perform the data import before network cutover, please
 -   Terraform module - module "pttp-infrastructure-ci-pipeline-dns-dhcp-admin-container"
 -   AWS Account - MOJ Official (Shared Services)
 -   [Pipeline "Staff-Device-Admin-Portal"](https://eu-west-2.console.aws.amazon.com/codesuite/codepipeline/pipelines/Staff-Device-Admin-Portal/view?region=eu-west-2)
+
+
+## Known Issues
+
+Dependabot currently does not support a container image monitoring solution. so the [Docker container](Dockerfile)  needs to be  updated manually,This cannot currently be automated through a dependabot and therefore this process needs to be done manually.


### PR DESCRIPTION
# What
 Container image monitoring known issue update in readme

# Why
Dependabot currently does not support a container image monitoring solution

# Screenshots

# Notes
