### PR TITLE
Feature/nd 570 remove secrets baked into admin container 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ authenticate-docker: ## Authenticate docker script
 
 .PHONY: build
 build: ## docker build image
-	docker build --platform linux/amd64 -t admin . --build-arg RACK_ENV --build-arg DB_HOST --build-arg DB_USER --build-arg DB_PASS --build-arg SECRET_KEY_BASE --build-arg DB_NAME --build-arg BUNDLE_WITHOUT
+	docker build --platform linux/amd64 -t admin . --build-arg RACK_ENV --build-arg BUNDLE_WITHOUT
 
 .PHONY: build-dev
 build-dev: ## build-dev image


### PR DESCRIPTION
removed secrets/environment variables that are passed in as arguments into make build command as these are passed to the container from the ECS task definitions and should not be baked in during build as results in a security vulnerability ND-570. Tested the removal of vars/secrets passed as args from the make build command. Can build the container image locally when running 'make build' makefile command. The build completes successfully without failures and all tests pass
