### PR TITLE
Feature search function

### DIFF
--- a/app/controllers/sites_controller.rb
+++ b/app/controllers/sites_controller.rb
@@ -4,6 +4,17 @@ class SitesController < ApplicationController
   def index
     @sites = Site.order(:fits_id).all
     @navigation_crumbs = [["Home", root_path]]
+    @sites = if params[:query].present?
+               # Site.where('name LIKE ? OR fits_id LIKE ?', "%#{params[:query]}%", "%#{params[:query]}%")
+               Site.where('name LIKE ? OR fits_id LIKE ? OR id IN (
+               SELECT sn.site_id
+               FROM subnets s
+               INNER JOIN shared_networks sn ON s.shared_network_id = sn.id
+               WHERE s.cidr_block LIKE ?
+             )', "%#{params[:query]}%", "%#{params[:query]}%", "%#{params[:query]}%")
+             else
+               Site.all
+             end
   end
 
   def show

--- a/app/controllers/sites_controller.rb
+++ b/app/controllers/sites_controller.rb
@@ -5,7 +5,6 @@ class SitesController < ApplicationController
     @sites = Site.order(:fits_id).all
     @navigation_crumbs = [["Home", root_path]]
     @sites = if params[:query].present?
-               # Site.where('name LIKE ? OR fits_id LIKE ?', "%#{params[:query]}%", "%#{params[:query]}%")
                Site.where('name LIKE ? OR fits_id LIKE ? OR id IN (
                SELECT sn.site_id
                FROM subnets s
@@ -13,7 +12,7 @@ class SitesController < ApplicationController
                WHERE s.cidr_block LIKE ?
              )', "%#{params[:query]}%", "%#{params[:query]}%", "%#{params[:query]}%")
              else
-               Site.all
+               Site.order(:fits_id).all
              end
   end
 

--- a/app/views/sites/index.html.erb
+++ b/app/views/sites/index.html.erb
@@ -5,7 +5,19 @@
   <%= link_to "Client classes", client_classes_path, class: "govuk-button govuk-button--secondary" %>
 
   <h3 class="govuk-heading-m">Sites</h3>
-
+  <!-- Adding the search form -->
+  <div style="text-align: right;class="govuk-grid-column-one-half search_bar">
+    <%= form_tag(dhcp_path, method: :get, class: "govuk-form") do %>
+      <%= text_field_tag :query, params[:query], placeholder: "Search sites by FITS ID or name...", class: 'govuk-input govuk-input--width-10' %>
+      <%= submit_tag "Search", class: "govuk-button", "data-module" => "govuk-button" %>
+    <% end %>
+  </div>
+<!--  <div style="text-align: right; margin-bottom: 10px;">-->
+  <%#= form_tag(dhcp_path, method: :get, class: "govuk-form") do %>
+    <%#= text_field_tag :query, params[:query], placeholder: "Search sites..." %>
+    <%#= submit_tag "Search", class: "govuk-button" %>
+  <%# end %>
+<!--  </div>-->
   <% if can? :create, Site %>
     <%= link_to "Create a new site", new_site_path, class: "govuk-button" %>
   <% end %>

--- a/app/views/sites/index.html.erb
+++ b/app/views/sites/index.html.erb
@@ -12,12 +12,6 @@
       <%= submit_tag "Search", class: "govuk-button", "data-module" => "govuk-button" %>
     <% end %>
   </div>
-<!--  <div style="text-align: right; margin-bottom: 10px;">-->
-  <%#= form_tag(dhcp_path, method: :get, class: "govuk-form") do %>
-    <%#= text_field_tag :query, params[:query], placeholder: "Search sites..." %>
-    <%#= submit_tag "Search", class: "govuk-button" %>
-  <%# end %>
-<!--  </div>-->
   <% if can? :create, Site %>
     <%= link_to "Create a new site", new_site_path, class: "govuk-button" %>
   <% end %>


### PR DESCRIPTION
# What
We are adding search function to the DHCP admin to search across Sites,Name and Subnet CIDR.
# Why
As we prepare to onboard a substantial number of sites onto the MOJO DHCP service as part of the DHCP migration, navigating through DHCP sites and subnets within the ADMIN console poses a considerable challenge.

# Notes
While the search function performs an exact match of the subnet CIDR, it lacks the capability to recognize subnetting and won't retrieve results if an IP address falls within a specific IP range.
in addition search feature queries using SQL queries which can be changed to use [ransack](https://github.com/activerecord-hackery/ransack) 

# Screenshots
<img width="1613" alt="Screenshot 2023-11-23 at 12 38 29" src="https://github.com/ministryofjustice/staff-device-dns-dhcp-admin/assets/124062934/3cf36a61-4731-4ce9-8541-c1777ab26329">
