### PR TITLE
upgraded mysql version on docker compose for dhcp admin to match prod…

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3.4"
 services:
   admin-db:
     platform: linux/amd64
-    image: "mysql:5.7"
+    image: "mysql:8.0"
     env_file: .env.${ENV}
     expose:
       - "3306"


### PR DESCRIPTION
…uction

# What
Mysql version in Docker Compose not matching production version 

# Why
Not updated as a part of the production upgrade as the RDS version managed in Infra  
# Screenshots

# Notes
