### PR TITLE
added wait for services to be steady

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -22,7 +22,19 @@ deploy() {
     --cluster $cluster_name \
     --service $service_name \
     --force-new-deployment
+
+  # Wait for the ECS service to stabilize (reach steady state)
+  echo "Waiting for ECS service $service_name to reach steady state..."
+  aws ecs wait services-stable --cluster "$cluster_name" --services "$service_name"
+  
+  if [ $? -eq 0 ]; then
+    echo "ECS service $service_name has reached steady state."
+  else
+    echo "ECS service $service_name failed to reach steady state."
+    exit 1
+  fi
 }
+
 
 main() {
   assume_deploy_role


### PR DESCRIPTION
# What
Added wait step for services to be steady before the pipeline shows a success.

# Why
Gives us better visibility on false positive deployments
