### PR TITLE
Nd 261 CVE 2023 40175

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ ruby File.read(".ruby-version").strip
 
 gem "rails", "~> 7.0.8"
 gem "mysql2", "~> 0.5.5"
-gem "puma", "~> 6.4"
+gem "puma", "~> 6.4.2"
 gem "sassc-rails"
 gem "sprockets", "~> 4.2.0"
 gem "jbuilder", "~> 2.11"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -217,7 +217,7 @@ GEM
     parser (3.1.0.0)
       ast (~> 2.4.1)
     public_suffix (5.0.1)
-    puma (6.4.0)
+    puma (6.4.2)
       nio4r (~> 2.0)
     racc (1.7.3)
     rack (2.2.8)
@@ -399,7 +399,7 @@ DEPENDENCIES
   mysql2 (~> 0.5.5)
   omniauth-oauth2
   omniauth-rails_csrf_protection (~> 1.0.1)
-  puma (~> 6.4)
+  puma (~> 6.4.2)
   rails (~> 7.0.8)
   rails-controller-testing
   rspec-rails (~> 6.0.3)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,4 +43,3 @@ networks:
   dhcp:
     external:
       name: "staff-device-dhcp-server_default"
-

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@ version: "3.4"
 
 services:
   admin-db:
+    platform: linux/amd64
     image: "mysql:5.7"
     env_file: .env.${ENV}
     expose:
@@ -12,6 +13,7 @@ services:
       - datavolume:/var/lib/mysql
 
   app:
+    platform: linux/amd64
     build:
       context: .
       args:


### PR DESCRIPTION
# What
Upgraded Puma version to patch CVE 2023 40175
Added platform to Docker compose.yml to allow image to build on M* machines


# Notes
Before testing locally you might need to run the below command to update gem sources: 
gem sources --update

Needs to be tested in pipeline to ensure it builds successfully 