### PR TITLE
amended spacing in generate_bind_config and spec to make tests pass

### DIFF
--- a/app/lib/use_cases/generate_bind_config.rb
+++ b/app/lib/use_cases/generate_bind_config.rb
@@ -29,6 +29,7 @@ options {
 statistics-channels {
   inet 127.0.0.1 port 8080 allow { 127.0.0.1; };
 };
+
 logging {
   channel query_logging {
     stderr;

--- a/spec/use_cases/generate_bind_config_spec.rb
+++ b/spec/use_cases/generate_bind_config_spec.rb
@@ -60,7 +60,6 @@ logging {
   category resolver { resolver; };
 };
 
-
 zone "localhost" IN {
   type master;
   file "pri/localhost.zone";


### PR DESCRIPTION
Test was failing - generates a BIND template with no dynamic zones

Amended spacing in config and spec to be the same to make the test pass